### PR TITLE
[MM-15229] Add "/jira view <issuekey>" command

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -433,7 +433,7 @@ func (p *Plugin) getIssueAsSlackAttachment(ji Instance, jiraUser JIRAUser, issue
 	// reuse the webhook parser for now
 	jwh := &JiraWebhook{Issue: *issue}
 	wh := parseWebhookCreated(jwh)
-	wh.headline = ""
+	wh.headline = jwh.mdJiraLink(issue.Key+": "+issue.Fields.Summary, "/browse/"+issue.Key)
 
 	post := &model.Post{}
 	if wh.text != "" || len(wh.fields) != 0 {

--- a/server/issue.go
+++ b/server/issue.go
@@ -424,32 +424,13 @@ func (p *Plugin) getIssueAsSlackAttachment(ji Instance, jiraUser JIRAUser, issue
 
 			// return more detail for an exceptional error case
 			bb, _ := ioutil.ReadAll(resp.Body)
-			resp.Body.Close()
-			message += ", details:" + string(bb)
+			_ = resp.Body.Close()
+			message += ", details: " + string(bb)
 		}
 		return nil, errors.Wrap(err, message)
 	}
 
-	// reuse the webhook parser for now
-	jwh := &JiraWebhook{Issue: *issue}
-	wh := parseWebhookCreated(jwh)
-	wh.headline = jwh.mdJiraLink(issue.Key+": "+issue.Fields.Summary, "/browse/"+issue.Key)
-
-	post := &model.Post{}
-	if wh.text != "" || len(wh.fields) != 0 {
-		model.ParseSlackAttachment(post, []*model.SlackAttachment{
-			{
-				// TODO is this supposed to be themed?
-				Color:    "#95b7d0",
-				Fallback: wh.headline,
-				Pretext:  wh.headline,
-				Text:     wh.text,
-				Fields:   wh.fields,
-			},
-		})
-	}
-
-	return post.Attachments(), nil
+	return parseIssue(issue), nil
 }
 
 func (p *Plugin) transitionJiraIssue(mmUserId, issueKey, toState string) (string, error) {

--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -1,0 +1,62 @@
+// See License for license information.
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	jira "github.com/andygrunwald/go-jira"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+var jiraLinkWithTextRegex = regexp.MustCompile(`\[([^\[]+)\|([^\]]+)\]`)
+
+func parseJiraLinksToMarkdown(text string) string {
+	return jiraLinkWithTextRegex.ReplaceAllString(text, "[${1}](${2})")
+}
+
+func mdKeySummaryLink(issue *jira.Issue) string {
+	pos := strings.LastIndex(issue.Self, "/rest/api")
+	if pos < 0 {
+		return ""
+	}
+	return fmt.Sprintf("[%s](%s%s)", issue.Key+": "+issue.Fields.Summary, issue.Self[:pos], "/browse/"+issue.Key)
+}
+
+func parseIssue(issue *jira.Issue) []*model.SlackAttachment {
+	text := mdKeySummaryLink(issue)
+	fmt.Printf("%q", issue.Fields.Description)
+	desc := truncate(issue.Fields.Description, 3000)
+	desc = parseJiraLinksToMarkdown(desc)
+	if desc != "" {
+		text += "\n\n" + desc + "\n"
+	}
+
+	var fields []*model.SlackAttachmentField
+	if issue.Fields.Assignee != nil {
+		fields = append(fields, &model.SlackAttachmentField{
+			Title: "Assignee",
+			Value: issue.Fields.Assignee.DisplayName,
+			Short: true,
+		})
+	}
+	if issue.Fields.Priority != nil {
+		fields = append(fields, &model.SlackAttachmentField{
+			Title: "Priority",
+			Value: issue.Fields.Priority.Name,
+			Short: true,
+		})
+	}
+	return []*model.SlackAttachment{
+		{
+			// TODO is this supposed to be themed?
+			Color:  "#95b7d0",
+			Text:   text,
+			Fields: fields,
+		},
+	}
+}

--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -29,7 +29,6 @@ func mdKeySummaryLink(issue *jira.Issue) string {
 
 func parseIssue(issue *jira.Issue) []*model.SlackAttachment {
 	text := mdKeySummaryLink(issue)
-	fmt.Printf("%q", issue.Fields.Description)
 	desc := truncate(issue.Fields.Description, 3000)
 	desc = parseJiraLinksToMarkdown(desc)
 	if desc != "" {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -92,7 +92,7 @@ func parseWebhookChangeLog(jwh *JiraWebhook) Webhook {
 	return nil
 }
 
-func parseWebhookCreated(jwh *JiraWebhook) *webhook {
+func parseWebhookCreated(jwh *JiraWebhook) Webhook {
 	wh := newWebhook(jwh, eventCreated, "created")
 
 	wh.text = jwh.mdSummaryLink()

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -92,7 +92,7 @@ func parseWebhookChangeLog(jwh *JiraWebhook) Webhook {
 	return nil
 }
 
-func parseWebhookCreated(jwh *JiraWebhook) Webhook {
+func parseWebhookCreated(jwh *JiraWebhook) *webhook {
 	wh := newWebhook(jwh, eventCreated, "created")
 
 	wh.text = jwh.mdSummaryLink()


### PR DESCRIPTION
#### Summary
- Adds a `/jira view` command
- As described in the ticket: Makes the default command point to view, e.g. `/jira issue`.
- Not reusing the webhook parser; wrote a new one. Correctly handles jira messages now.

UX looks like:
![image](https://user-images.githubusercontent.com/1490756/59392745-becf6200-8d46-11e9-97ce-54670e552e13.png)

#### Links
[MM-15229](https://mattermost.atlassian.net/browse/MM-15229)