### PR TITLE
[MM-16097] Fixing: Attach to Jira Issue fails silently when user lacks permissions

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -372,21 +371,8 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	commentAdded, _, err := jiraClient.Issue.AddComment(attach.IssueKey, &jiraComment)
 	if err != nil {
 		if strings.Contains(err.Error(), "you do not have the permission to comment on this issue") {
-			reply := &model.Post{
-				Message:   "You do not have permission to create a comment in the selected Jira issue. Please choose another issue or contact your Jira admin.",
-				ChannelId: post.ChannelId,
-				UserId:    ji.GetPlugin().getConfig().botUserID,
-			}
-			_ = api.SendEphemeralPost(mattermostUserId, reply)
-
-			// No need to return an error to the client
-			w.Header().Set("Content-Type", "application/json")
-			_, err = io.WriteString(w, "{}")
-			if err != nil {
-				return http.StatusInternalServerError,
-					errors.WithMessage(err, "failed to write response")
-			}
-			return http.StatusOK, nil
+			return http.StatusNotFound,
+				errors.New("You do not have permission to create a comment in the selected Jira issue. Please choose another issue or contact your Jira admin.")
 		}
 
 		// The error was not a permissions error; it was unanticipated. Return it to the client.

--- a/webapp/src/client/index.js
+++ b/webapp/src/client/index.js
@@ -28,10 +28,5 @@ export const doFetchWithResponse = async (url, options) => {
 
     data = await response.text();
 
-    throw new Error({
-        message: data,
-        server_error_id: '',
-        status_code: 500,
-        url,
-    });
+    throw new Error(data);
 };

--- a/webapp/src/components/form_button.jsx
+++ b/webapp/src/components/form_button.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 export default class FormButton extends PureComponent {
     static propTypes = {
-        executing: PropTypes.bool.isRequired,
+        executing: PropTypes.bool,
         disabled: PropTypes.bool,
         executingMessage: PropTypes.node,
         defaultMessage: PropTypes.node,

--- a/webapp/src/components/input.jsx
+++ b/webapp/src/components/input.jsx
@@ -8,7 +8,7 @@ import Setting from './setting.jsx';
 
 export default class Input extends PureComponent {
     static propTypes = {
-        id: PropTypes.string.isRequired,
+        id: PropTypes.string,
         label: PropTypes.node.isRequired,
         placeholder: PropTypes.string,
         helpText: PropTypes.node,
@@ -17,7 +17,7 @@ export default class Input extends PureComponent {
             PropTypes.number,
         ]).isRequired,
         maxLength: PropTypes.number,
-        onChange: PropTypes.func.isRequired,
+        onChange: PropTypes.func,
         disabled: PropTypes.bool,
         required: PropTypes.bool,
         readOnly: PropTypes.bool,

--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -17,7 +17,6 @@ export default class JiraIssueSelector extends Component {
     static propTypes = {
         isRequired: PropTypes.bool,
         theme: PropTypes.object.isRequired,
-        currentProject: PropTypes.string.isRequired,
         onChange: PropTypes.func.isRequired,
         fetchIssuesEndpoint: PropTypes.string.isRequired,
     };
@@ -27,11 +26,9 @@ export default class JiraIssueSelector extends Component {
     };
 
     searchIssues = (text) => {
-        const projectSearchTerm = this.props.currentProject ? 'project=' + this.props.currentProject : '';
         const textEncoded = encodeURIComponent(text.trim().replace(/"/g, '\\"'));
         const textSearchTerm = (textEncoded.length > 0) ? 'text ~ "' + textEncoded + '*"' : '';
-        const combinedTerms = (projectSearchTerm.length > 0 && textSearchTerm.length > 0) ? projectSearchTerm + ' AND ' + textSearchTerm : projectSearchTerm + textSearchTerm;
-        const finalQuery = combinedTerms + ' ' + searchDefaults;
+        const finalQuery = textSearchTerm + ' ' + searchDefaults;
 
         return doFetchWithResponse(this.props.fetchIssuesEndpoint + `?jql=${finalQuery}`).then(
             ({data}) => {

--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -19,6 +19,7 @@ export default class JiraIssueSelector extends Component {
         theme: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
         fetchIssuesEndpoint: PropTypes.string.isRequired,
+        error: PropTypes.string.isRequired,
     };
 
     handleIssueSearchTermChange = (inputValue) => {
@@ -39,6 +40,8 @@ export default class JiraIssueSelector extends Component {
     debouncedSearchIssues = debounce(this.searchIssues, searchDebounceDelay);
 
     render = () => {
+        const {error} = this.props;
+
         const requiredStar = (
             <span
                 className={'error-text'}
@@ -47,6 +50,15 @@ export default class JiraIssueSelector extends Component {
                 {'*'}
             </span>
         );
+
+        let issueError = null;
+        if (error) {
+            issueError = (
+                <p className='help-text error-text'>
+                    <span>{error}</span>
+                </p>
+            );
+        }
 
         return (
             <div className={'form-group margin-bottom x3'}>
@@ -71,6 +83,7 @@ export default class JiraIssueSelector extends Component {
                     menuPlacement='auto'
                     styles={getStyleForReactSelect(this.props.theme)}
                 />
+                {issueError}
                 <div className={'help-text'}>
                     {'Returns issues sorted by most recently updated.'} <br/>
                     {'Tip: Use AND, OR, *, ~, and other modifiers like in a JQL query.'}

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -77,22 +77,13 @@ export default class AttachIssueModal extends PureComponent {
             return null;
         }
 
-        let errorFeedback = null;
-        if (error) {
-            errorFeedback = (
-                <Alert bsStyle='danger'>
-                    <h4>{'Error'}</h4>
-                    <p>{error}</p>
-                </Alert>
-            );
-        }
-
         const component = (
             <div style={style.modal}>
                 <JiraIssueSelector
                     onChange={this.handleIssueKeyChange}
                     isRequired={true}
                     theme={theme}
+                    error={error}
                 />
                 <Input
                     label='Message Attached to Jira Issue'
@@ -127,7 +118,6 @@ export default class AttachIssueModal extends PureComponent {
                 >
                     <Modal.Body ref='modalBody'>
                         {component}
-                        {errorFeedback}
                     </Modal.Body>
                     <Modal.Footer>
                         <FormButton

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Modal, Alert} from 'react-bootstrap';
+import {Modal} from 'react-bootstrap';
 
 import FormButton from 'components/form_button';
 import Input from 'components/input';

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -3,7 +3,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {Modal} from 'react-bootstrap';
+import {Modal, Alert} from 'react-bootstrap';
 
 import FormButton from 'components/form_button';
 import Input from 'components/input';
@@ -77,8 +77,14 @@ export default class AttachIssueModal extends PureComponent {
             return null;
         }
 
+        let errorFeedback = null;
         if (error) {
-            console.error('render error', error); //eslint-disable-line no-console
+            errorFeedback = (
+                <Alert bsStyle='danger'>
+                    <h4>{'Error'}</h4>
+                    <p>{error}</p>
+                </Alert>
+            );
         }
 
         const component = (
@@ -121,6 +127,7 @@ export default class AttachIssueModal extends PureComponent {
                 >
                     <Modal.Body ref='modalBody'>
                         {component}
+                        {errorFeedback}
                     </Modal.Body>
                     <Modal.Footer>
                         <FormButton


### PR DESCRIPTION
#### Summary
- When a user has access to browse a project but does not have access to add comments to the issue, Attach to Jira Issue fails silently
- Also some clean-up:
  - some proptypes were marked as required but weren't actually required causing red in the console
  - forgot to remove the project props in the attach-to-issue search (we're not filtering by project anymore)

UX:

![image](https://user-images.githubusercontent.com/1490756/59125639-eda59c80-8930-11e9-9fb6-4ad1a384f673.png)

#### Links
[MM-16097](https://mattermost.atlassian.net/browse/MM-16097)