### PR TITLE
[MM-15924] Server-side error handling for create/attach Jira issue dialogs

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -128,7 +128,33 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			resp.Body.Close()
 			message += ", details:" + string(bb)
 		}
-		return http.StatusInternalServerError, errors.WithMessage(err, message)
+
+		// if have an error and Jira tells us there are required fields send user
+		// link to jira with fields already filled in.  Note the user will also see
+		// these errors in Jira.
+		// Note that RequiredFieldsNotCovered is also empty
+		if strings.Contains(message, "is required.") {
+			req := buildCreateQuery(ji, project, issue)
+
+			message := "This plugin did not receive all the required fields from your Jira project and could not complete the request. "
+			reply := &model.Post{
+				Message:   fmt.Sprintf("%v [Please create your Jira issue manually](%v) or contact your Jira administrator.", message, req.URL.String()),
+				ChannelId: post.ChannelId,
+				RootId:    rootId,
+				ParentId:  parentId,
+				UserId:    ji.GetPlugin().getConfig().botUserID,
+			}
+
+			_ = api.SendEphemeralPost(mattermostUserId, reply)
+
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, "{}")
+			return http.StatusOK, nil
+		}
+
+		// The error was a fields required error; it was unanticipated. Return it to the client.
+		return http.StatusInternalServerError,
+			errors.WithMessage(err, message)
 	}
 
 	// Reply to the post with the issue link that was created

--- a/server/issue.go
+++ b/server/issue.go
@@ -136,7 +136,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 		if strings.Contains(message, "is required.") {
 			req := buildCreateQuery(ji, project, issue)
 
-			message := "This plugin did not receive all the required fields from your Jira project and could not complete the request. "
+			message = "This plugin did not receive all the required fields from your Jira project and could not complete the request. "
 			reply := &model.Post{
 				Message:   fmt.Sprintf("%v [Please create your Jira issue manually](%v) or contact your Jira administrator.", message, req.URL.String()),
 				ChannelId: post.ChannelId,

--- a/server/issue.go
+++ b/server/issue.go
@@ -152,7 +152,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			return http.StatusOK, nil
 		}
 
-		// The error was a fields required error; it was unanticipated. Return it to the client.
+		// The error was not a fields required error; it was unanticipated. Return it to the client.
 		return http.StatusInternalServerError,
 			errors.WithMessage(err, message)
 	}

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -191,6 +191,17 @@ export default class CreateIssueModal extends PureComponent {
             console.error('render error', error); //eslint-disable-line no-console
         }
 
+        let issueError = null;
+        if (error) {
+            issueError = (
+                <React.Fragment>
+                    <p className='help-text error-text'>
+                        <span>{error}</span>
+                    </p>
+                    <br/>
+                </React.Fragment>
+            );
+        }
         let component;
         let footer = (
             <React.Fragment>
@@ -234,6 +245,7 @@ export default class CreateIssueModal extends PureComponent {
             const projectOptions = getProjectValues(jiraIssueMetadata);
             component = (
                 <div style={style.modal}>
+                    {issueError}
                     <ReactSelectSetting
                         name={'project'}
                         label={'Project'}

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -187,10 +187,6 @@ export default class CreateIssueModal extends PureComponent {
             return null;
         }
 
-        if (error) {
-            console.error('render error', error); //eslint-disable-line no-console
-        }
-
         let issueError = null;
         if (error) {
             issueError = (

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -195,10 +195,13 @@ export default class CreateIssueModal extends PureComponent {
         if (error) {
             issueError = (
                 <React.Fragment>
-                    <p className='help-text error-text'>
+                    <p className='alert alert-danger'>
+                        <i
+                            className='fa fa-warning'
+                            title='Warning Icon'
+                        />
                         <span>{error}</span>
                     </p>
-                    <br/>
                 </React.Fragment>
             );
         }

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -200,7 +200,7 @@ export default class CreateIssueModal extends PureComponent {
                             className='fa fa-warning'
                             title='Warning Icon'
                         />
-                        <span>{error}</span>
+                        <span> {error}</span>
                     </p>
                 </React.Fragment>
             );


### PR DESCRIPTION
**Summary**

This ticket solves two problems. 

1. When a user tries to create a Jira issue and Jira is in a state that requires fields that do not show up in the creation window, Jira will fail.  This actually happens in the Jira instance create issue window.   When this case occurred, the create issue dialog window would allow the user to hit create and provide no feedback.  Now, a link is provided in an ephemeral MM post that takes the user to Jira with the handled fields pre-populated.  From here, the user will see the fields that are failing and can resolve by working with their Jira Admin.

Here is a sample of the response:
![image](https://user-images.githubusercontent.com/7575921/59233690-12a74300-8baf-11e9-8fb3-82926a5543d1.png)

2. When the user clicks the create button and Jira responds with an error, post the error in the create issue dialog window.

Here is a sample of this response type:
![image](https://user-images.githubusercontent.com/7575921/59233706-28b50380-8baf-11e9-8b32-c60cd2eeac17.png)

**Ticket**
https://mattermost.atlassian.net/browse/MM-15924