### PR TITLE
Fixed go vet shadow variable

### DIFF
--- a/server/format-markdown.go
+++ b/server/format-markdown.go
@@ -18,7 +18,7 @@ const (
 	mdUpdateStyle = "###### "
 )
 
-type parsed struct {
+type parsedWebhook struct {
 	*Webhook
 	RawJSON  string
 	headline string
@@ -43,7 +43,7 @@ func AsMarkdown(in io.Reader) (func(post *model.Post), error) {
 	}, nil
 }
 
-func newMarkdownMessage(parsed *parsed) string {
+func newMarkdownMessage(parsed *parsedWebhook) string {
 	if parsed.headline == "" {
 		return ""
 	}
@@ -57,7 +57,7 @@ func newMarkdownMessage(parsed *parsed) string {
 	return s
 }
 
-func parse(in io.Reader, linkf func(w *Webhook) string) (*parsed, error) {
+func parse(in io.Reader, linkf func(w *Webhook) string) (*parsedWebhook, error) {
 	bb, err := ioutil.ReadAll(in)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func parse(in io.Reader, linkf func(w *Webhook) string) (*parsed, error) {
 		return nil, fmt.Errorf("No webhook event")
 	}
 
-	parsed := parsed{
+	parsed := parsedWebhook{
 		Webhook: &webhook,
 	}
 	parsed.RawJSON = string(bb)
@@ -124,7 +124,7 @@ func parse(in io.Reader, linkf func(w *Webhook) string) (*parsed, error) {
 	return &parsed, nil
 }
 
-func (p *parsed) fromChangeLog(issue string) (string, string) {
+func (p *parsedWebhook) fromChangeLog(issue string) (string, string) {
 	for _, item := range p.ChangeLog.Items {
 		to := item.ToString
 		from := item.FromString

--- a/server/format-markdown_test.go
+++ b/server/format-markdown_test.go
@@ -125,7 +125,7 @@ func TestMarkdown(t *testing.T) {
 func TestWebhookVariousErrorsForCoverage(t *testing.T) {
 	assert.Equal(t, "", mdUser(nil))
 
-	parsed := &parsed{
+	parsed := &parsedWebhook{
 		Webhook: &Webhook{},
 	}
 	assert.Equal(t, "", parsed.mdIssueReportedBy())

--- a/server/format-slack-attachment.go
+++ b/server/format-slack-attachment.go
@@ -23,7 +23,7 @@ func AsSlackAttachment(in io.Reader) (func(post *model.Post), error) {
 	}, nil
 }
 
-func newSlackAttachment(parsed *parsed) *model.SlackAttachment {
+func newSlackAttachment(parsed *parsedWebhook) *model.SlackAttachment {
 	if parsed.headline == "" {
 		return nil
 	}

--- a/server/format-slack-attachment_test.go
+++ b/server/format-slack-attachment_test.go
@@ -30,7 +30,7 @@ func TestSlackAttachment(t *testing.T) {
 }
 
 func TestSlackAttachmentForCoverage(t *testing.T) {
-	parsed := &parsed{
+	parsed := &parsedWebhook{
 		Webhook: &Webhook{},
 	}
 	parsed.WebhookEvent = "something-else"


### PR DESCRIPTION
I am not sure why go vet decided to complain about this one, renamed `type parsed` to `type parsedWebhook` to eliminate the naming conflict. 2/5 it reads better now anyway.