### PR TITLE
[MM-15913] Update UX when creating issues for projects that require additional fields

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -111,7 +111,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			ChannelId: post.ChannelId,
 			RootId:    rootId,
 			ParentId:  parentId,
-			UserId:    mattermostUserId,
+			UserId:    ji.GetPlugin().conf.botUserID,
 		}
 		_ = api.SendEphemeralPost(mattermostUserId, reply)
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -111,7 +111,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			ChannelId: post.ChannelId,
 			RootId:    rootId,
 			ParentId:  parentId,
-			UserId:    ji.GetPlugin().conf.botUserID,
+			UserId:    ji.GetPlugin().getConfig().botUserID,
 		}
 		_ = api.SendEphemeralPost(mattermostUserId, reply)
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -107,7 +107,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 		}
 
 		reply := &model.Post{
-			Message:   fmt.Sprintf("[Please create your Jira issue manually](%v). %v.\n%v", req.URL.String(), message, fieldsString),
+			Message:   fmt.Sprintf("[Please create your Jira issue manually](%v). %v\n%v", req.URL.String(), message, fieldsString),
 			ChannelId: post.ChannelId,
 			RootId:    rootId,
 			ParentId:  parentId,

--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -44,17 +44,6 @@ export default class JiraField extends React.PureComponent {
     render() {
         const field = this.props.field;
 
-        // only allow these custom types until handle further types
-        if (field.schema.custom &&
-              (field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textarea' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textfield' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:select' &&
-               field.schema.custom !== 'com.pyxis.greenhopper.jira:gh-epic-label' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:project')
-        ) {
-            return null;
-        }
-
         if (field.schema.system === 'description') {
             return (
                 <Input

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -11,15 +11,20 @@ export default class JiraFields extends React.PureComponent {
         fields: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
         values: PropTypes.object,
+        allowedFields: PropTypes.object.isRequired,
+        allowedSchemaCustom: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
     };
 
     render() {
-        if (!this.props.fields) {
+        const fields = this.props.fields;
+        const {allowedFields, allowedSchemaCustom} = this.props;
+
+        if (!fields) {
             return null;
         }
 
-        let fieldNames = Object.keys(this.props.fields);
+        let fieldNames = Object.keys(fields);
         const fullLength = fieldNames.length;
         fieldNames = fieldNames.filter((name) => name !== 'summary');
         if (fullLength > fieldNames.length) {
@@ -31,11 +36,19 @@ export default class JiraFields extends React.PureComponent {
             if (fieldName === 'project' || fieldName === 'issuetype') {
                 return null;
             }
+
+            // only allow these default Jira fields and custom types until handle further types
+            if ((fields[fieldName].schema.custom && !allowedSchemaCustom.includes(fields[fieldName].schema.custom)) ||
+                (!fields[fieldName].schema.custom && !allowedFields.includes(fieldName))
+            ) {
+                return null;
+            }
+
             return (
                 <JiraField
                     key={fieldName}
                     id={fieldName}
-                    field={this.props.fields[fieldName]}
+                    field={fields[fieldName]}
                     obeyRequired={true}
                     onChange={this.props.onChange}
                     value={this.props.values && this.props.values[fieldName]}

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -17,8 +17,7 @@ export default class JiraFields extends React.PureComponent {
     };
 
     render() {
-        const fields = this.props.fields;
-        const {allowedFields, allowedSchemaCustom} = this.props;
+        const {allowedFields, allowedSchemaCustom, fields} = this.props;
 
         if (!fields) {
             return null;
@@ -37,10 +36,13 @@ export default class JiraFields extends React.PureComponent {
                 return null;
             }
 
-            // only allow these default Jira fields and custom types until handle further types
-            if ((fields[fieldName].schema.custom && !allowedSchemaCustom.includes(fields[fieldName].schema.custom)) ||
-                (!fields[fieldName].schema.custom && !allowedFields.includes(fieldName))
-            ) {
+            // only allow these some custom types until handle further types
+            if (fields[fieldName].schema.custom && !allowedSchemaCustom.includes(fields[fieldName].schema.custom)) {
+                return null;
+            }
+
+            // only allow some default Jira fields until handle further types
+            if (!fields[fieldName].schema.custom && !allowedFields.includes(fieldName)) {
                 return null;
             }
 

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -66,8 +66,12 @@ export default class CreateIssueModal extends PureComponent {
         'com.atlassian.jira.plugin.system.customfieldtypes:textarea',
         'com.atlassian.jira.plugin.system.customfieldtypes:textfield',
         'com.atlassian.jira.plugin.system.customfieldtypes:select',
-        'com.pyxis.greenhopper.jira:gh-epic-label',
         'com.atlassian.jira.plugin.system.customfieldtypes:project',
+
+        // 'com.pyxis.greenhopper.jira:gh-epic-link',
+
+        // epic label is 'Epic Name' for cloud instance
+        'com.pyxis.greenhopper.jira:gh-epic-label',
     ];
 
     getFieldsNotCovered() {
@@ -82,7 +86,6 @@ export default class CreateIssueModal extends PureComponent {
                      (myfields[key].schema.custom && !this.allowedSchemaCustom.includes(myfields[key].schema.custom))
                 ) {
                     if (!fieldsNotCovered.includes(key)) {
-                        console.log('found UNALLOWED value -> ', key);
                         fieldsNotCovered.push(key);
                     }
                 }
@@ -93,7 +96,6 @@ export default class CreateIssueModal extends PureComponent {
 
     handleCreate = (e) => {
         const requiredFieldsNotCovered = this.getFieldsNotCovered();
-        console.log('create_issue.jsx -> requiredFieldsNotCovered', requiredFieldsNotCovered);
 
         if (e && e.preventDefault) {
             e.preventDefault();

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -86,8 +86,10 @@ export default class CreateIssueModal extends PureComponent {
                 if ((!myfields[key].schema.custom && !this.allowedFields.includes(key)) ||
                      (myfields[key].schema.custom && !this.allowedSchemaCustom.includes(myfields[key].schema.custom))
                 ) {
+                    console.log(myfields[key].name);
                     if (!fieldsNotCovered.includes(key)) {
-                        fieldsNotCovered.push(key);
+                        // fieldsNotCovered.push([key, myfields[key].name]);
+                        fieldsNotCovered.push(myfields[key].name);
                     }
                 }
             }

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -86,7 +86,6 @@ export default class CreateIssueModal extends PureComponent {
                 if ((!myfields[key].schema.custom && !this.allowedFields.includes(key)) ||
                      (myfields[key].schema.custom && !this.allowedSchemaCustom.includes(myfields[key].schema.custom))
                 ) {
-                    console.log(myfields[key].name);
                     if (!fieldsNotCovered.includes(key)) {
                         // fieldsNotCovered.push([key, myfields[key].name]);
                         fieldsNotCovered.push(myfields[key].name);

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -54,7 +54,47 @@ export default class CreateIssueModal extends PureComponent {
         }
     }
 
+    allowedFields = [
+        'project',
+        'issuetype',
+        'priority',
+        'description',
+        'summary',
+    ]
+
+    allowedSchemaCustom = [
+        'com.atlassian.jira.plugin.system.customfieldtypes:textarea',
+        'com.atlassian.jira.plugin.system.customfieldtypes:textfield',
+        'com.atlassian.jira.plugin.system.customfieldtypes:select',
+        'com.pyxis.greenhopper.jira:gh-epic-label',
+        'com.atlassian.jira.plugin.system.customfieldtypes:project',
+    ];
+
+    getFieldsNotCovered() {
+        const {jiraIssueMetadata} = this.props;
+        const myfields = getFields(jiraIssueMetadata, this.state.projectKey, this.state.issueType);
+
+        const fieldsNotCovered = [];
+
+        Object.keys(myfields).forEach((key) => {
+            if (myfields[key].required) {
+                if ((!myfields[key].schema.custom && !this.allowedFields.includes(key)) ||
+                     (myfields[key].schema.custom && !this.allowedSchemaCustom.includes(myfields[key].schema.custom))
+                ) {
+                    if (!fieldsNotCovered.includes(key)) {
+                        console.log('found UNALLOWED value -> ', key);
+                        fieldsNotCovered.push(key);
+                    }
+                }
+            }
+        });
+        return fieldsNotCovered;
+    }
+
     handleCreate = (e) => {
+        const requiredFieldsNotCovered = this.getFieldsNotCovered();
+        console.log('create_issue.jsx -> requiredFieldsNotCovered', requiredFieldsNotCovered);
+
         if (e && e.preventDefault) {
             e.preventDefault();
         }
@@ -62,6 +102,7 @@ export default class CreateIssueModal extends PureComponent {
         const issue = {
             post_id: this.props.post.id,
             fields: this.state.fields,
+            required_fields_not_covered: requiredFieldsNotCovered,
         };
 
         this.setState({submitting: true});
@@ -178,6 +219,8 @@ export default class CreateIssueModal extends PureComponent {
                         fields={getFields(jiraIssueMetadata, this.state.projectKey, this.state.issueType)}
                         onChange={this.handleFieldChange}
                         values={this.state.fields}
+                        allowedFields={this.allowedFields}
+                        allowedSchemaCustom={this.allowedSchemaCustom}
                         theme={theme}
                     />
                     <br/>


### PR DESCRIPTION
**Summary** 
This ticket addresses the issue when a user tries to create a ticket and the connected Jira instance requires fields we currently don't support.

I'm using the Draft Pull Request feature because there are some steps still remaining, but I would like to receive early feedback due to the time crunch for Jira2.0 

**Description of enhancements made for UX (from Ticket)**

Update UX when creating issues for projects that require additional fields

step 1: allow the user to fill in the parameters we support in the Create Jira Issue dialog
step 2: allow user to hit "Create"
step 3: respond back with an ephemeral message saying

>The project you tried to create an issue for has **required fields** this plugin does not yet support. Please [create your Jira issue manually](...link to Create Jira Issue modal).

step 4: clicking the link brings the user to an issue creation screen in Jira, with the fields they entered previously pre-filled

**NOTES for QA** 
Cases that should be covered following this ticket are listed below:

*Jira Default Fields*
- Project
- Issue Type
- Priority
- Description
- Summary

*Jira Custom Fields*
- Project Picker
- Select List (single choice)
- Text Field (multi-line)
- Text Field (single line)

- Given a field that is not supported, message in the description section above is posted in MM

@jasonblais I would really like to have this version spun up for people to thoroughly test.

**Ticket Link**
Please view the following ticket for a description
https://mattermost.atlassian.net/browse/MM-15913