### PR TITLE
Fixed a nil pointer panic on empty Fields.Priority in new issues

### DIFF
--- a/server/format-markdown.go
+++ b/server/format-markdown.go
@@ -220,6 +220,9 @@ func (w *Webhook) mdIssueLabels() string {
 }
 
 func (w *Webhook) mdIssuePriority() string {
+	if w.Issue.Fields.Priority == nil {
+		return ""
+	}
 	return "Priority: " + mdBOLD(w.Issue.Fields.Priority.Name)
 }
 


### PR DESCRIPTION
This was overlooked in https://github.com/mattermost/mattermost-plugin-jira/pull/22

I verified that all pointer fields of Webhook are nil-checked now.

This has been deployed to community-daily, and now new issues are displayed.