### PR TITLE
[MM-15932] In Jira Connect approval page, display a better name

### DIFF
--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -4,13 +4,14 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-server/model"
 	"net/http"
 	"path"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 const (

--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -4,14 +4,13 @@
 package main
 
 import (
+	"github.com/mattermost/mattermost-server/model"
 	"net/http"
 	"path"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
-
-	"github.com/mattermost/mattermost-server/model"
 )
 
 const (
@@ -116,6 +115,14 @@ func httpACUserInteractive(jci *jiraCloudInstance, w http.ResponseWriter, r *htt
 		return http.StatusInternalServerError, err
 	}
 
+	mmDisplayName := mmuser.GetDisplayName(model.SHOW_FULLNAME)
+	userName := mmuser.GetDisplayName(model.SHOW_USERNAME)
+	if mmDisplayName == userName {
+		mmDisplayName = "@" + mmDisplayName
+	} else {
+		mmDisplayName += " (@" + userName + ")"
+	}
+
 	// This set of props should work for all relevant routes/templates
 	return jci.Plugin.respondWithTemplate(w, r, "text/html", struct {
 		ConnectSubmitURL      string
@@ -132,6 +139,6 @@ func httpACUserInteractive(jci *jiraCloudInstance, w http.ResponseWriter, r *htt
 		ArgMMToken:            argMMToken,
 		MMToken:               mmToken,
 		JiraDisplayName:       displayName + " (" + username + ")",
-		MattermostDisplayName: mmuser.GetDisplayName(model.SHOW_NICKNAME_FULLNAME),
+		MattermostDisplayName: mmDisplayName,
 	})
 }


### PR DESCRIPTION
#### Summary
- Instead of displaying nickname, display "fullname (@username)" or "@username" if user has no fullname set.
- This makes it easier for the user to understand what is being connected.

#### Links
[MM-15932](https://mattermost.atlassian.net/browse/MM-15932)