### PR TITLE
[MM-15536/MM-15832] Only show one "Connect to Jira" menu option. (#66)

### DIFF
--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -42,34 +42,20 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
     }
 
     render() {
-        if (this.props.isSystemMessage) {
+        if (this.props.isSystemMessage || !this.props.connected) {
             return null;
         }
 
-        const conn = this.props.connected || {};
-        let content;
-        if (conn.connected) {
-            content = (
-                <button
-                    className='style--none'
-                    role='presentation'
-                    onClick={this.handleClick}
-                >
-                    <JiraIcon type='menu'/>
-                    {this.getLocalizedTitle()}
-                </button>
-            );
-        } else {
-            content = (
-                <button
-                    className='style--none'
-                    role='menuitem'
-                    onClick={this.connectClick}
-                >
-                    {'Connect to Jira'}
-                </button>
-            );
-        }
+        const content = (
+            <button
+                className='style--none'
+                role='presentation'
+                onClick={this.handleClick}
+            >
+                <JiraIcon type='menu'/>
+                {this.getLocalizedTitle()}
+            </button>
+        );
 
         return (
             <li

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -9,9 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openAttachCommentToIssueModal} from 'actions';
 
-import {getCurrentUserLocale} from 'selectors';
-
-import PluginId from 'plugin_id';
+import {getCurrentUserLocale, isConnected} from 'selectors';
 
 import AttachCommentToIssuePostMenuAction from './attach_comment_to_issue';
 
@@ -20,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: state[`plugins-${PluginId}`],
+        connected: isConnected(state),
     };
 };
 

--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -45,9 +45,8 @@ export default class CreateIssuePostMenuAction extends PureComponent {
             return null;
         }
 
-        const conn = this.props.connected || {};
         let content;
-        if (conn.connected) {
+        if (this.props.connected) {
             content = (
                 <button
                     className='style--none'

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -9,9 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openCreateModal} from 'actions';
 
-import {getCurrentUserLocale} from 'selectors';
-
-import PluginId from 'plugin_id';
+import {getCurrentUserLocale, isConnected} from 'selectors';
 
 import CreateIssuePostMenuAction from './create_issue';
 
@@ -20,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: state[`plugins-${PluginId}`],
+        connected: isConnected(state),
     };
 };
 

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -50,3 +50,4 @@ export const getJiraIssueMetadata = (state) => getPluginState(state).jiraIssueMe
 export const getChannelIdWithSettingsOpen = (state) => getPluginState(state).channelIdWithSettingsOpen;
 
 export const getChannelSubscriptions = (state) => getPluginState(state).channelSubscripitons;
+export const isConnected = (state) => getPluginState(state).connected;


### PR DESCRIPTION
@jfrerich there was just one minor conflict when merging, please check

* When Jira instance exists, but user is not connected, only show one
"connected to jira" post menu item.  This checkin is the cheapest
solution which basically uses create issue as the master for dispaying
the "connect to jira" menu option.

* Consolidate lines and remove extra if statement.

* Add isConnected selector and return as bool from mapStateToProps in
post_menu_actions/attach_comment_to_issue/index.js and
post_menu_actions/create_issue/index.js

Add Jira icon to "Connect to Jira" post menu item