### PR TITLE
[MM-15537] Fix 'connect to jira' menu item when not connected (#75)

### DIFF
--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -76,7 +76,7 @@ func httpACInstalled(p *Plugin, w http.ResponseWriter, r *http.Request) (int, er
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	err = p.StoreCurrentJIRAInstance(jiraInstance)
+	err = p.StoreCurrentJIRAInstanceAndNotify(jiraInstance)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -95,6 +95,7 @@ func httpACUninstalled(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 			errors.New("method " + r.Method + " is not allowed, must be POST")
 	}
 
+	// Just send an ok to the Jira server, even though we're not doing anything.
 	_ = json.NewEncoder(w).Encode([]string{"OK"})
 	return http.StatusOK, nil
 }

--- a/server/command.go
+++ b/server/command.go
@@ -17,9 +17,14 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
 	"  * [value] can be `on` or `off`\n" +
-	"\nFor System Administrators:\n" +
+
+	"\n###### For System Administrators:\n" +
+	"Install:\n" +
 	"* `/jira install cloud <URL>` - Connect Mattermost to a Jira Cloud instance located at <URL>\n" +
 	"* `/jira install server <URL>` - Connect Mattermost to a Jira Server or Data Center instance located at <URL>\n" +
+	"Uninstall:\n" +
+	"* `/jira uninstall cloud <URL>` - Disconnect Mattermost from a Jira Cloud instance located at <URL>\n" +
+	"* `/jira uninstall server <URL>` - Disconnect Mattermost from a Jira Server or Data Center instance located at <URL>\n" +
 	""
 
 // Available settings
@@ -36,12 +41,14 @@ type CommandHandler struct {
 
 var jiraCommandHandler = CommandHandler{
 	handlers: map[string]CommandHandlerFunc{
-		"install/cloud":  executeInstallCloud,
-		"install/server": executeInstallServer,
-		"transition":     executeTransition,
-		"connect":        executeConnect,
-		"disconnect":     executeDisconnect,
-		"settings":       executeSettings,
+		"connect":          executeConnect,
+		"disconnect":       executeDisconnect,
+		"install/cloud":    executeInstallCloud,
+		"install/server":   executeInstallServer,
+		"settings":         executeSettings,
+		"transition":       executeTransition,
+		"uninstall/cloud":  executeUninstallCloud,
+		"uninstall/server": executeUninstallServer,
 		//"webhook":        executeWebhookURL,
 		//"webhook/url":    executeWebhookURL,
 		//"list":        executeList,
@@ -261,7 +268,7 @@ If you see an option to create a Jira issue, you're all set! If not, refer to ou
 	if err != nil {
 		return responsef(err.Error())
 	}
-	err = p.StoreCurrentJIRAInstance(ji)
+	err = p.StoreCurrentJIRAInstanceAndNotify(ji)
 	if err != nil {
 		return responsef(err.Error())
 	}
@@ -271,6 +278,100 @@ If you see an option to create a Jira issue, you're all set! If not, refer to ou
 		return responsef("Failed to load public key: %v", err)
 	}
 	return responsef(addResponseFormat, p.GetSiteURL(), ji.GetMattermostKey(), pkey)
+}
+
+// executeUninstallCloud will uninstall the jira cloud instance if the url matches, and then update all connected
+// clients so that their Jira-related menu options are removed.
+func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	authorized, err := authorizedSysAdmin(p, header.UserId)
+	if err != nil {
+		return responsef("%v", err)
+	}
+	if !authorized {
+		return responsef("`/jira uninstall` can only be run by a System Administrator.")
+	}
+	if len(args) != 1 {
+		return help()
+	}
+	jiraURL := args[0]
+
+	ji, err := p.LoadCurrentJIRAInstance()
+	if err != nil {
+		return responsef("No current Jira instance to uninstall")
+	}
+
+	jci, ok := ji.(*jiraCloudInstance)
+	if !ok {
+		return responsef("The current Jira instance is not a cloud instance")
+	}
+
+	if jiraURL != jci.GetURL() {
+		return responsef("You have entered an incorrect URL. The current Jira instance URL is: `" + jci.GetURL() + "`. Please enter the URL correctly to confirm the uninstall command.")
+	}
+
+	err = p.DeleteJiraInstance(jci.GetURL())
+	if err != nil {
+		return responsef("Failed to delete Jira instance " + ji.GetURL())
+	}
+
+	// Notify users we have uninstalled an instance
+	p.API.PublishWebSocketEvent(
+		wSEventInstanceStatus,
+		map[string]interface{}{
+			"instance_installed": false,
+		},
+		&model.WebsocketBroadcast{},
+	)
+
+	const uninstallInstructions = `Jira instance successfully disconnected. Go to **Settings > Apps > Manage Apps** to remove the application in your Jira Cloud instance.`
+
+	return responsef(uninstallInstructions)
+}
+
+func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	authorized, err := authorizedSysAdmin(p, header.UserId)
+	if err != nil {
+		return responsef("%v", err)
+	}
+	if !authorized {
+		return responsef("`/jira uninstall` can only be run by a System Administrator.")
+	}
+	if len(args) != 1 {
+		return help()
+	}
+	jiraURL := args[0]
+
+	ji, err := p.LoadCurrentJIRAInstance()
+	if err != nil {
+		return responsef("No current Jira instance to uninstall")
+	}
+
+	jsi, ok := ji.(*jiraServerInstance)
+	if !ok {
+		return responsef("The current Jira instance is not a server instance")
+	}
+
+	if jiraURL != jsi.GetURL() {
+		return responsef("You have entered an incorrect URL. The current Jira instance URL is: `" + jsi.GetURL() + "`. Please enter the URL correctly to confirm the uninstall command.")
+	}
+
+	err = p.DeleteJiraInstance(jsi.GetURL())
+	if err != nil {
+		return responsef("Failed to delete Jira instance " + ji.GetURL())
+	}
+
+	// Notify users we have uninstalled an instance
+	p.API.PublishWebSocketEvent(
+		wSEventInstanceStatus,
+		map[string]interface{}{
+			"instance_installed": false,
+		},
+		&model.WebsocketBroadcast{},
+	)
+
+	const uninstallInstructions = `Jira instance successfully disconnected. Go to **Settings > Applications > Application Links** to remove the application in your Jira Server or Data Center instance.`
+
+	return responsef(uninstallInstructions)
 }
 
 func executeTransition(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
@@ -313,7 +414,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Jira",
 		Description:      "Integration with Jira.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: connect, disconnect, create, transition, settings, install cloud, install server, help",
+		AutoCompleteDesc: "Available commands: connect, disconnect, create, transition, settings, install cloud/server, uninstall cloud/server, help",
 		AutoCompleteHint: "[command]",
 	}
 }
@@ -357,7 +458,7 @@ func responsef(format string, args ...interface{}) *model.CommandResponse {
 //	if err != nil {
 //		return responsef("Failed to load Jira instance %s: %v", instanceKey, err)
 //	}
-//	err = p.StoreCurrentJIRAInstance(ji)
+//	err = p.StoreCurrentJIRAInstanceAndNotify(ji)
 //	if err != nil {
 //		return responsef(err.Error())
 //	}

--- a/server/http.go
+++ b/server/http.go
@@ -66,7 +66,7 @@ func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 
 	// User APIs
 	case routeAPIUserInfo:
-		return withInstance(p, w, r, httpAPIGetUserInfo)
+		return httpAPIGetUserInfo(p, w, r)
 
 	// Atlassian Connect application
 	case routeACInstalled:

--- a/server/instance.go
+++ b/server/instance.go
@@ -18,6 +18,8 @@ const (
 
 const prefixForInstance = true
 
+const wSEventInstanceStatus = "instance_status"
+
 type Instance interface {
 	GetJIRAClient(jiraUser JIRAUser) (*jira.Client, error)
 	GetDisplayDetails() map[string]string
@@ -35,6 +37,10 @@ type JIRAInstance struct {
 
 	Key  string
 	Type string
+}
+
+type InstanceStatus struct {
+	InstanceInstalled bool `json:"instance_installed"`
 }
 
 var regexpNonAlnum = regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -180,7 +180,7 @@ func (jci jiraCloudInstance) parseHTTPRequestJWT(r *http.Request) (*jwt.Token, s
 		return []byte(jci.AtlassianSecurityContext.SharedSecret), nil
 	})
 	if err != nil || !token.Valid {
-		return nil, "", errors.WithMessage(err, "failed to validatte JWT")
+		return nil, "", errors.WithMessage(err, "failed to validate JWT")
 	}
 
 	return token, tokenString, nil

--- a/server/kv.go
+++ b/server/kv.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"github.com/mattermost/mattermost-server/model"
 
 	"github.com/pkg/errors"
 )
@@ -138,7 +139,7 @@ func (p *Plugin) CreateInactiveCloudInstance(jiraURL string) (returnErr error) {
 	return nil
 }
 
-func (p *Plugin) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
+func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) (returnErr error) {
 	defer func() {
 		if returnErr == nil {
 			return
@@ -151,6 +152,16 @@ func (p *Plugin) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
 		return err
 	}
 	p.debugf("Stored: current Jira instance: %s", ji.GetURL())
+
+	// Notify users we have installed an instance
+	p.API.PublishWebSocketEvent(
+		wSEventInstanceStatus,
+		map[string]interface{}{
+			"instance_installed": true,
+		},
+		&model.WebsocketBroadcast{},
+	)
+
 	return nil
 }
 

--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -12,6 +12,7 @@ export default {
     OPEN_ATTACH_COMMENT_TO_ISSUE_MODAL: `${PluginId}_open_attach_modal`,
 
     RECEIVED_CONNECTED: `${PluginId}_connected`,
+    RECEIVED_INSTANCE_STATUS: `${PluginId}_instance_status`,
 
     RECEIVED_JIRA_ISSUE_METADATA: `${PluginId}_received_metadata`,
 

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -181,6 +181,11 @@ export function getConnected() {
             data,
         });
 
+        dispatch({
+            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
+            data,
+        });
+
         return {data};
     };
 }
@@ -212,3 +217,16 @@ export const closeChannelSettings = () => {
         type: ActionTypes.CLOSE_CHANNEL_SETTINGS,
     };
 };
+
+export function handleInstanceStatusChange(store) {
+    return (msg) => {
+        if (!msg.data) {
+            return;
+        }
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_INSTANCE_STATUS,
+            data: msg.data,
+        });
+    };
+}

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -14,7 +14,8 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
         locale: PropTypes.string,
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
-        connected: PropTypes.object.isRequired,
+        userConnected: PropTypes.bool.isRequired,
+        instanceInstalled: PropTypes.bool.isRequired,
     };
 
     static defaultTypes = {
@@ -39,10 +40,10 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
 
     connectClick = () => {
         window.open('/plugins/' + PluginId + '/user/connect');
-    }
+    };
 
     render() {
-        if (this.props.isSystemMessage || !this.props.connected) {
+        if (this.props.isSystemMessage || !this.props.instanceInstalled || !this.props.userConnected) {
             return null;
         }
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openAttachCommentToIssueModal} from 'actions';
 
-import {getCurrentUserLocale, isConnected} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
 
 import AttachCommentToIssuePostMenuAction from './attach_comment_to_issue';
 
@@ -18,7 +18,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: isConnected(state),
+        userConnected: isUserConnected(state),
+        instanceInstalled: isInstanceInstalled(state),
     };
 };
 

--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -13,7 +13,8 @@ export default class CreateIssuePostMenuAction extends PureComponent {
         locale: PropTypes.string,
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
-        connected: PropTypes.object.isRequired,
+        userConnected: PropTypes.bool.isRequired,
+        instanceInstalled: PropTypes.bool.isRequired,
     };
 
     static defaultTypes = {
@@ -38,15 +39,15 @@ export default class CreateIssuePostMenuAction extends PureComponent {
 
     connectClick = () => {
         window.open('/plugins/' + PluginId + '/user/connect');
-    }
+    };
 
     render() {
-        if (this.props.isSystemMessage) {
+        if (this.props.isSystemMessage || !this.props.instanceInstalled) {
             return null;
         }
 
         let content;
-        if (this.props.connected) {
+        if (this.props.userConnected) {
             content = (
                 <button
                     className='style--none'

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openCreateModal} from 'actions';
 
-import {getCurrentUserLocale, isConnected} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
 
 import CreateIssuePostMenuAction from './create_issue';
 
@@ -18,7 +18,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         locale: getCurrentUserLocale(state),
         isSystemMessage: isSystemMessage(post),
-        connected: isConnected(state),
+        userConnected: isUserConnected(state),
+        instanceInstalled: isInstanceInstalled(state),
     };
 };
 

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -13,7 +13,7 @@ import AttachCommentToIssueModal from 'components/modals/attach_comment_to_issue
 import PluginId from 'plugin_id';
 
 import reducers from './reducers';
-import {handleConnectChange, getConnected, openChannelSettings} from './actions';
+import {handleConnectChange, getConnected, openChannelSettings, handleInstanceStatusChange} from './actions';
 import Hooks from './hooks/hooks';
 
 export default class Plugin {
@@ -41,6 +41,7 @@ export default class Plugin {
         } finally {
             registry.registerWebSocketEventHandler(`custom_${PluginId}_connect`, handleConnectChange(store));
             registry.registerWebSocketEventHandler(`custom_${PluginId}_disconnect`, handleConnectChange(store));
+            registry.registerWebSocketEventHandler(`custom_${PluginId}_instance_status`, handleInstanceStatusChange(store));
         }
     }
 }

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -5,10 +5,23 @@ import {combineReducers} from 'redux';
 
 import ActionTypes from 'action_types';
 
-function connected(state = false, action) {
+function userConnected(state = false, action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_CONNECTED:
         return action.data.is_connected;
+    default:
+        return state;
+    }
+}
+
+function instanceInstalled(state = false, action) {
+    // We're notified of the instance status at startup (through getConnected)
+    // and when we get a websocket instance_status event
+    switch (action.type) {
+    case ActionTypes.RECEIVED_CONNECTED:
+        return action.data.instance_installed ? action.data.instance_installed : state;
+    case ActionTypes.RECEIVED_INSTANCE_STATUS:
+        return action.data.instance_installed;
     default:
         return state;
     }
@@ -98,7 +111,8 @@ const channelSubscripitons = (state = {}, action) => {
 };
 
 export default combineReducers({
-    connected,
+    userConnected,
+    instanceInstalled,
     createModalVisible,
     createModal,
     attachCommentToIssueModalVisible,

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -50,4 +50,7 @@ export const getJiraIssueMetadata = (state) => getPluginState(state).jiraIssueMe
 export const getChannelIdWithSettingsOpen = (state) => getPluginState(state).channelIdWithSettingsOpen;
 
 export const getChannelSubscriptions = (state) => getPluginState(state).channelSubscripitons;
-export const isConnected = (state) => getPluginState(state).connected;
+
+export const isUserConnected = (state) => getPluginState(state).userConnected;
+
+export const isInstanceInstalled = (state) => getPluginState(state).instanceInstalled;


### PR DESCRIPTION
@cpoile - again, a slightly non-trivial merge, please verify

[MM-15537] Fix 'Connect to Jira' menu item when not connected

* * keep one API endpoint: userinfo can give both isntance and connected

* * remove httpAPIGetInstanceStatus

* PR comments, and implemented MM-15828

* finishing up MM-15828

* minor cleanup

* Update server/command.go

Co-Authored-By: Jason Blais <13119842+jasonblais@users.noreply.github.com>

* Update server/command.go

Co-Authored-By: Jason Blais <13119842+jasonblais@users.noreply.github.com>

* Update server/command.go

Co-Authored-By: Jason Blais <13119842+jasonblais@users.noreply.github.com>

* Update server/command.go

Co-Authored-By: Jason Blais <13119842+jasonblais@users.noreply.github.com>

* Update server/command.go

Co-Authored-By: Jason Blais <13119842+jasonblais@users.noreply.github.com>