### PR TITLE
MM-16116 Fix serching in single select dropdowns.

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import {components} from 'react-select';
+
 import ReactSelectSetting from 'components/react_select_setting';
 import Input from 'components/input';
 
@@ -23,6 +25,27 @@ export default class JiraField extends React.PureComponent {
         obeyRequired: true,
     };
 
+    static IconOption = (props) => {
+        let img = null;
+        if (props.data.allowedValue.iconUrl) {
+            img = (
+                <img
+                    style={getStyle().jiraIcon}
+                    src={props.data.allowedValue.iconUrl}
+                />
+            );
+        }
+        return (
+            <components.Option
+                {...props}
+                style={getStyle().selectComponent}
+            >
+                {img}
+                {props.data.label}
+            </components.Option>
+        );
+    };
+
     constructor(props) {
         super(props);
 
@@ -37,23 +60,10 @@ export default class JiraField extends React.PureComponent {
         this.props.removeValidate(this.props.id);
     }
 
-    // Creates an option for react-select from an allowedValue from the jira field metadata
-    // includes both .value and .name because allowedValue test cases have used .value or .name
-    // and are mutually exclusive.
-    // should wrap this with some if else logic
     makeReactSelectValue = (allowedValue) => {
-        const iconLabel = (
-            <React.Fragment>
-                <img
-                    style={getStyle().jiraIcon}
-                    src={allowedValue.iconUrl}
-                />
-                {allowedValue.value}
-                {allowedValue.name}
-            </React.Fragment>
-        );
+        const label = allowedValue.name ? allowedValue.name : allowedValue.value;
         return (
-            {value: allowedValue.id, label: iconLabel}
+            {value: allowedValue.id, label, allowedValue}
         );
     };
 
@@ -123,6 +133,7 @@ export default class JiraField extends React.PureComponent {
                     value={options.find((option) => option.value === this.props.value)}
                     theme={this.props.theme}
                     isClearable={true}
+                    components={{Option: JiraField.IconOption}}
                 />
             );
         }


### PR DESCRIPTION
Uses a custom component to render options that has icon if available. Avoids the issue of component labels not being searchable without special casing priority.

Replaces: https://github.com/mattermost/mattermost-plugin-jira/pull/156
