### PR TITLE
[MM-15589] Create Issue: (Jira server) Priority field fails to select…

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -11,20 +11,15 @@ export default class JiraField extends React.Component {
     static propTypes = {
         id: PropTypes.object.isRequired,
         field: PropTypes.object.isRequired,
+        fieldKey: PropTypes.string.isRequired,
         obeyRequired: PropTypes.bool,
-        onChange: PropTypes.func,
+        onChange: PropTypes.func.isRequired,
         value: PropTypes.any,
         isFilter: PropTypes.bool,
     };
 
     static defaultProps = {
         obeyRequired: true,
-    };
-
-    handleChange = (id, value) => {
-        if (this.props.onChange) {
-            this.props.onChange(id, value);
-        }
     };
 
     // Creates an option for react-select from an allowedValue from the jira field metadata
@@ -41,20 +36,20 @@ export default class JiraField extends React.Component {
         return (
             {value: allowedValue.id, label: iconLabel}
         );
-    }
+    };
 
     renderCreateFields() {
-        const field = this.props.field;
+        const {field, fieldKey, obeyRequired} = this.props;
 
         if (field.schema.system === 'description') {
             return (
                 <Input
-                    key={field.key}
-                    id={field.key}
+                    key={fieldKey}
+                    id={fieldKey}
                     label={field.name}
                     type='textarea'
-                    onChange={this.handleChange}
-                    required={this.props.obeyRequired && field.required}
+                    onChange={this.props.onChange}
+                    required={obeyRequired && field.required}
                     value={this.props.value}
                 />
             );
@@ -63,29 +58,31 @@ export default class JiraField extends React.Component {
         if (field.schema.type === 'string') {
             return (
                 <Input
-                    key={field.key}
-                    id={field.key}
+                    key={fieldKey}
+                    id={fieldKey}
                     label={field.name}
                     type='input'
-                    onChange={this.handleChange}
-                    required={this.props.obeyRequired && field.required}
+                    onChange={this.props.onChange}
+                    required={obeyRequired && field.required}
                     value={this.props.value}
                 />
             );
         }
 
+        // if this.props.field has allowedValues, then props.value will be an object
         if (field.allowedValues && field.allowedValues.length) {
             const options = field.allowedValues.map(this.makeReactSelectValue);
+
             return (
                 <ReactSelectSetting
-                    key={field.key}
-                    name={field.key}
+                    key={fieldKey}
+                    name={fieldKey}
                     label={field.name}
                     options={options}
-                    required={this.props.obeyRequired && field.required}
-                    onChange={this.handleChange}
+                    required={obeyRequired && field.required}
+                    onChange={(id, val) => this.props.onChange(id, {id: val})}
                     isMulti={false}
-                    value={options.filter((option) => option.value === this.props.value)}
+                    value={options.find((option) => option.value === this.props.value)}
                 />
             );
         }

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -9,7 +9,7 @@ import JiraField from 'components/jira_field';
 export default class JiraFields extends React.Component {
     static propTypes = {
         fields: PropTypes.object.isRequired,
-        onChange: PropTypes.func,
+        onChange: PropTypes.func.isRequired,
         values: PropTypes.object,
         isFilter: PropTypes.bool,
     };
@@ -34,6 +34,7 @@ export default class JiraFields extends React.Component {
                 <JiraField
                     key={fieldName}
                     id={fieldName}
+                    fieldKey={fieldName}
                     field={this.props.fields[fieldName]}
                     obeyRequired={true}
                     onChange={this.props.onChange}

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -122,7 +122,7 @@ export default class CreateIssueModal extends PureComponent {
             issueType,
             fields,
         });
-    }
+    };
 
     handleIssueTypeChange = (id, value) => {
         const fields = {...this.state.fields};
@@ -134,7 +134,7 @@ export default class CreateIssueModal extends PureComponent {
             issueType,
             fields,
         });
-    }
+    };
 
     handleFieldChange = (id, value) => {
         const fields = {...this.state.fields};
@@ -142,7 +142,7 @@ export default class CreateIssueModal extends PureComponent {
         this.setState({
             fields,
         });
-    }
+    };
 
     render() {
         const {visible, theme, jiraIssueMetadata} = this.props;


### PR DESCRIPTION
… (#81)

* The priority field type, inside the fields object, is an object, not a string value.
For the priority ReactSelectSetting component, filter against
this.props.value.id to get the value, not this.props.value which is an
object

* Remove default values in initialState object.
Remove special casing for priority field in JiraField component. Note
that fields that have field.allowedValues will return an object.
Otherwise returns a string with is handled when field.schema.type ===
'string'

* minor changes

* fixup