### PR TITLE
[MM-15537] Fix 'connect to jira' menu item when not connected

### DIFF
--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/mattermost/mattermost-server/model"
 	"io/ioutil"
 	"net/http"
 
@@ -96,32 +95,7 @@ func httpACUninstalled(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 			errors.New("method " + r.Method + " is not allowed, must be POST")
 	}
 
-	// Notify users we have uninstalled an instance
-	// We're doing this first because there's a chance of getting into a state where the clients think there is an
-	// instance_installed, but the admin has deleted the instance somehow (eg. through the slash commands if we
-	// expose them). If that happens, then we'll error out of this function before we get to the end.
-	// We want to make sure to send the notification to clients that there is no instance_installed.
-	p.API.PublishWebSocketEvent(
-		wSEventInstanceStatus,
-		map[string]interface{}{
-			"instance_installed": false,
-		},
-		&model.WebsocketBroadcast{},
-	)
-
-	ji, err := p.LoadCurrentJIRAInstance()
-	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "no current Jira instance to uninstall")
-	}
-
-	// Remove the instance. If we don't, we will mistakenly think that there is a connected instance.
-	err = p.DeleteJiraInstance(ji.GetURL())
-	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to delete Jira instance"+ji.GetURL())
-	}
-
+	// Just send an ok to the Jira server, even though we're not doing anything.
 	_ = json.NewEncoder(w).Encode([]string{"OK"})
 	return http.StatusOK, nil
 }

--- a/server/command.go
+++ b/server/command.go
@@ -334,7 +334,7 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 		&model.WebsocketBroadcast{},
 	)
 
-	const uninstallInstructions = `Jira instance successfully disconnected. Go to XXX to remove the application in your Jira Server instance.`
+	const uninstallInstructions = `Jira instance successfully disconnected. Go to **Settings > Applications > Application Links** to remove the application in your Jira Server or Data Center instance.`
 
 	return responsef(uninstallInstructions)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -299,7 +299,7 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 		return responsef("%v", err)
 	}
 	if !authorized {
-		return responsef("`/jira uninstall` can only be run by a system administrator.")
+		return responsef("`/jira uninstall` can only be run by a System Administrator.")
 	}
 	if len(args) != 1 {
 		return help()

--- a/server/command.go
+++ b/server/command.go
@@ -288,7 +288,7 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 		&model.WebsocketBroadcast{},
 	)
 
-	const uninstallInstructions = `Jira instance successfully disconnected. Go to XXX to remove the application in your Jira Cloud instance.`
+	const uninstallInstructions = `Jira instance successfully disconnected. Go to **Settings > Apps > Manage Apps** to remove the application in your Jira Cloud instance.`
 
 	return responsef(uninstallInstructions)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -13,7 +13,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira connect` - Connect your Mattermost account to your Jira account\n" +
 	"* `/jira disconnect` - Disconnect your Mattermost account from your Jira account\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"\n###### For system administrators:\n" +
+	"\n###### For System Administrators:\n" +
 	"Install:\n" +
 	"* `/jira install cloud <URL>` - Connect Mattermost to a Jira Cloud instance located at <URL>\n" +
 	"* `/jira install server <URL>` - Connect Mattermost to a Jira Server or Data Center instance located at <URL>\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -280,11 +280,6 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 	}
 
 	// Notify users we have uninstalled an instance
-	// We're doing this as early as possible because there's a chance of getting into a state where the clients
-	// think there is an instance_installed, but the admin has deleted the instance somehow (eg. through the
-	// slash commands if we expose them). If that happens, then we'll error out of this function before we get
-	// to the end, but there will be no instance_installed. We want to make sure to send the notification
-	// to clients that there is no instance_installed.
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
@@ -331,11 +326,6 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 	}
 
 	// Notify users we have uninstalled an instance
-	// We're doing this as early as possible because there's a chance of getting into a state where the clients
-	// think there is an instance_installed, but the admin has deleted the instance somehow (eg. through the
-	// slash commands if we expose them). If that happens, then we'll error out of this function before we get
-	// to the end, but there will be no instance_installed. We want to make sure to send the notification
-	// to clients that there is no instance_installed.
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{

--- a/server/command.go
+++ b/server/command.go
@@ -253,7 +253,7 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 		return responsef("%v", err)
 	}
 	if !authorized {
-		return responsef("`/jira uninstall` can only be run by a system administrator.")
+		return responsef("`/jira uninstall` can only be run by a System Administrator.")
 	}
 	if len(args) != 1 {
 		return help()

--- a/server/command.go
+++ b/server/command.go
@@ -227,7 +227,7 @@ If you see an option to create a Jira issue, you're all set! If not, refer to ou
 	if err != nil {
 		return responsef(err.Error())
 	}
-	err = p.StoreCurrentJIRAInstance(ji)
+	err = p.StoreCurrentJIRAInstanceAndNotify(ji)
 	if err != nil {
 		return responsef(err.Error())
 	}
@@ -323,7 +323,7 @@ func responsef(format string, args ...interface{}) *model.CommandResponse {
 //	if err != nil {
 //		return responsef("Failed to load Jira instance %s: %v", instanceKey, err)
 //	}
-//	err = p.StoreCurrentJIRAInstance(ji)
+//	err = p.StoreCurrentJIRAInstanceAndNotify(ji)
 //	if err != nil {
 //		return responsef(err.Error())
 //	}

--- a/server/http.go
+++ b/server/http.go
@@ -20,6 +20,7 @@ const (
 	routeAPIGetCreateIssueMetadata = "/api/v2/get-create-issue-metadata"
 	routeAPIAttachCommentToIssue   = "/api/v2/attach-comment-to-issue"
 	routeAPIUserInfo               = "/api/v2/userinfo"
+	routeAPIInstanceStatus         = "/api/v2/instancestatus"
 	routeACInstalled               = "/ac/installed"
 	routeACJSON                    = "/ac/atlassian-connect.json"
 	routeACUninstalled             = "/ac/uninstalled"
@@ -64,6 +65,10 @@ func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 	// User APIs
 	case routeAPIUserInfo:
 		return withInstance(p, w, r, httpAPIGetUserInfo)
+
+	// Instance APIs
+	case routeAPIInstanceStatus:
+		return httpAPIGetInstanceStatus(p, w, r)
 
 	// Atlassian Connect application
 	case routeACInstalled:

--- a/server/http.go
+++ b/server/http.go
@@ -20,7 +20,6 @@ const (
 	routeAPIGetCreateIssueMetadata = "/api/v2/get-create-issue-metadata"
 	routeAPIAttachCommentToIssue   = "/api/v2/attach-comment-to-issue"
 	routeAPIUserInfo               = "/api/v2/userinfo"
-	routeAPIInstanceStatus         = "/api/v2/instancestatus"
 	routeACInstalled               = "/ac/installed"
 	routeACJSON                    = "/ac/atlassian-connect.json"
 	routeACUninstalled             = "/ac/uninstalled"
@@ -64,11 +63,7 @@ func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 
 	// User APIs
 	case routeAPIUserInfo:
-		return withInstance(p, w, r, httpAPIGetUserInfo)
-
-	// Instance APIs
-	case routeAPIInstanceStatus:
-		return httpAPIGetInstanceStatus(p, w, r)
+		return httpAPIGetUserInfo(p, w, r)
 
 	// Atlassian Connect application
 	case routeACInstalled:

--- a/server/instance.go
+++ b/server/instance.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"encoding/json"
-	"github.com/pkg/errors"
 	"net/http"
 	"regexp"
 	"sync"
@@ -80,30 +78,4 @@ func withInstance(p *Plugin, w http.ResponseWriter, r *http.Request, f withInsta
 		return http.StatusInternalServerError, err
 	}
 	return f(ji, w, r)
-}
-
-func httpAPIGetInstanceStatus(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
-	if r.Method != http.MethodGet {
-		return http.StatusMethodNotAllowed,
-			errors.New("method " + r.Method + " is not allowed, must be GET")
-	}
-
-	mattermostUserId := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserId == "" {
-		return http.StatusUnauthorized, errors.New("not authorized")
-	}
-
-	resp := InstanceStatus{InstanceInstalled: true}
-
-	_, err := p.LoadCurrentJIRAInstance()
-	if err != nil {
-		resp = InstanceStatus{InstanceInstalled: false}
-	}
-
-	b, _ := json.Marshal(resp)
-	_, err = w.Write(b)
-	if err != nil {
-		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
-	}
-	return http.StatusOK, nil
 }

--- a/server/instance.go
+++ b/server/instance.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	JIRATypeCloud         = "cloud"
-	JIRATypeServer        = "server"
-	wSEventInstanceStatus = "instance_status"
+	JIRATypeCloud  = "cloud"
+	JIRATypeServer = "server"
 )
 
 const prefixForInstance = true
+
+const wSEventInstanceStatus = "instance_status"
 
 type Instance interface {
 	GetJIRAClient(jiraUser JIRAUser) (*jira.Client, error)

--- a/server/instance.go
+++ b/server/instance.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"encoding/json"
+	"github.com/pkg/errors"
 	"net/http"
 	"regexp"
 	"sync"
@@ -12,8 +14,9 @@ import (
 )
 
 const (
-	JIRATypeCloud  = "cloud"
-	JIRATypeServer = "server"
+	JIRATypeCloud         = "cloud"
+	JIRATypeServer        = "server"
+	wSEventInstanceStatus = "instance_status"
 )
 
 const prefixForInstance = true
@@ -35,6 +38,10 @@ type JIRAInstance struct {
 
 	Key  string
 	Type string
+}
+
+type InstanceStatus struct {
+	InstanceInstalled bool `json:"instance_installed"`
 }
 
 var regexpNonAlnum = regexp.MustCompile("[^a-zA-Z0-9]+")
@@ -73,4 +80,30 @@ func withInstance(p *Plugin, w http.ResponseWriter, r *http.Request, f withInsta
 		return http.StatusInternalServerError, err
 	}
 	return f(ji, w, r)
+}
+
+func httpAPIGetInstanceStatus(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
+	if r.Method != http.MethodGet {
+		return http.StatusMethodNotAllowed,
+			errors.New("method " + r.Method + " is not allowed, must be GET")
+	}
+
+	mattermostUserId := r.Header.Get("Mattermost-User-Id")
+	if mattermostUserId == "" {
+		return http.StatusUnauthorized, errors.New("not authorized")
+	}
+
+	resp := InstanceStatus{InstanceInstalled: true}
+
+	_, err := p.LoadCurrentJIRAInstance()
+	if err != nil {
+		resp = InstanceStatus{InstanceInstalled: false}
+	}
+
+	b, _ := json.Marshal(resp)
+	_, err = w.Write(b)
+	if err != nil {
+		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
+	}
+	return http.StatusOK, nil
 }

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -180,7 +180,7 @@ func (jci jiraCloudInstance) parseHTTPRequestJWT(r *http.Request) (*jwt.Token, s
 		return []byte(jci.AtlassianSecurityContext.SharedSecret), nil
 	})
 	if err != nil || !token.Valid {
-		return nil, "", errors.WithMessage(err, "failed to validatte JWT")
+		return nil, "", errors.WithMessage(err, "failed to validate JWT")
 	}
 
 	return token, tokenString, nil

--- a/server/kv.go
+++ b/server/kv.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"github.com/mattermost/mattermost-server/model"
 
 	"github.com/pkg/errors"
 )
@@ -138,7 +139,7 @@ func (p *Plugin) CreateInactiveCloudInstance(jiraURL string) (returnErr error) {
 	return nil
 }
 
-func (p *Plugin) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
+func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) (returnErr error) {
 	defer func() {
 		if returnErr == nil {
 			return
@@ -151,6 +152,16 @@ func (p *Plugin) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
 		return err
 	}
 	p.debugf("Stored: current Jira instance: %s", ji.GetURL())
+
+	// Notify users we have installed an instance
+	p.API.PublishWebSocketEvent(
+		wSEventInstanceStatus,
+		map[string]interface{}{
+			"instance_installed": true,
+		},
+		&model.WebsocketBroadcast{},
+	)
+
 	return nil
 }
 

--- a/server/user.go
+++ b/server/user.go
@@ -107,7 +107,6 @@ func httpAPIGetUserInfo(p *Plugin, w http.ResponseWriter, r *http.Request) (int,
 	}
 
 	resp := UserInfo{}
-
 	if ji, err := p.LoadCurrentJIRAInstance(); err == nil {
 		if jiraUser, err := ji.GetPlugin().LoadJIRAUser(ji, mattermostUserId); err == nil {
 			resp = UserInfo{

--- a/server/user.go
+++ b/server/user.go
@@ -26,8 +26,9 @@ type JIRAUser struct {
 
 type UserInfo struct {
 	JIRAUser
-	IsConnected bool   `json:"is_connected"`
-	JIRAURL     string `json:"jira_url,omitempty"`
+	IsConnected       bool   `json:"is_connected"`
+	InstanceInstalled bool   `json:"instance_installed"`
+	JIRAURL           string `json:"jira_url,omitempty"`
 }
 
 func httpUserConnect(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
@@ -94,7 +95,7 @@ func httpUserDisconnect(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	return http.StatusOK, nil
 }
 
-func httpAPIGetUserInfo(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
+func httpAPIGetUserInfo(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
 	if r.Method != http.MethodGet {
 		return http.StatusMethodNotAllowed,
 			errors.New("method " + r.Method + " is not allowed, must be GET")
@@ -106,17 +107,20 @@ func httpAPIGetUserInfo(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	}
 
 	resp := UserInfo{}
-	jiraUser, err := ji.GetPlugin().LoadJIRAUser(ji, mattermostUserId)
-	if err == nil {
-		resp = UserInfo{
-			JIRAUser:    jiraUser,
-			IsConnected: true,
-			JIRAURL:     ji.GetURL(),
+
+	if ji, err := p.LoadCurrentJIRAInstance(); err == nil {
+		if jiraUser, err := ji.GetPlugin().LoadJIRAUser(ji, mattermostUserId); err == nil {
+			resp = UserInfo{
+				JIRAUser:          jiraUser,
+				InstanceInstalled: true,
+				IsConnected:       true,
+				JIRAURL:           ji.GetURL(),
+			}
 		}
 	}
 
 	b, _ := json.Marshal(resp)
-	_, err = w.Write(b)
+	_, err := w.Write(b)
 	if err != nil {
 		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}

--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -11,6 +11,7 @@ export default {
     OPEN_ATTACH_COMMENT_TO_ISSUE_MODAL: `${PluginId}_open_attach_modal`,
 
     RECEIVED_CONNECTED: `${PluginId}_connected`,
+    RECEIVED_INSTANCE_STATUS: `${PluginId}_instance_status`,
 
     RECEIVED_JIRA_ISSUE_METADATA: `${PluginId}_received_metadata`,
 };

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -121,3 +121,37 @@ export function handleConnectChange(store) {
         });
     };
 }
+
+export const getInstanceStatus = () => {
+    return async (dispatch, getState) => {
+        let data;
+        const baseUrl = getPluginServerRoute(getState());
+        try {
+            data = await doFetch(`${baseUrl}/api/v2/instancestatus`, {
+                method: 'get',
+            });
+        } catch (error) {
+            return {error};
+        }
+
+        dispatch({
+            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
+            data,
+        });
+
+        return {data};
+    };
+};
+
+export function handleInstanceStatusChange(store) {
+    return (msg) => {
+        if (!msg.data) {
+            return;
+        }
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
+            data: msg.data,
+        });
+    };
+}

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -105,6 +105,11 @@ export function getConnected() {
             data,
         });
 
+        dispatch({
+            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
+            data,
+        });
+
         return {data};
     };
 }
@@ -121,27 +126,6 @@ export function handleConnectChange(store) {
         });
     };
 }
-
-export const getInstanceStatus = () => {
-    return async (dispatch, getState) => {
-        let data;
-        const baseUrl = getPluginServerRoute(getState());
-        try {
-            data = await doFetch(`${baseUrl}/api/v2/instancestatus`, {
-                method: 'get',
-            });
-        } catch (error) {
-            return {error};
-        }
-
-        dispatch({
-            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
-            data,
-        });
-
-        return {data};
-    };
-};
 
 export function handleInstanceStatusChange(store) {
     return (msg) => {

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -14,7 +14,8 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
         locale: PropTypes.string,
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
-        connected: PropTypes.object.isRequired,
+        userConnected: PropTypes.bool.isRequired,
+        instanceInstalled: PropTypes.bool.isRequired,
     };
 
     static defaultTypes = {
@@ -39,16 +40,15 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
 
     connectClick = () => {
         window.open('/plugins/' + PluginId + '/user/connect');
-    }
+    };
 
     render() {
-        if (this.props.isSystemMessage) {
+        if (this.props.isSystemMessage || !this.props.instanceInstalled) {
             return null;
         }
 
-        const conn = this.props.connected || {};
         let content;
-        if (conn.connected) {
+        if (this.props.userConnected) {
             content = (
                 <button
                     className='style--none'

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -43,7 +43,7 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
     };
 
     render() {
-        if (this.props.isSystemMessage || !this.props.instanceInstalled || !this.props.connected) {
+        if (this.props.isSystemMessage || !this.props.instanceInstalled || !this.props.userConnected) {
             return null;
         }
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -20,7 +20,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: state[`plugins-${PluginId}`],
+        userConnected: state[`plugins-${PluginId}`].userConnected,
+        instanceInstalled: state[`plugins-${PluginId}`].instanceInstalled,
     };
 };
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openAttachCommentToIssueModal} from 'actions';
 
-import {getCurrentUserLocale, isConnected} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
 
 import AttachCommentToIssuePostMenuAction from './attach_comment_to_issue';
 
@@ -18,8 +18,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: isConnected(state),
-        instanceInstalled: state[`plugins-${PluginId}`].instanceInstalled,
+        userConnected: isUserConnected(state),
+        instanceInstalled: isInstanceInstalled(state),
     };
 };
 

--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -14,7 +14,8 @@ export default class CreateIssuePostMenuAction extends PureComponent {
         locale: PropTypes.string,
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
-        connected: PropTypes.object.isRequired,
+        userConnected: PropTypes.bool.isRequired,
+        instanceInstalled: PropTypes.bool.isRequired,
     };
 
     static defaultTypes = {
@@ -39,16 +40,15 @@ export default class CreateIssuePostMenuAction extends PureComponent {
 
     connectClick = () => {
         window.open('/plugins/' + PluginId + '/user/connect');
-    }
+    };
 
     render() {
-        if (this.props.isSystemMessage) {
+        if (this.props.isSystemMessage || !this.props.instanceInstalled) {
             return null;
         }
 
-        const conn = this.props.connected || {};
         let content;
-        if (conn.connected) {
+        if (this.props.userConnected) {
             content = (
                 <button
                     className='style--none'

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -20,7 +20,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: state[`plugins-${PluginId}`],
+        userConnected: state[`plugins-${PluginId}`].userConnected,
+        instanceInstalled: state[`plugins-${PluginId}`].instanceInstalled,
     };
 };
 

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openCreateModal} from 'actions';
 
-import {getCurrentUserLocale, isConnected} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
 
 import CreateIssuePostMenuAction from './create_issue';
 
@@ -18,8 +18,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: isConnected(state),
-        instanceInstalled: state[`plugins-${PluginId}`].instanceInstalled,
+        userConnected: isUserConnected(state),
+        instanceInstalled: isInstanceInstalled(state),
     };
 };
 

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -10,17 +10,14 @@ import AttachCommentToIssueModal from 'components/modals/attach_comment_to_issue
 import PluginId from 'plugin_id';
 
 import reducers from './reducers';
-import {handleConnectChange, getConnected, getInstanceStatus, handleInstanceStatusChange} from './actions';
+import {handleConnectChange, getConnected, handleInstanceStatusChange} from './actions';
 
 export default class Plugin {
     async initialize(registry, store) {
         registry.registerReducer(reducers);
 
         try {
-            await Promise.all([
-                getConnected()(store.dispatch, store.getState),
-                getInstanceStatus()(store.dispatch, store.getState),
-            ]);
+            await getConnected()(store.dispatch, store.getState);
 
             registry.registerRootComponent(CreateIssueModal);
             registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -10,14 +10,17 @@ import AttachCommentToIssueModal from 'components/modals/attach_comment_to_issue
 import PluginId from 'plugin_id';
 
 import reducers from './reducers';
-import {handleConnectChange, getConnected} from './actions';
+import {handleConnectChange, getConnected, getInstanceStatus, handleInstanceStatusChange} from './actions';
 
 export default class Plugin {
     async initialize(registry, store) {
         registry.registerReducer(reducers);
 
         try {
-            await getConnected()(store.dispatch, store.getState);
+            await Promise.all([
+                getConnected()(store.dispatch, store.getState),
+                getInstanceStatus()(store.dispatch, store.getState),
+            ]);
 
             registry.registerRootComponent(CreateIssueModal);
             registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);
@@ -29,6 +32,7 @@ export default class Plugin {
         } finally {
             registry.registerWebSocketEventHandler(`custom_${PluginId}_connect`, handleConnectChange(store));
             registry.registerWebSocketEventHandler(`custom_${PluginId}_disconnect`, handleConnectChange(store));
+            registry.registerWebSocketEventHandler(`custom_${PluginId}_instance_status`, handleInstanceStatusChange(store));
         }
     }
 }

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -15,7 +15,10 @@ function userConnected(state = false, action) {
 }
 
 function instanceInstalled(state = false, action) {
+    // We're notified of the instance status at startup (through getConnected)
+    // and when we get a websocket instance_status event
     switch (action.type) {
+    case ActionTypes.RECEIVED_CONNECTED:
     case ActionTypes.RECEIVED_INSTANCE_STATUS:
         return action.data.instance_installed;
     default:

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -19,6 +19,7 @@ function instanceInstalled(state = false, action) {
     // and when we get a websocket instance_status event
     switch (action.type) {
     case ActionTypes.RECEIVED_CONNECTED:
+        return action.data.instance_installed ? action.data.instance_installed : state;
     case ActionTypes.RECEIVED_INSTANCE_STATUS:
         return action.data.instance_installed;
     default:

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -5,10 +5,19 @@ import {combineReducers} from 'redux';
 
 import ActionTypes from 'action_types';
 
-function connected(state = false, action) {
+function userConnected(state = false, action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_CONNECTED:
         return action.data.is_connected;
+    default:
+        return state;
+    }
+}
+
+function instanceInstalled(state = false, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_INSTANCE_STATUS:
+        return action.data.instance_installed;
     default:
         return state;
     }
@@ -68,7 +77,8 @@ const jiraIssueMetadata = (state = null, action) => {
 };
 
 export default combineReducers({
-    connected,
+    userConnected,
+    instanceInstalled,
     createModalVisible,
     createModalForPostId,
     attachCommentToIssueModalVisible,

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -47,4 +47,6 @@ export const getAttachCommentToIssueModalForPostId = (state) => getPluginState(s
 
 export const getJiraIssueMetadata = (state) => getPluginState(state).jiraIssueMetadata;
 
-export const isConnected = (state) => getPluginState(state).connected;
+export const isUserConnected = (state) => getPluginState(state).userConnected;
+
+export const isInstanceInstalled = (state) => getPluginState(state).instanceInstalled;


### PR DESCRIPTION
#### Summary
The 'Connect to Jira' menu item will not appear if there is no installed Jira instance.

Notes:
- One edge case: When connecting server, if a user was already connected to that server, their client won't be updated until they reload. Possible second ticket @jasonblais ?
- Some refactoring  (eg. state variables to make it more clear, connected -> userConnected)
- now using `/jira uninstall cloud/server <URL>`, and the cloud server's callback to ACUnistalled does nothing because we can't authenticate it with the JWT. 

#### Links
[MM-15537](https://mattermost.atlassian.net/browse/MM-15537)
[MM-15828](https://mattermost.atlassian.net/browse/MM-15828)