### PR TITLE
Update few texts in post menu and Attach/Create Jira issue screens

### DIFF
--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -109,7 +109,7 @@ export default class AttachIssueModal extends PureComponent {
                         label={'Project'}
                         required={true}
                         onChange={this.handleProjectChange}
-                        placeholder={'Select...'}
+                        placeholder={'Select project'}
                         options={projectOptions}
                         isMuli={false}
                         key={'LT'}

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -109,7 +109,7 @@ export default class AttachIssueModal extends PureComponent {
                         label={'Project'}
                         required={true}
                         onChange={this.handleProjectChange}
-                        placeholder={'Select the project containing the issue you wish to attach the message to.'}
+                        placeholder={'Select...'}
                         options={projectOptions}
                         isMuli={false}
                         key={'LT'}
@@ -118,7 +118,7 @@ export default class AttachIssueModal extends PureComponent {
                     <Input
                         key='key'
                         id='issueKey'
-                        placeholder={'Enter the issue key, e.g. EXT-20'}
+                        placeholder={'Enter issue key to attach message to, e.g. EXT-20'}
                         label='Issue Key'
                         type='input'
                         onChange={this.handleIssueKeyChange}
@@ -147,7 +147,7 @@ export default class AttachIssueModal extends PureComponent {
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
-                        {'Attach Message To Jira Issue'}
+                        {'Attach Message to Jira Issue'}
                     </Modal.Title>
                 </Modal.Header>
                 <form

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -192,7 +192,7 @@ export default class CreateIssueModal extends PureComponent {
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
-                        {'Create Jira Ticket'}
+                        {'Create Jira Issue'}
                     </Modal.Title>
                 </Modal.Header>
                 <form

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -25,7 +25,7 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
         case 'es':
             return 'Crear incidencia en Jira';
         default:
-            return 'Attach Jira Issue';
+            return 'Attach to Jira Issue';
         }
     };
 


### PR DESCRIPTION
1. Update post menu text from "Attach Jira Issue" to "Attach to Jira Issue" to clarify the message would be attached TO a Jira issue.

![image](https://user-images.githubusercontent.com/13119842/58057329-7b604a00-7b32-11e9-84d0-272b6c864b78.png)

2. Update "Create Jira Ticket" title in issue creation screen to "Create Jira Issue"

3. Update texts in "Attach Message to Jira Issue" screen

 - `Attach Message To ...` in title to `Attach Message to...`
 - Update input text for "Project" field to `Select...`. This is for consistency with the new Jira issue creation screen.
 - Update input text for "Issue Key" field to `Enter issue key to attach message to, e.g. EXT-20`.

![image](https://user-images.githubusercontent.com/13119842/58057763-21f91a80-7b34-11e9-9169-fcc3a09a7c6d.png)
