### PR TITLE
[MM-15986] Check if user does not have permissions to create issues

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -185,6 +185,13 @@ func httpAPIGetCreateIssueMetadata(ji Instance, w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+
+	if len(cimd.Projects) == 0 {
+		fmt.Fprintf(w, "{\"error\": \"You do not have permission to create issues in any projects. Please contact your Jira admin.\"}")
+		return http.StatusInternalServerError,
+			errors.WithMessage(err, "failed to marshal response")
+	}
+
 	b, err := json.Marshal(cimd)
 	if err != nil {
 		return http.StatusInternalServerError,

--- a/server/issue.go
+++ b/server/issue.go
@@ -186,18 +186,17 @@ func httpAPIGetCreateIssueMetadata(ji Instance, w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", "application/json")
 
+	var bb []byte
 	if len(cimd.Projects) == 0 {
-		fmt.Fprintf(w, "{\"error\": \"You do not have permission to create issues in any projects. Please contact your Jira admin.\"}")
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to marshal response")
+		bb = []byte(`{"error": "You do not have permission to create issues in any projects. Please contact your Jira admin."}`)
+	} else {
+		bb, err = json.Marshal(cimd)
+		if err != nil {
+			return http.StatusInternalServerError,
+				errors.WithMessage(err, "failed to marshal response")
+		}
 	}
-
-	b, err := json.Marshal(cimd)
-	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to marshal response")
-	}
-	_, err = w.Write(b)
+	_, err = w.Write(bb)
 	if err != nil {
 		return http.StatusInternalServerError,
 			errors.WithMessage(err, "failed to write response")

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -141,12 +141,47 @@ export default class CreateIssueModal extends PureComponent {
             return null;
         }
 
-        let component;
         if (error) {
             console.error('render error', error); //eslint-disable-line no-console
         }
 
-        if (!post || !jiraIssueMetadata || !jiraIssueMetadata.projects) {
+        let component;
+        let footer = (
+            <React.Fragment>
+                <FormButton
+                    type='button'
+                    btnClass='btn-link'
+                    defaultMessage='Cancel'
+                    onClick={this.handleClose}
+                />
+                <FormButton
+                    type='submit'
+                    btnClass='btn btn-primary'
+                    saving={submitting}
+                >
+                    {'Create'}
+                </FormButton>
+            </React.Fragment>
+        );
+
+        if (jiraIssueMetadata && jiraIssueMetadata.error) {
+            component = (
+                <div style={style.modal}>
+                    {jiraIssueMetadata.error}
+                </div>
+            );
+
+            footer = (
+                <React.Fragment>
+                    <FormButton
+                        type='submit'
+                        btnClass='btn btn-primary'
+                        defaultMessage='Close'
+                        onClick={this.handleClose}
+                    />
+                </React.Fragment>
+            );
+        } else if (!post || !jiraIssueMetadata || !jiraIssueMetadata.projects) {
             component = <Loading/>;
         } else {
             const issueOptions = getIssueValues(jiraIssueMetadata, this.state.projectKey);
@@ -206,19 +241,7 @@ export default class CreateIssueModal extends PureComponent {
                         {component}
                     </Modal.Body>
                     <Modal.Footer>
-                        <FormButton
-                            type='button'
-                            btnClass='btn-link'
-                            defaultMessage='Cancel'
-                            onClick={this.handleClose}
-                        />
-                        <FormButton
-                            type='submit'
-                            btnClass='btn btn-primary'
-                            saving={submitting}
-                        >
-                            {'Create'}
-                        </FormButton>
+                        {footer}
                     </Modal.Footer>
                 </form>
             </Modal>


### PR DESCRIPTION
**Summary**
If a user does not have permissions to create issues, alert them in the create issue dialog window.  Previously, the dialog window hung in the "loading" state.

*New Dialog Window*
- Message added
- Cancel and Create buttons changed to singe Close button.

![image](https://user-images.githubusercontent.com/7575921/59008332-e034c900-87ef-11e9-807a-b2aa9f250b9a.png)

**Testing** 
Tested on sales-jira instance

**Repro**
*disable create issue permissions*
- Jira Administration > Issues > Permission schemes > Default software scheme > Permissions
- Create Issues > Edit > Remove 
- Removes Application access for Any logged in user

*reenable access*
- Permission > Add `Create Issues` label
- Granted to > Application access > Any logged in user

**Ticket**
Please view the following ticket for additional description
https://mattermost.atlassian.net/browse/MM-15986