### PR TITLE
[MM- 15838] Handle selected elements in Jira issue creation screen (#…

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -22,6 +22,9 @@ export default class JiraField extends React.Component {
     };
 
     // Creates an option for react-select from an allowedValue from the jira field metadata
+    // includes both .value and .name because allowedValue test cases have used .value or .name
+    // and are mutually exclusive.
+    // should wrap this with some if else logic
     makeReactSelectValue = (allowedValue) => {
         const iconLabel = (
             <React.Fragment>
@@ -29,6 +32,7 @@ export default class JiraField extends React.Component {
                     style={getStyle().jiraIcon}
                     src={allowedValue.iconUrl}
                 />
+                {allowedValue.value}
                 {allowedValue.name}
             </React.Fragment>
         );
@@ -41,6 +45,21 @@ export default class JiraField extends React.Component {
         const field = this.props.field;
 
         if (field.schema.system === 'description') {
+            return (
+                <Input
+                    key={this.props.id}
+                    id={this.props.id}
+                    label={field.name}
+                    type='textarea'
+                    onChange={this.props.onChange}
+                    required={this.props.obeyRequired && field.required}
+                    value={this.props.value}
+                />
+            );
+        }
+
+        // detect if JIRA multiline textarea, and set for JiraField component
+        if (field.schema.custom === 'com.atlassian.jira.plugin.system.customfieldtypes:textarea') {
             return (
                 <Input
                     key={this.props.id}


### PR DESCRIPTION
cc @jfrerich 

…108)

* For custom Jira Fields:
- if schema.custom is textarea, render input component with type='textarea'
- in makeReactSelectValue, when displaying values, some allowdValue obects use .name and others user .value.
  for test cases I used, these were mutually exclusive

* Move comment out of fragment for better comment style