### PR TITLE
[MM-15533] Change ephemeral message to <issue-key> transitioned to <state>

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -246,11 +246,12 @@ func executeTransition(p *Plugin, c *plugin.Context, header *model.CommandArgs, 
 	issueKey := args[0]
 	toState := strings.Join(args[1:], " ")
 
-	if err := p.transitionJiraIssue(header.UserId, issueKey, toState); err != nil {
+	msg, err := p.transitionJiraIssue(header.UserId, issueKey, toState)
+	if err != nil {
 		return responsef("%v", err)
 	}
 
-	return responsef("Transition completed.")
+	return responsef(msg)
 }
 
 func executeWebhookURL(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/issue.go
+++ b/server/issue.go
@@ -307,29 +307,29 @@ func getPermaLink(ji Instance, postId string, post *model.Post) (string, error) 
 	return permalink, nil
 }
 
-func (p *Plugin) transitionJiraIssue(mmUserId, issueKey, toState string) error {
+func (p *Plugin) transitionJiraIssue(mmUserId, issueKey, toState string) (string, error) {
 	ji, err := p.LoadCurrentJIRAInstance()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	jiraUser, err := ji.GetPlugin().LoadJIRAUser(ji, mmUserId)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	jiraClient, err := ji.GetJIRAClient(jiraUser)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	transitions, _, err := jiraClient.Issue.GetTransitions(issueKey)
 	if err != nil {
-		return errors.New("We couldn't find the issue key. Please confirm the issue key and try again. You may not have permissions to access this issue.")
+		return "", errors.New("We couldn't find the issue key. Please confirm the issue key and try again. You may not have permissions to access this issue.")
 	}
 
 	if len(transitions) < 1 {
-		return errors.New("You do not have the appropriate permissions to perform this action. Please contact your Jira administrator.")
+		return "", errors.New("You do not have the appropriate permissions to perform this action. Please contact your Jira administrator.")
 	}
 
 	var transitionToUse *jira.Transition
@@ -341,12 +341,13 @@ func (p *Plugin) transitionJiraIssue(mmUserId, issueKey, toState string) error {
 	}
 
 	if transitionToUse == nil {
-		return errors.New("We couldn't find the state. Please use a Jira state such as 'done' and try again.")
+		return "", errors.New("We couldn't find the state. Please use a Jira state such as 'done' and try again.")
 	}
 
 	if _, err := jiraClient.Issue.DoTransition(issueKey, transitionToUse.ID); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	msg := fmt.Sprintf("[%s](%v/browse/%v) transitioned to `%s`", issueKey, ji.GetURL(), issueKey, toState)
+	return msg, nil
 }


### PR DESCRIPTION
**Summary**
This PR changes the ephemeral message from a generic message to a message that verifies to the user that the state was changed for a specified issue.

Example of new messages:
![image](https://user-images.githubusercontent.com/7575921/58069225-030d7f00-7b5a-11e9-9155-39fc77d92725.png)

**Ticket Link**
Please view the following ticket for a description
https://mattermost.atlassian.net/browse/MM-15533