### PR TITLE
[MM-16098] Add a plugin.json setting to allow disabling of all Jirav2 UI features

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -26,7 +26,7 @@
         "key": "EnableJiraUI",
         "display_name": "Allow users to connect their Mattermost accounts to Jira",
         "type": "bool",
-        "help_text": "When true, users can create and manage issues across Mattermost channels by connecting their Mattermost account to Jira with '/jira connect'. \n \n After changing this setting to true, install this plugin to your Jira instance with '/jira install'. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
+        "help_text": "When false, disables all Jira-related user interactions in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
         "default": true
       },
       {

--- a/plugin.json
+++ b/plugin.json
@@ -23,6 +23,13 @@
         "help_text": "Select the username that this integration is attached to."
       },
       {
+        "key": "EnableJiraUI",
+        "display_name": "Allow users to connect their Mattermost accounts to Jira",
+        "type": "bool",
+        "help_text": "When true, users can create and manage issues across Mattermost channels by connecting their Mattermost account to Jira with '/jira connect'. \n \n After changing this setting to true, install this plugin to your Jira instance with '/jira install'. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
+        "default": true
+      },
+      {
         "key": "Secret",
         "display_name": "Webhook Secret",
         "type": "generated",

--- a/server/http.go
+++ b/server/http.go
@@ -22,6 +22,7 @@ const (
 	routeAPIGetSearchIssues        = "/api/v2/get-search-issues"
 	routeAPIAttachCommentToIssue   = "/api/v2/attach-comment-to-issue"
 	routeAPIUserInfo               = "/api/v2/userinfo"
+	routeAPISettingsInfo           = "/api/v2/settingsinfo"
 	routeACInstalled               = "/ac/installed"
 	routeACJSON                    = "/ac/atlassian-connect.json"
 	routeACUninstalled             = "/ac/uninstalled"
@@ -69,6 +70,8 @@ func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 	// User APIs
 	case routeAPIUserInfo:
 		return httpAPIGetUserInfo(p, w, r)
+	case routeAPISettingsInfo:
+		return httpAPIGetSettingsInfo(p, w, r)
 
 	// Atlassian Connect application
 	case routeACInstalled:

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -21,6 +21,9 @@ type externalConfig struct {
 	// Bot username
 	UserName string `json:"username"`
 
+	// Setting to turn on/off the webapp components of this plugin
+	EnableJiraUI bool `json:"enablejiraui"`
+
 	// Legacy 1.x Webhook secret
 	Secret string `json:"secret"`
 }

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -88,6 +88,20 @@ export const attachCommentToIssue = (payload) => {
     };
 };
 
+export function getSettings(getState) {
+    let data;
+    const baseUrl = getPluginServerRoute(getState());
+    try {
+        data = doFetch(`${baseUrl}/api/v2/settingsinfo`, {
+            method: 'get',
+        });
+    } catch (error) {
+        return {error};
+    }
+
+    return data;
+}
+
 export function getConnected() {
     return async (dispatch, getState) => {
         let data;

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -10,10 +10,15 @@ import AttachCommentToIssueModal from 'components/modals/attach_comment_to_issue
 import PluginId from 'plugin_id';
 
 import reducers from './reducers';
-import {handleConnectChange, getConnected, handleInstanceStatusChange} from './actions';
+import {handleConnectChange, getConnected, handleInstanceStatusChange, getSettings} from './actions';
 
 export default class Plugin {
     async initialize(registry, store) {
+        const settings = await getSettings(store.getState);
+        if (!settings.ui_enabled) {
+            return;
+        }
+
         registry.registerReducer(reducers);
 
         try {


### PR DESCRIPTION
#### Summary
- added a system console setting
- opened up a new API endpoint (didn't think it belonged in the user info, and needed this settings info before the userInfo)
- it's quick and dirty -- the system console settings changes are not pushed to the clients, so if they had the ability to use the UI, they will still have it until they refresh. Open to any suggestions if you think it's too simplistic.

UX:
![image](https://user-images.githubusercontent.com/1490756/59133290-7d554600-8945-11e9-8b8d-d04af021e531.png)

#### Links
[MM-16098](https://mattermost.atlassian.net/browse/MM-16098)