### PR TITLE
[MM-15962] Allow only handled fields to show in Create Issue Dialog

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -44,6 +44,17 @@ export default class JiraField extends React.PureComponent {
     render() {
         const field = this.props.field;
 
+        // only allow these custom types until handle further types
+        if (field.schema.custom &&
+              (field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textarea' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textfield' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:select' &&
+               field.schema.custom !== 'com.pyxis.greenhopper.jira:gh-epic-label' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:project')
+        ) {
+            return null;
+        }
+
         if (field.schema.system === 'description') {
             return (
                 <Input
@@ -88,7 +99,7 @@ export default class JiraField extends React.PureComponent {
         }
 
         // if this.props.field has allowedValues, then props.value will be an object
-        if (field.allowedValues && field.allowedValues.length) {
+        if (field.allowedValues && field.allowedValues.length && field.schema.type !== 'array') {
             const options = field.allowedValues.map(this.makeReactSelectValue);
 
             return (

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -27,7 +27,8 @@ export default class JiraFields extends React.PureComponent {
         }
 
         return fieldNames.map((fieldName) => {
-            if (fieldName === 'project' || fieldName === 'issuetype' || fieldName === 'reporter' || (fieldName !== 'description' && !this.props.fields[fieldName].required)) {
+            // Always Required Jira fields
+            if (fieldName === 'project' || fieldName === 'issuetype') {
                 return null;
             }
             return (


### PR DESCRIPTION
**Summary** 
This ticket is to reduce the fields that show up in the create issue dialog window to only those currently supported.

- Allow fields that are not required to show up in create issue dialog
- restrict custom field types to textarea, textfield, select (single-select), epic-label (for epic issue types), and project picker
- for non-custom types, with allowedValues, don't show fields with field.schema.type == array.  Fix at later date

**Ticket Link**
https://mattermost.atlassian.net/browse/MM-15962