### PR TITLE
Fixed a bug in unescaping webhook secret

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -20,6 +20,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"  * `list` - List known Jira instances\n" +
 	"  * `select <number or URL>` - Select a known instance as current\n" +
 	"  * `delete <number or URL>` - Delete a known instance, select the first remaining as the current\n" +
+	"* `/jira webhook` - Display a Jira webhook URL customized for the current team/channel\n" +
 	""
 
 type CommandHandlerFunc func(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse
@@ -36,6 +37,8 @@ var jiraCommandHandler = CommandHandler{
 		"instance/list":       executeInstanceList,
 		"instance/select":     executeInstanceSelect,
 		"instance/delete":     executeInstanceDelete,
+		"webhook":             executeWebhookURL,
+		"webhook/url":         executeWebhookURL,
 		"transition":          executeTransition,
 		"connect":             executeConnect,
 		"disconnect":          executeDisconnect,
@@ -260,6 +263,18 @@ func executeTransition(p *Plugin, c *plugin.Context, header *model.CommandArgs, 
 	}
 
 	return responsef("Transition completed.")
+}
+
+func executeWebhookURL(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	if len(args) != 0 {
+		return help()
+	}
+
+	u, err := p.GetWebhookURL(header.TeamId, header.ChannelId)
+	if err != nil {
+		return responsef(err.Error())
+	}
+	return responsef("Please use the following URL to set up a Jira webhook: %v", u)
 }
 
 func getCommand() *model.Command {

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"net/http"
-	"path"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/dghubble/oauth1"
@@ -147,7 +146,7 @@ func (jsi *jiraServerInstance) GetOAuth1Config() (returnConfig *oauth1.Config, r
 	jsi.oauth1Config = &oauth1.Config{
 		ConsumerKey:    jsi.MattermostKey,
 		ConsumerSecret: "dontcare",
-		CallbackURL:    path.Join(jsi.GetPluginURL(), routeOAuth1Complete),
+		CallbackURL:    jsi.GetPluginURL() + "/" + routeOAuth1Complete,
 		Endpoint: oauth1.Endpoint{
 			RequestTokenURL: jsi.GetURL() + "/plugins/servlet/oauth/request-token",
 			AuthorizeURL:    jsi.GetURL() + "/plugins/servlet/oauth/authorize",


### PR DESCRIPTION
This PR fixes the issue that we'd receive the secret double-%-escaped. This is to unescape the secret repeatedly until there are no more valid %hh sequences left, comparing each version.

@jasonblais I am not sure there was a prior (1.0) ticket on this, couldn't find it. This may or may not be the same issue, but should be a general improvement anyway. I'd prefer that the secret was base64-encoded but I don't think it's better to stick with a backwards-compatible approach.

Also added `/jira webhook` command to see a URL custom-fit to the current channel.