### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "jira",
     "name": "Jira",
     "description": "Receives webhook events from JIRA and makes Mattermost posts for them.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "jira",
-	Version: "1.1.0",
+	Version: "1.1.1",
 }


### PR DESCRIPTION
I want to release this to fix an NPE multiple user reported.

This NPE will also be fixed server side in v5.8, but since it's a annoying bug, releases a bugfix release is necessary IMO.

The only diff the previous version is https://github.com/mattermost/mattermost-plugin-jira/commit/5c62e8987f4df590d45ee84953f114f5bba322c4.