### PR TITLE
Fix missing return

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -91,6 +91,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		errorMessage := "Failed to create post"
 		p.postHTTPDebugMessage(errorMessage)
 		http.Error(w, errorMessage, http.StatusInternalServerError)
+		return
 	}
 
 	user, appErr := p.API.GetUserByUsername(config.UserName)


### PR DESCRIPTION
I missed an `return` in #16. Because of this `attachment` could be `nil` which caused `ParseSlackAttachment()` to panic and cause the problem reported in https://github.com/mattermost/mattermost-plugin-jira/issues/15#issuecomment-456833546.

I will submit a PR to `mattermost-server` to also fix this server-side.