### PR TITLE
MM-15866: Webhook presentation tweaks in jira2

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -295,8 +295,6 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 	for _, item := range p.ChangeLog.Items {
 		to := item.ToString
 		from := item.FromString
-		lto := strings.ToLower(item.ToString)
-		lfrom := strings.ToLower(item.FromString)
 		switch {
 		case item.Field == "resolution" && to == "" && from != "":
 			p.event(eventUpdatedReopened)
@@ -306,21 +304,9 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 			p.event(eventUpdatedResolved)
 			return fmt.Sprintf("resolved %v", issue), ""
 
-		case item.Field == "status" && lto == "in progress":
-			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("started working on %v", issue), ""
-
-		case item.Field == "status" && lfrom == "in progress" && lto == "to do":
-			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("stopped working on %v", issue), ""
-
-		case item.Field == "status" && lfrom == "in progress" && lto == "done":
-			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("finished work on %v", issue), ""
-
 		case item.Field == "status":
 			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("transitioned %v to %q", issue, to), ""
+			return fmt.Sprintf("transitioned %v from %q to %q", issue, from, to), ""
 
 		case item.Field == "priority" && item.From > item.To:
 			p.event(eventUpdatedPriority)

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -86,18 +86,19 @@ type JIRAWebhook struct {
 
 type parsedJIRAWebhook struct {
 	*JIRAWebhook
-	RawJSON           string
-	events            uint64
-	headline          string
-	details           string
-	text              string
-	style             string
-	authorDisplayName string
-	authorUsername    string
-	authorURL         string
-	assigneeUsername  string
-	issueKey          string
-	issueURL          string
+	RawJSON            string
+	events             uint64
+	headline           string
+	details            string
+	text               string
+	style              string
+	useSlackAttachment bool
+	authorDisplayName  string
+	authorUsername     string
+	authorURL          string
+	assigneeUsername   string
+	issueKey           string
+	issueURL           string
 }
 
 type notifier interface {
@@ -167,7 +168,6 @@ func httpWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error)
 		return http.StatusOK, nil
 	}
 
-	slackAttachment := newSlackAttachment(parsed)
 	post := &model.Post{
 		ChannelId: channel.Id,
 		UserId:    user.Id,
@@ -176,7 +176,12 @@ func httpWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error)
 			"use_user_icon": "true",
 		},
 	}
-	model.ParseSlackAttachment(post, []*model.SlackAttachment{slackAttachment})
+	if parsed.useSlackAttachment {
+		slackAttachment := newSlackAttachment(parsed)
+		model.ParseSlackAttachment(post, []*model.SlackAttachment{slackAttachment})
+	} else {
+		post.Message = parsed.headline
+	}
 
 	_, appErr = p.API.CreatePost(post)
 	if appErr != nil {
@@ -218,7 +223,7 @@ func parse(in io.Reader, linkf func(w *JIRAWebhook) string) (*parsedJIRAWebhook,
 	parsed.RawJSON = string(bb)
 	if linkf == nil {
 		linkf = func(w *JIRAWebhook) string {
-			return parsed.mdIssueLink()
+			return parsed.mdIssueLongLink()
 		}
 	}
 
@@ -233,6 +238,7 @@ func parse(in io.Reader, linkf func(w *JIRAWebhook) string) (*parsedJIRAWebhook,
 		headline = fmt.Sprintf("created %v", issue)
 		parsed.details = parsed.mdIssueCreatedDetails()
 		parsed.text = parsed.mdIssueDescription()
+		parsed.useSlackAttachment = true
 	case "jira:issue_deleted":
 		parsed.event(eventDeleted)
 		if parsed.Issue.Fields != nil && parsed.Issue.Fields.Resolution == nil {
@@ -259,12 +265,14 @@ func parse(in io.Reader, linkf func(w *JIRAWebhook) string) (*parsedJIRAWebhook,
 		user = &parsed.Comment.UpdateAuthor
 		headline = fmt.Sprintf("edited a comment in %v", issue)
 		parsed.text = truncate(parsed.Comment.Body, 3000)
+		parsed.useSlackAttachment = true
 
 	case "comment_created":
 		parsed.event(eventCreatedComment)
 		user = &parsed.Comment.UpdateAuthor
 		headline = fmt.Sprintf("commented on %v", issue)
 		parsed.text = truncate(parsed.Comment.Body, 3000)
+		parsed.useSlackAttachment = true
 	}
 	if headline == "" {
 		return nil, fmt.Errorf("Unsupported webhook data: %v", parsed.WebhookEvent)
@@ -287,6 +295,8 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 	for _, item := range p.ChangeLog.Items {
 		to := item.ToString
 		from := item.FromString
+		lto := strings.ToLower(item.ToString)
+		lfrom := strings.ToLower(item.FromString)
 		switch {
 		case item.Field == "resolution" && to == "" && from != "":
 			p.event(eventUpdatedReopened)
@@ -296,17 +306,21 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 			p.event(eventUpdatedResolved)
 			return fmt.Sprintf("resolved %v", issue), ""
 
-		case item.Field == "status" && to == "Backlog":
-			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("moved %v to backlog", issue), ""
-
-		case item.Field == "status" && to == "In Progress":
+		case item.Field == "status" && lto == "in progress":
 			p.event(eventUpdatedStatus)
 			return fmt.Sprintf("started working on %v", issue), ""
 
-		case item.Field == "status" && to == "Selected for Development":
+		case item.Field == "status" && lfrom == "in progress" && lto == "to do":
 			p.event(eventUpdatedStatus)
-			return fmt.Sprintf("selected %v for development", issue), ""
+			return fmt.Sprintf("stopped working on %v", issue), ""
+
+		case item.Field == "status" && lfrom == "in progress" && lto == "done":
+			p.event(eventUpdatedStatus)
+			return fmt.Sprintf("finished work on %v", issue), ""
+
+		case item.Field == "status":
+			p.event(eventUpdatedStatus)
+			return fmt.Sprintf("transitioned %v to %q", issue, to), ""
 
 		case item.Field == "priority" && item.From > item.To:
 			p.event(eventUpdatedPriority)
@@ -322,6 +336,8 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 
 		case item.Field == "description":
 			p.event(eventUpdatedDescription)
+			p.text = p.mdIssueDescription()
+			p.useSlackAttachment = true
 			return fmt.Sprintf("edited description of %v", issue),
 				p.mdIssueDescription()
 

--- a/server/webhook_markdown_test.go
+++ b/server/webhook_markdown_test.go
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 	}, {
 		file:             "testdata/webhook-issue-updated-started-working.json",
 		expectedStyle:    mdUpdateStyle,
-		expectedHeadline: "Test User started working on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+		expectedHeadline: "Test User transitioned story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41) from \"To Do\" to \"In Progress\"",
 	},
 	} {
 		t.Run(tc.file, func(t *testing.T) {

--- a/server/webhook_slack_attachment.go
+++ b/server/webhook_slack_attachment.go
@@ -19,12 +19,6 @@ func newSlackAttachment(parsed *parsedJIRAWebhook) *model.SlackAttachment {
 		Text:     parsed.text,
 	}
 
-	text := parsed.mdIssueLongLink() + "\n"
-	if parsed.text != "" {
-		text += "\n"
-		text += parsed.text + "\n"
-	}
-
 	var fields []*model.SlackAttachmentField
 	if parsed.WebhookEvent == "jira:issue_created" {
 
@@ -44,7 +38,6 @@ func newSlackAttachment(parsed *parsedJIRAWebhook) *model.SlackAttachment {
 		}
 	}
 
-	a.Text = text
 	a.Fields = fields
 	return a
 }

--- a/server/webhook_slack_attachment_test.go
+++ b/server/webhook_slack_attachment_test.go
@@ -21,10 +21,10 @@ func TestSlackAttachment(t *testing.T) {
 	require.NoError(t, err)
 	a := newSlackAttachment(parsed)
 
-	assert.Equal(t, "Test User created story [TES-41](https://some-instance-test.atlassian.net/browse/TES-41)", a.Fallback)
+	assert.Equal(t, "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)", a.Fallback)
 	assert.Equal(t, "#95b7d0", a.Color)
-	assert.Equal(t, "Test User created story [TES-41](https://some-instance-test.atlassian.net/browse/TES-41)", a.Pretext)
-	assert.Equal(t, "[TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)\n\nUnit test description, not that long\n", a.Text)
+	assert.Equal(t, "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)", a.Pretext)
+	assert.Equal(t, "Unit test description, not that long", a.Text)
 	assert.Equal(t, 1, len(a.Fields))
 	assert.Equal(t, &model.SlackAttachmentField{Title: "Priority", Value: "High", Short: true}, a.Fields[0])
 }


### PR DESCRIPTION
Discussed with @jasonblais offline - some small improvements:
- Added the issue description to the headline of the posts
- Remove the (now redundant) headline from the Slack attachment
- Do not use Slack attachments for 1-liners

https://mattermost.atlassian.net/browse/MM-15866