### PR TITLE
Leverage GetChannelByNameForTeamName

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 5f70014e098292babafccc5c2f975cefb83c54c19ccd09b99c986e46dd4e88fc
-updated: 2018-07-15T20:52:37.714560347-04:00
+updated: 2018-07-20T16:22:03.929663-04:00
 imports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/golang/protobuf
@@ -14,7 +14,7 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/gorilla/websocket
-  version: ea4d1f681babbce9545c9c5f3d5194a789c89f5b
+  version: 5ed622c449da6d44c3c8329331ff47a9e5844f71
 - name: github.com/hashicorp/go-hclog
   version: ff2cf002a8dd750586d91dddd4470c341f981fe1
 - name: github.com/hashicorp/go-plugin
@@ -22,20 +22,20 @@ imports:
 - name: github.com/hashicorp/yamux
   version: 3520598351bb3500a49ae9563f5539666ae0a27c
 - name: github.com/mattermost/mattermost-server
-  version: 62c64594ccaa0e634023b358758f2a6bf04164ad
+  version: 6104c37761deb8f06ea4af8838db12b8158318be
   subpackages:
+  - mlog
   - model
   - plugin
-  - plugin/rpcplugin
   - plugin/plugintest
   - plugin/plugintest/mock
-  - mlog
+  - plugin/rpcplugin
   - utils/jsonutils
   - utils/markdown
 - name: github.com/mitchellh/go-testing-interface
   version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/nicksnyder/go-i18n
-  version: 0dc1626d56435e9d605a29875701721c54bc9bbd
+  version: f6ac3d9cf0c4b6a32527779e992ebde26bd3d948
   subpackages:
   - i18n
   - i18n/bundle
@@ -44,50 +44,50 @@ imports:
 - name: github.com/oklog/run
   version: 6934b124db28979da51d3470dadfa34d73d72652
 - name: github.com/pborman/uuid
-  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
+  version: c65b2f87fee37d1c7854c9164a450713c28d50cd
 - name: github.com/pelletier/go-toml
-  version: 4e9e0ee19b60b13eb79915933f44d8ed5f268bdd
+  version: 5c5490133daa8660ec676ca8b096cc27e223beaa
 - name: github.com/pkg/errors
-  version: f15c970de5b76fac0b59abb32d62c17cc7bed265
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: b8b73a35e9830ae509858c10dec5866b4d5c8bff
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
-  - require
   - mock
+  - require
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 7e7e266a8dbce911a49554b945538c5b950196b8
+  version: 55d3c264ce04be1d1aeac671f981697d0589b7c0
   subpackages:
-  - zapcore
-  - internal/bufferpool
   - buffer
+  - internal/bufferpool
   - internal/color
   - internal/exit
+  - zapcore
 - name: golang.org/x/crypto
-  version: 94eea52f7b742c7cbe0b03b22f0c4c8631ece122
+  version: a2144134853fc9a27a7b1e3eb4f19f1a76df13c9
   subpackages:
   - bcrypt
   - blowfish
 - name: golang.org/x/net
-  version: d0887baf81f4598189d4e12a37c6da86f0bba4d0
+  version: a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
   subpackages:
   - context
-  - http2
-  - trace
   - http/httpguts
+  - http2
   - http2/hpack
   - idna
   - internal/timeseries
+  - trace
 - name: golang.org/x/sys
   version: ac767d655b305d4e9612f5f6e33120b9176c4ad4
   subpackages:
@@ -96,26 +96,27 @@ imports:
   version: 0605a8320aceb4207a5fb3521281e17ec2075476
   subpackages:
   - secure/bidirule
+  - transform
   - unicode/bidi
   - unicode/norm
-  - transform
 - name: google.golang.org/genproto
-  version: e92b116572682a5b432ddd840aeaba2a559eeff1
+  version: fedd2861243fd1a8152376292b921b394c7bef7e
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: ce6ee6b031cb9e88a81e8d4d502d5b3eafb27f98
+  version: 445634bdcc9393d2681e504aafd3efc9b28c4bf2
   subpackages:
-  - credentials
-  - health
-  - health/grpc_health_v1
   - balancer
+  - balancer/base
   - balancer/roundrobin
   - codes
   - connectivity
+  - credentials
   - encoding
   - encoding/proto
   - grpclog
+  - health
+  - health/grpc_health_v1
   - internal
   - internal/backoff
   - internal/channelz
@@ -132,9 +133,8 @@ imports:
   - stats
   - status
   - tap
-  - balancer/base
 - name: gopkg.in/natefinch/lumberjack.v2
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
-  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports: []

--- a/plugin.go
+++ b/plugin.go
@@ -46,7 +46,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Message, err.StatusCode)
 	} else if team, err := p.API.GetTeamByName(r.URL.Query().Get("team")); err != nil {
 		http.Error(w, err.Message, err.StatusCode)
-	} else if channel, err := p.API.GetChannelByName(r.URL.Query().Get("channel"), team.Id); err != nil {
+	} else if channel, err := p.API.GetChannelByName(team.Id, r.URL.Query().Get("channel")); err != nil {
 		http.Error(w, err.Message, err.StatusCode)
 	} else if _, err := p.API.CreatePost(&model.Post{
 		ChannelId: channel.Id,

--- a/plugin.go
+++ b/plugin.go
@@ -44,9 +44,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		http.Error(w, "You must provide a channel.", http.StatusBadRequest)
 	} else if user, err := p.API.GetUserByUsername(p.UserName); err != nil {
 		http.Error(w, err.Message, err.StatusCode)
-	} else if team, err := p.API.GetTeamByName(r.URL.Query().Get("team")); err != nil {
-		http.Error(w, err.Message, err.StatusCode)
-	} else if channel, err := p.API.GetChannelByName(team.Id, r.URL.Query().Get("channel")); err != nil {
+	} else if channel, err := p.API.GetChannelByNameForTeamName(r.URL.Query().Get("team"), r.URL.Query().Get("channel")); err != nil {
 		http.Error(w, err.Message, err.StatusCode)
 	} else if _, err := p.API.CreatePost(&model.Post{
 		ChannelId: channel.Id,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@ backend:
     executable: plugin.exe
 name: JIRA
 description: Receives webhook events from JIRA and makes Mattermost posts for them.
-version: '1.0.0'
+version: '1.0.1'
 settings_schema:
   settings:
     - key: Enabled

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -134,18 +134,14 @@ func TestPlugin(t *testing.T) {
 			}, (*model.AppError)(nil))
 			api.On("GetUserByUsername", "nottheuser").Return((*model.User)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
 
-			api.On("GetTeamByName", "theteam").Return(&model.Team{
-				Id: "theteamid",
-			}, (*model.AppError)(nil))
-			api.On("GetTeamByName", "nottheteam").Return((*model.Team)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
-
-			api.On("GetChannelByName", "theteamid", "thechannel").Run(func(args mock.Arguments) {
+			api.On("GetChannelByNameForTeamName", "nottheteam", "thechannel").Return((*model.Channel)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
+			api.On("GetChannelByNameForTeamName", "theteam", "notthechannel").Return((*model.Channel)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
+			api.On("GetChannelByNameForTeamName", "theteam", "thechannel").Run(func(args mock.Arguments) {
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, tc.CreatePostError)
 			}).Return(&model.Channel{
 				Id:     "thechannelid",
 				TeamId: "theteamid",
 			}, (*model.AppError)(nil))
-			api.On("GetChannelByName", "theteamid", "notthechannel").Return((*model.Channel)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
 
 			p := Plugin{}
 			p.Enabled = tc.Configuration.Enabled

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -139,13 +139,13 @@ func TestPlugin(t *testing.T) {
 			}, (*model.AppError)(nil))
 			api.On("GetTeamByName", "nottheteam").Return((*model.Team)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
 
-			api.On("GetChannelByName", "thechannel", "theteamid").Run(func(args mock.Arguments) {
+			api.On("GetChannelByName", "theteamid", "thechannel").Run(func(args mock.Arguments) {
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, tc.CreatePostError)
 			}).Return(&model.Channel{
 				Id:     "thechannelid",
 				TeamId: "theteamid",
 			}, (*model.AppError)(nil))
-			api.On("GetChannelByName", "notthechannel", "theteamid").Return((*model.Channel)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
+			api.On("GetChannelByName", "theteamid", "notthechannel").Return((*model.Channel)(nil), model.NewAppError("foo", "bar", nil, "", http.StatusBadRequest))
 
 			p := Plugin{}
 			p.Enabled = tc.Configuration.Enabled


### PR DESCRIPTION
This fixes the plugin to work with the most recent plugin API breakages in 5.2 by just using `GetChannelByNameForTeamName`.