### PR TITLE
[MM-15938] Prevent modal closing on clicking or keyboard escape

### DIFF
--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -107,6 +107,8 @@ export default class AttachIssueModal extends PureComponent {
                 onHide={this.handleClose}
                 onExited={this.handleClose}
                 bsSize='large'
+                backdrop='static'
+                keyboard={false}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -194,6 +194,8 @@ export default class CreateIssueModal extends PureComponent {
                 onHide={this.handleClose}
                 onExited={this.handleClose}
                 bsSize='large'
+                backdrop='static'
+                keyboard={false}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>


### PR DESCRIPTION
#### Summary
- Setting a couple attributes on the bootstrap modals fixes the problem.

#### Links
Fixes: [MM-15938](https://mattermost.atlassian.net/browse/MM-15938)