### PR TITLE
MM-16098 Clarify what exactly EnableJiraUI enables

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -24,9 +24,9 @@
       },
       {
         "key": "EnableJiraUI",
-        "display_name": "Allow users to connect their Mattermost accounts to Jira",
+        "display_name": "Allow users to attach and create Jira issues in Mattermost",
         "type": "bool",
-        "help_text": "When false, disables all Jira-related user interactions in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
+        "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
         "default": true
       },
       {


### PR DESCRIPTION
State that EnableJiraUI allows users to attach and create Jira issues in Mattermost. When disabled, users aren't able to take these actions.

Fixes https://mattermost.atlassian.net/browse/MM-16098