### PR TITLE
Webhooks - Jira cloud old view assignee

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -288,6 +288,10 @@ func (p *parsedJIRAWebhook) fromChangeLog(issue string) (string, string) {
 		to := item.ToString
 		from := item.FromString
 		switch {
+		case item.Field == "assignee":
+			p.event(eventUpdatedAssignee)
+			return fmt.Sprintf("assigned %v to %v", issue, p.mdIssueAssignee()), ""
+
 		case item.Field == "resolution" && to == "" && from != "":
 			p.event(eventUpdatedReopened)
 			return fmt.Sprintf("reopened %v", issue), ""


### PR DESCRIPTION
This PR addresses issue (B) that was found in https://mattermost.atlassian.net/browse/MM-15439

The "old view" in Jira cloud was sending an issue_updated, rather than an issue_assigned webhook.