### PR TITLE
MM-15871 strengthened one-time checks for auth links

### DIFF
--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -89,19 +88,18 @@ func (jci jiraCloudInstance) GetDisplayDetails() map[string]string {
 }
 
 func (jci jiraCloudInstance) GetUserConnectURL(mattermostUserId string) (string, error) {
-	secret := make([]byte, 256)
-	_, err := rand.Read(secret)
+	randomBytes := make([]byte, 32)
+	_, err := rand.Read(randomBytes)
 	if err != nil {
 		return "", err
 	}
-	secretKey := fmt.Sprintf("%x", sha256.Sum256(secret))
-	secretValue := "true"
-	err = jci.Plugin.StoreOneTimeSecret(secretKey, secretValue)
+	secret := fmt.Sprintf("%x", randomBytes)
+	err = jci.Plugin.StoreOneTimeSecret(mattermostUserId, secret)
 	if err != nil {
 		return "", err
 	}
 
-	token, err := jci.Plugin.NewEncodedAuthToken(mattermostUserId, secretKey)
+	token, err := jci.Plugin.NewEncodedAuthToken(mattermostUserId, secret)
 	if err != nil {
 		return "", err
 	}

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -76,7 +76,7 @@ func (jsi jiraServerInstance) GetUserConnectURL(mattermostUserId string) (return
 		return "", err
 	}
 
-	err = jsi.Plugin.StoreOneTimeSecret(token, secret)
+	err = jsi.Plugin.StoreOneTimeSecret(mattermostUserId, secret)
 	if err != nil {
 		return "", err
 	}

--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -83,17 +83,13 @@ func httpACUserInteractive(jci *jiraCloudInstance, w http.ResponseWriter, r *htt
 
 	switch r.URL.Path {
 	case routeACUserConnected:
-		value := ""
-		value, err = jci.Plugin.LoadOneTimeSecret(secret)
+		storedSecret := ""
+		storedSecret, err = jci.Plugin.LoadOneTimeSecret(mattermostUserId)
 		if err != nil {
 			return http.StatusUnauthorized, err
 		}
-		err = jci.Plugin.DeleteOneTimeSecret(secret)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-		if len(value) == 0 {
-			return http.StatusUnauthorized, errors.New("link expired")
+		if len(storedSecret) == 0 || storedSecret != secret {
+			return http.StatusUnauthorized, ErrLinkUnauthorized
 		}
 
 		err = jci.Plugin.StoreUserInfoNotify(jci, mattermostUserId, uinfo)


### PR DESCRIPTION
The issue was that specific (Jira-side) "connect" links could not be reused, but a user could generate a number of simultaneously valid links. 

For the cloud auth now handle this by storing the mmuserid->secret mapping, and then verifying the secret in the link.

For Server, Jira appears to ignore the secret value, but still protect the link from multiple use by deleting the stored key after its first use.