### PR TITLE
Proposed update to response after a successful /jira transition

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -264,7 +264,7 @@ func executeTransition(p *Plugin, c *plugin.Context, args []string, userId strin
 		return responsef("%v", err)
 	}
 
-	return responsef("Transition completed.")
+	return responsef("issueKey transitioned to toState.")
 }
 
 func responsef(format string, args ...interface{}) *model.CommandResponse {


### PR DESCRIPTION
#### Context

When "/jira transition" results in a successful jira issue transition, we post back an ephemeral message `Transition completed.`

![image](https://user-images.githubusercontent.com/13119842/57375922-b050c200-716c-11e9-94de-57879e41847c.png)

In the ticket (https://mattermost.atlassian.net/browse/MM-15101), the proposal had been to use an ephemeral message with the UI matching a notification that is sent to a Mattermost channel when the state of an issue is changed.

An example of that is shown below.

![image](https://user-images.githubusercontent.com/13119842/57375966-ca8aa000-716c-11e9-9ee2-a24e18852852.png)

I'm not sure if the UI was a bigger effort, and hence a simpler message was used. If so, this is okay because of our tight timeline.

#### Proposed Change

However, propose we update the response to

```
<issue-key> transition to <state>
```

to confirm for the user which issue was moved to which state.