### PR TITLE
 [MM-16229] Implement proper client-side error handling for create/attach Jira issue dialogs

### DIFF
--- a/webapp/src/components/input.jsx
+++ b/webapp/src/components/input.jsx
@@ -66,9 +66,9 @@ export default class Input extends PureComponent {
 
     render() {
         const requiredMsg = 'This field is required.';
-        let error = null;
+        let validationError = null;
         if (this.props.required && this.state.invalidRequired) {
-            error = (
+            validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>
                 </p>
@@ -131,7 +131,7 @@ export default class Input extends PureComponent {
                 required={this.props.required}
             >
                 {input}
-                {error}
+                {validationError}
             </Setting>
         );
     }

--- a/webapp/src/components/input.jsx
+++ b/webapp/src/components/input.jsx
@@ -38,12 +38,12 @@ export default class Input extends PureComponent {
     constructor(props) {
         super(props);
 
-        this.state = {invalidRequired: false};
+        this.state = {invalid: false};
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.invalidRequired && this.props.value !== prevProps.value) {
-            this.setState({invalidRequired: false}); //eslint-disable-line react/no-did-update-set-state
+        if (prevState.invalid && this.props.value !== prevProps.value) {
+            this.setState({invalid: false}); //eslint-disable-line react/no-did-update-set-state
         }
     }
 
@@ -60,14 +60,14 @@ export default class Input extends PureComponent {
             return true;
         }
         const valid = this.props.value && this.props.value.toString().length !== 0;
-        this.setState({invalidRequired: !valid});
+        this.setState({invalid: !valid});
         return valid;
     };
 
     render() {
         const requiredMsg = 'This field is required.';
         let validationError = null;
-        if (this.props.required && this.state.invalidRequired) {
+        if (this.props.required && this.state.invalid) {
             validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>

--- a/webapp/src/components/input.jsx
+++ b/webapp/src/components/input.jsx
@@ -35,6 +35,18 @@ export default class Input extends PureComponent {
         readOnly: false,
     };
 
+    constructor(props) {
+        super(props);
+
+        this.state = {invalidRequired: false};
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.invalidRequired && this.props.value !== prevProps.value) {
+            this.setState({invalidRequired: false}); //eslint-disable-line react/no-did-update-set-state
+        }
+    }
+
     handleChange = (e) => {
         if (this.props.type === 'number') {
             this.props.onChange(this.props.id, parseInt(e.target.value, 10));
@@ -43,11 +55,31 @@ export default class Input extends PureComponent {
         }
     };
 
+    isValid = () => {
+        if (!this.props.required) {
+            return true;
+        }
+        const valid = this.props.value && this.props.value.toString().length !== 0;
+        this.setState({invalidRequired: !valid});
+        return valid;
+    };
+
     render() {
+        const requiredMsg = 'This field is required.';
+        let error = null;
+        if (this.props.required && this.state.invalidRequired) {
+            error = (
+                <p className='help-text error-text'>
+                    <span>{requiredMsg}</span>
+                </p>
+            );
+        }
+
         let input = null;
         if (this.props.type === 'input') {
             input = (
                 <input
+                    ref={this.ref}
                     id={this.props.id}
                     className='form-control'
                     type='text'
@@ -56,13 +88,13 @@ export default class Input extends PureComponent {
                     maxLength={this.props.maxLength}
                     onChange={this.handleChange}
                     disabled={this.props.disabled}
-                    required={this.props.required}
                     readOnly={this.props.readOnly}
                 />
             );
         } else if (this.props.type === 'number') {
             input = (
                 <input
+                    ref={this.ref}
                     id={this.props.id}
                     className='form-control'
                     type='number'
@@ -71,13 +103,13 @@ export default class Input extends PureComponent {
                     maxLength={this.props.maxLength}
                     onChange={this.handleChange}
                     disabled={this.props.disabled}
-                    required={this.props.required}
                     readOnly={this.props.readOnly}
                 />
             );
         } else if (this.props.type === 'textarea') {
             input = (
                 <textarea
+                    ref={this.ref}
                     id={this.props.id}
                     className='form-control'
                     rows='5'
@@ -86,7 +118,6 @@ export default class Input extends PureComponent {
                     maxLength={this.props.maxLength}
                     onChange={this.handleChange}
                     disabled={this.props.disabled}
-                    required={this.props.required}
                     readOnly={this.props.readOnly}
                 />
             );
@@ -100,6 +131,7 @@ export default class Input extends PureComponent {
                 required={this.props.required}
             >
                 {input}
+                {error}
             </Setting>
         );
     }

--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -9,17 +9,33 @@ import Input from 'components/input';
 
 export default class JiraField extends React.PureComponent {
     static propTypes = {
-        id: PropTypes.object.isRequired,
+        id: PropTypes.string.isRequired,
         field: PropTypes.object.isRequired,
         obeyRequired: PropTypes.bool,
         onChange: PropTypes.func.isRequired,
         value: PropTypes.any,
         theme: PropTypes.object.isRequired,
+        addValidate: PropTypes.func.isRequired,
+        removeValidate: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
         obeyRequired: true,
     };
+
+    constructor(props) {
+        super(props);
+
+        this.ref = React.createRef();
+    }
+
+    componentDidMount() {
+        this.props.addValidate(this.props.id, this.ref);
+    }
+
+    componentWillUnmount() {
+        this.props.removeValidate(this.props.id);
+    }
 
     // Creates an option for react-select from an allowedValue from the jira field metadata
     // includes both .value and .name because allowedValue test cases have used .value or .name
@@ -47,6 +63,7 @@ export default class JiraField extends React.PureComponent {
         if (field.schema.system === 'description') {
             return (
                 <Input
+                    ref={this.ref}
                     key={this.props.id}
                     id={this.props.id}
                     label={field.name}
@@ -62,6 +79,7 @@ export default class JiraField extends React.PureComponent {
         if (field.schema.custom === 'com.atlassian.jira.plugin.system.customfieldtypes:textarea') {
             return (
                 <Input
+                    ref={this.ref}
                     key={this.props.id}
                     id={this.props.id}
                     label={field.name}
@@ -76,6 +94,7 @@ export default class JiraField extends React.PureComponent {
         if (field.schema.type === 'string') {
             return (
                 <Input
+                    ref={this.ref}
                     key={this.props.id}
                     id={this.props.id}
                     label={field.name}
@@ -93,6 +112,7 @@ export default class JiraField extends React.PureComponent {
 
             return (
                 <ReactSelectSetting
+                    ref={this.ref}
                     key={this.props.id}
                     name={this.props.id}
                     label={field.name}

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -8,12 +8,17 @@ import JiraField from 'components/jira_field';
 
 export default class JiraFields extends React.PureComponent {
     static propTypes = {
-        fields: PropTypes.object.isRequired,
+        fields: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.array,
+        ]).isRequired,
         onChange: PropTypes.func.isRequired,
         values: PropTypes.object,
-        allowedFields: PropTypes.object.isRequired,
-        allowedSchemaCustom: PropTypes.object.isRequired,
+        allowedFields: PropTypes.array.isRequired,
+        allowedSchemaCustom: PropTypes.array.isRequired,
         theme: PropTypes.object.isRequired,
+        addValidate: PropTypes.func.isRequired,
+        removeValidate: PropTypes.func.isRequired,
     };
 
     render() {
@@ -55,6 +60,8 @@ export default class JiraFields extends React.PureComponent {
                     onChange={this.props.onChange}
                     value={this.props.values && this.props.values[fieldName]}
                     theme={this.props.theme}
+                    addValidate={this.props.addValidate}
+                    removeValidate={this.props.removeValidate}
                 />
             );
         });

--- a/webapp/src/components/jira_issue_selector/index.js
+++ b/webapp/src/components/jira_issue_selector/index.js
@@ -13,4 +13,4 @@ const mapStateToProps = (state) => {
     };
 };
 
-export default connect(mapStateToProps)(JiraIssueSelector);
+export default connect(mapStateToProps, null, null, {withRef: true})(JiraIssueSelector);

--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -26,12 +26,12 @@ export default class JiraIssueSelector extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {invalidRequired: false};
+        this.state = {invalid: false};
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.invalidRequired && this.props.value !== prevProps.value) {
-            this.setState({invalidRequired: false}); //eslint-disable-line react/no-did-update-set-state
+        if (prevState.invalid && this.props.value !== prevProps.value) {
+            this.setState({invalid: false}); //eslint-disable-line react/no-did-update-set-state
         }
     }
 
@@ -58,7 +58,7 @@ export default class JiraIssueSelector extends Component {
         }
 
         const valid = this.props.value && this.props.value.toString().length !== 0;
-        this.setState({invalidRequired: !valid});
+        this.setState({invalid: !valid});
         return valid;
     };
 
@@ -85,7 +85,7 @@ export default class JiraIssueSelector extends Component {
 
         const requiredMsg = 'This field is required.';
         let validationError = null;
-        if (this.props.required && this.state.invalidRequired) {
+        if (this.props.required && this.state.invalid) {
             validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>

--- a/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/modals/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -9,6 +9,7 @@ import FormButton from 'components/form_button';
 import Input from 'components/input';
 
 import JiraIssueSelector from 'components/jira_issue_selector';
+import Validator from 'components/validator';
 
 const initialState = {
     submitting: false,
@@ -30,11 +31,27 @@ export default class AttachIssueModal extends PureComponent {
     constructor(props) {
         super(props);
         this.state = initialState;
+
+        this.issueRef = React.createRef();
+
+        this.validator = new Validator();
+    }
+
+    componentDidMount() {
+        this.validator.addComponent('issue', this.issueRef);
+    }
+
+    componentWillUnmount() {
+        this.validator.removeComponent('issue');
     }
 
     handleCreate = (e) => {
         if (e && e.preventDefault) {
             e.preventDefault();
+        }
+
+        if (!this.validator.validate()) {
+            return;
         }
 
         const issue = {
@@ -80,10 +97,12 @@ export default class AttachIssueModal extends PureComponent {
         const component = (
             <div style={style.modal}>
                 <JiraIssueSelector
+                    ref={this.issueRef}
                     onChange={this.handleIssueKeyChange}
-                    isRequired={true}
+                    required={true}
                     theme={theme}
                     error={error}
+                    value={this.state.issueKey}
                 />
                 <Input
                     label='Message Attached to Jira Issue'

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -5,6 +5,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {Modal} from 'react-bootstrap';
 
+import Validator from 'components/validator';
 import JiraFields from 'components/jira_fields';
 import FormButton from 'components/form_button';
 import Loading from 'components/loading';
@@ -46,20 +47,19 @@ export default class CreateIssueModal extends PureComponent {
         this.state = initialState;
 
         this.projectRef = React.createRef();
-        this.issuesRef = React.createRef();
+        this.issueRef = React.createRef();
 
-        // Our list of components we have to validate before allowing a submit action.
-        this.toValidate = new Map();
+        this.validator = new Validator();
     }
 
     componentDidMount() {
-        this.addValidate('project', this.projectRef);
-        this.addValidate('issues', this.issuesRef);
+        this.validator.addComponent('project', this.projectRef);
+        this.validator.addComponent('issue', this.issueRef);
     }
 
     componentWillUnmount() {
-        this.removeValidate('project');
-        this.removeValidate('issues');
+        this.validator.removeComponent('project');
+        this.validator.removeComponent('issue');
     }
 
     componentDidUpdate(prevProps) {
@@ -112,28 +112,12 @@ export default class CreateIssueModal extends PureComponent {
         return fieldsNotCovered;
     }
 
-    addValidate = (key, ref) => {
-        this.toValidate.set(key, ref);
-    };
-
-    removeValidate = (key) => {
-        this.toValidate.delete(key);
-    };
-
-    validateFields = () => {
-        const validator = (accum, ref) => {
-            // Check every field, but only return true if every field is valid.
-            return ref.current.isValid() && accum;
-        };
-        return Array.from(this.toValidate.values()).reduce(validator, true);
-    };
-
     handleCreate = (e) => {
         if (e && e.preventDefault) {
             e.preventDefault();
         }
 
-        if (!this.validateFields()) {
+        if (!this.validator.validate()) {
             return;
         }
 
@@ -283,7 +267,7 @@ export default class CreateIssueModal extends PureComponent {
                         value={projectOptions.find((option) => option.value === this.state.projectKey)}
                     />
                     <ReactSelectSetting
-                        ref={this.issuesRef}
+                        ref={this.issueRef}
                         name={'issue_type'}
                         label={'Issue Type'}
                         required={true}
@@ -301,8 +285,8 @@ export default class CreateIssueModal extends PureComponent {
                         allowedSchemaCustom={this.allowedSchemaCustom}
                         theme={theme}
                         value={this.state.fields}
-                        addValidate={this.addValidate}
-                        removeValidate={this.removeValidate}
+                        addValidate={this.validator.addComponent}
+                        removeValidate={this.validator.removeComponent}
                     />
                     <br/>
                 </div>

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -43,16 +43,16 @@ export default class ReactSelectSetting extends React.PureComponent {
         if (!this.props.required) {
             return true;
         }
-        const valid = this.props.value && this.props.value.toString().length !== 0;
+        const valid = Boolean(this.props.value);
         this.setState({invalidRequired: !valid});
         return valid;
     };
 
     render() {
         const requiredMsg = 'This field is required.';
-        let error = null;
+        let validationError = null;
         if (this.props.required && this.state.invalidRequired) {
-            error = (
+            validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>
                 </p>
@@ -66,13 +66,12 @@ export default class ReactSelectSetting extends React.PureComponent {
             >
                 <ReactSelect
                     {...this.props}
-                    ref={this.ref}
                     menuPortalTarget={document.body}
                     menuPlacement='auto'
                     onChange={this.handleChange}
                     styles={getStyleForReactSelect(this.props.theme)}
                 />
-                {error}
+                {validationError}
             </Setting>
         );
     }

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -16,7 +16,21 @@ export default class ReactSelectSetting extends React.PureComponent {
         onChange: PropTypes.func,
         theme: PropTypes.object.isRequired,
         isClearable: PropTypes.bool,
+        value: PropTypes.object,
+        required: PropTypes.bool,
     };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {invalidRequired: false};
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.invalidRequired && this.props.value !== prevProps.value) {
+            this.setState({invalidRequired: false}); //eslint-disable-line react/no-did-update-set-state
+        }
+    }
 
     handleChange = (value) => {
         if (this.props.onChange) {
@@ -25,7 +39,26 @@ export default class ReactSelectSetting extends React.PureComponent {
         }
     };
 
+    isValid = () => {
+        if (!this.props.required) {
+            return true;
+        }
+        const valid = this.props.value && this.props.value.toString().length !== 0;
+        this.setState({invalidRequired: !valid});
+        return valid;
+    };
+
     render() {
+        const requiredMsg = 'This field is required.';
+        let error = null;
+        if (this.props.required && this.state.invalidRequired) {
+            error = (
+                <p className='help-text error-text'>
+                    <span>{requiredMsg}</span>
+                </p>
+            );
+        }
+
         return (
             <Setting
                 inputId={this.props.name}
@@ -33,11 +66,13 @@ export default class ReactSelectSetting extends React.PureComponent {
             >
                 <ReactSelect
                     {...this.props}
+                    ref={this.ref}
                     menuPortalTarget={document.body}
                     menuPlacement='auto'
                     onChange={this.handleChange}
                     styles={getStyleForReactSelect(this.props.theme)}
                 />
+                {error}
             </Setting>
         );
     }

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -23,12 +23,12 @@ export default class ReactSelectSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.state = {invalidRequired: false};
+        this.state = {invalid: false};
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.invalidRequired && this.props.value !== prevProps.value) {
-            this.setState({invalidRequired: false}); //eslint-disable-line react/no-did-update-set-state
+        if (prevState.invalid && this.props.value !== prevProps.value) {
+            this.setState({invalid: false}); //eslint-disable-line react/no-did-update-set-state
         }
     }
 
@@ -44,14 +44,14 @@ export default class ReactSelectSetting extends React.PureComponent {
             return true;
         }
         const valid = Boolean(this.props.value);
-        this.setState({invalidRequired: !valid});
+        this.setState({invalid: !valid});
         return valid;
     };
 
     render() {
         const requiredMsg = 'This field is required.';
         let validationError = null;
-        if (this.props.required && this.state.invalidRequired) {
+        if (this.props.required && this.state.invalid) {
             validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>

--- a/webapp/src/components/validator.js
+++ b/webapp/src/components/validator.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export default class Validator {
+    constructor() {
+        // Our list of components we have to validate before allowing a submit action.
+        this.components = new Map();
+    }
+
+    addComponent = (key, ref) => {
+        this.components.set(key, ref);
+    };
+
+    removeComponent = (key) => {
+        this.components.delete(key);
+    };
+
+    validate = () => {
+        const validator = (accum, ref) => {
+            let currentRef = ref.current;
+
+            // If the ref was wrapped by react-redux connect, unwrap it
+            if (typeof currentRef.getWrappedInstance === 'function') {
+                currentRef = currentRef.getWrappedInstance();
+            }
+
+            // Check every field, but only return true if every field is valid.
+            return currentRef.isValid() && accum;
+        };
+        return Array.from(this.components.values()).reduce(validator, true);
+    };
+}


### PR DESCRIPTION
#### Summary
- Display a client-side error when the user clicks submit and there are empty fields marked `required`.
- Removed the built in validation for input fields (bootstrap?) because @jasonblais found that these errors did not display in the desktop app. Replaced with this method. 
- For now, the validation is simply whether or not it is required, and if so make sure it's not empty. Can be improved as needed.

Unrelated fixes:
- Found a few problems with required props, fixed those.
- Should be using find instead of filter in react-select value fields.

Looks like:
![image](https://user-images.githubusercontent.com/1490756/59290478-a8da7800-8c46-11e9-8f5a-ffc1742d2a96.png)
![image](https://user-images.githubusercontent.com/1490756/59290497-b4c63a00-8c46-11e9-8f00-867415c785f6.png)

#### Links
[MM-16229](https://mattermost.atlassian.net/browse/MM-16229)