### PR TITLE
[MM-15948] Create and attach issues to DM posts by sending in teamname

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -26,8 +26,9 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	api := ji.GetPlugin().API
 
 	create := &struct {
-		PostId string           `json:"post_id"`
-		Fields jira.IssueFields `json:"fields"`
+		PostId      string           `json:"post_id"`
+		CurrentTeam string           `json:"current_team"`
+		Fields      jira.IssueFields `json:"fields"`
 	}{}
 	err := json.NewDecoder(r.Body).Decode(&create)
 	if err != nil {
@@ -61,11 +62,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			errors.New("failed to load post " + create.PostId + ": not found")
 	}
 
-	permalink, err := getPermaLink(ji, create.PostId, post)
-	if err != nil {
-		return http.StatusInternalServerError,
-			errors.New("failed to get permalink for " + create.PostId + ": not found")
-	}
+	permalink := getPermaLink(ji, create.PostId, create.CurrentTeam)
 
 	if len(create.Fields.Description) > 0 {
 		create.Fields.Description += fmt.Sprintf("\n%v", permalink)
@@ -275,8 +272,9 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	api := ji.GetPlugin().API
 
 	attach := &struct {
-		PostId   string `json:"post_id"`
-		IssueKey string `json:"issueKey"`
+		PostId      string `json:"post_id"`
+		CurrentTeam string `json:"current_team"`
+		IssueKey    string `json:"issueKey"`
 	}{}
 	err := json.NewDecoder(r.Body).Decode(&attach)
 	if err != nil {
@@ -316,11 +314,7 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			errors.New("failed to load post.UserID " + post.UserId + ": not found")
 	}
 
-	permalink, err := getPermaLink(ji, attach.PostId, post)
-	if err != nil {
-		return http.StatusInternalServerError,
-			errors.New("failed to get permalink for " + attach.PostId + ": not found")
-	}
+	permalink := getPermaLink(ji, attach.PostId, attach.CurrentTeam)
 
 	permalinkMessage := fmt.Sprintf("*@%s attached a* [message|%s] *from @%s*\n", jiraUser.User.Name, permalink, commentUser.Username)
 
@@ -370,26 +364,8 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	return http.StatusOK, nil
 }
 
-func getPermaLink(ji Instance, postId string, post *model.Post) (string, error) {
-
-	api := ji.GetPlugin().API
-
-	channel, appErr := api.GetChannel(post.ChannelId)
-	if appErr != nil {
-		return "", errors.WithMessage(appErr, "failed to get ChannelId, ChannelId: "+post.ChannelId)
-	}
-
-	team, appErr := api.GetTeam(channel.TeamId)
-	if appErr != nil {
-		return "", errors.WithMessage(appErr, "failed to get team, TeamId: "+channel.TeamId)
-	}
-
-	permalink := fmt.Sprintf("%v/%v/pl/%v",
-		ji.GetPlugin().GetSiteURL(),
-		team.Name,
-		postId,
-	)
-	return permalink, nil
+func getPermaLink(ji Instance, postId string, currentTeam string) string {
+	return fmt.Sprintf("%v/%v/pl/%v", ji.GetPlugin().GetSiteURL(), currentTeam, postId)
 }
 
 func (p *Plugin) transitionJiraIssue(mmUserId, issueKey, toState string) (string, error) {

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -22,6 +22,7 @@ export default class AttachIssueModal extends PureComponent {
         close: PropTypes.func.isRequired,
         create: PropTypes.func.isRequired,
         post: PropTypes.object,
+        currentTeam: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
         visible: PropTypes.bool.isRequired,
     };
@@ -38,6 +39,7 @@ export default class AttachIssueModal extends PureComponent {
 
         const issue = {
             post_id: this.props.post.id,
+            current_team: this.props.currentTeam.name,
             issueKey: this.state.issueKey,
         };
 

--- a/webapp/src/components/modals/attach_comment_to_issue/index.js
+++ b/webapp/src/components/modals/attach_comment_to_issue/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {closeAttachCommentToIssueModal, attachCommentToIssue} from 'actions';
 import {isAttachCommentToIssueModalVisible, getAttachCommentToIssueModalForPostId} from 'selectors';
@@ -14,10 +15,12 @@ import AttachCommentToIssue from './attach_comment_to_issue';
 const mapStateToProps = (state) => {
     const postId = getAttachCommentToIssueModalForPostId(state);
     const post = getPost(state, postId);
+    const currentTeam = getCurrentTeam(state);
 
     return {
         visible: isAttachCommentToIssueModalVisible(state),
         post,
+        currentTeam,
     };
 };
 

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -33,6 +33,7 @@ export default class CreateIssueModal extends PureComponent {
         close: PropTypes.func.isRequired,
         create: PropTypes.func.isRequired,
         post: PropTypes.object,
+        currentTeam: PropTypes.string.isRequired,
         theme: PropTypes.object.isRequired,
         visible: PropTypes.bool.isRequired,
         jiraIssueMetadata: PropTypes.object,
@@ -61,6 +62,7 @@ export default class CreateIssueModal extends PureComponent {
 
         const issue = {
             post_id: this.props.post.id,
+            current_team: this.props.currentTeam.name,
             fields: this.state.fields,
         };
 

--- a/webapp/src/components/modals/create_issue/index.js
+++ b/webapp/src/components/modals/create_issue/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {closeCreateModal, createIssue, fetchJiraIssueMetadata} from 'actions';
 import {isCreateModalVisible, getCreateModalForPostId, getJiraIssueMetadata} from 'selectors';
@@ -14,6 +15,7 @@ import CreateIssue from './create_issue';
 const mapStateToProps = (state) => {
     const postId = getCreateModalForPostId(state);
     const post = getPost(state, postId);
+    const currentTeam = getCurrentTeam(state);
 
     const jiraIssueMetadata = getJiraIssueMetadata(state);
 
@@ -21,6 +23,7 @@ const mapStateToProps = (state) => {
         visible: isCreateModalVisible(state),
         jiraIssueMetadata,
         post,
+        currentTeam,
     };
 };
 


### PR DESCRIPTION
##### Summary

Can now create issues from DM posts, and attach to Jira issues from DM posts. Works by sending in the team name from the webapp component. As a bonus: making a permalink is less code now.

#### Links
Fixes: [MM-15948](https://mattermost.atlassian.net/browse/MM-15948)