### PR TITLE
- Allow fields that are not required to show up …(#112)

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -45,6 +45,17 @@ export default class JiraField extends React.Component {
     renderCreateFields() {
         const field = this.props.field;
 
+        // only allow these custom types until handle further types
+        if (field.schema.custom &&
+              (field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textarea' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textfield' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:select' &&
+               field.schema.custom !== 'com.pyxis.greenhopper.jira:gh-epic-label' &&
+               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:project')
+        ) {
+            return null;
+        }
+
         if (field.schema.system === 'description') {
             return (
                 <Input
@@ -89,7 +100,7 @@ export default class JiraField extends React.Component {
         }
 
         // if this.props.field has allowedValues, then props.value will be an object
-        if (field.allowedValues && field.allowedValues.length) {
+        if (field.allowedValues && field.allowedValues.length && field.schema.type !== 'array') {
             const options = field.allowedValues.map(this.makeReactSelectValue);
 
             return (

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -28,7 +28,8 @@ export default class JiraFields extends React.Component {
         }
 
         return fieldNames.map((fieldName) => {
-            if (fieldName === 'project' || fieldName === 'issuetype' || fieldName === 'reporter' || (fieldName !== 'description' && !this.props.fields[fieldName].required)) {
+            // Always Required Jira fields
+            if (fieldName === 'project' || fieldName === 'issuetype') {
                 return null;
             }
             return (


### PR DESCRIPTION
cc @jfrerich 

- restrict custom field types to textarea, textfield, select
(single-select), epic-label (for epic issue types), and project picker
- for non-custom types, with allowedValues, don't show fields with
field.schema.type == array.  Fix at later date