### PR TITLE
[MM-15786] /jira create without an installed Jira instance throws a 500 and hangs the create modal

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,6 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {PostTypes} from 'mattermost-redux/action_types';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/common';
+
 import ActionTypes from 'action_types';
 import {doFetch} from 'client';
 import {getPluginServerRoute} from 'selectors';
@@ -229,4 +232,26 @@ export function handleInstanceStatusChange(store) {
             data: msg.data,
         });
     };
+}
+
+export function sendEphemeralPost(store, message, channelId) {
+    const timestamp = Date.now();
+    const post = {
+        id: 'jiraPlugin' + Date.now(),
+        user_id: store.getState().entities.users.currentUserId,
+        channel_id: channelId || getCurrentChannelId(store.getState()),
+        message,
+        type: 'system_ephemeral',
+        create_at: timestamp,
+        update_at: timestamp,
+        root_id: '',
+        parent_id: '',
+        props: {},
+    };
+
+    store.dispatch({
+        type: PostTypes.RECEIVED_NEW_POST,
+        data: post,
+        channelId,
+    });
 }

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -12,7 +12,7 @@ export default class Hooks {
     slashCommandWillBePostedHook = (message, contextArgs) => {
         if (message && (message.startsWith('/jira create ') || message === '/jira create')) {
             if (!isInstanceInstalled(this.store.getState())) {
-                sendEphemeralPost(this.store, 'There is not Jira instance installed. Please contact your system administrator.');
+                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
                 return Promise.resolve({});
             }
             if (!isUserConnected(this.store.getState())) {

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {openCreateModalWithoutPost} from '../actions';
+import {openCreateModalWithoutPost, sendEphemeralPost} from '../actions';
+import {isUserConnected} from '../selectors';
 
 export default class Hooks {
     constructor(store) {
@@ -10,6 +11,10 @@ export default class Hooks {
 
     slashCommandWillBePostedHook = (message, contextArgs) => {
         if (message && (message.startsWith('/jira create ') || message === '/jira create')) {
+            if (!isUserConnected(this.store.getState())) {
+                sendEphemeralPost(this.store, 'Your username is not connected to Jira. Please type `/jira connect`.');
+                return Promise.resolve({});
+            }
             const description = message.slice(12).trim();
             this.store.dispatch(openCreateModalWithoutPost(description, contextArgs.channel_id));
             return Promise.resolve({});

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {openCreateModalWithoutPost, sendEphemeralPost} from '../actions';
-import {isUserConnected} from '../selectors';
+import {isUserConnected, isInstanceInstalled} from '../selectors';
 
 export default class Hooks {
     constructor(store) {
@@ -11,6 +11,10 @@ export default class Hooks {
 
     slashCommandWillBePostedHook = (message, contextArgs) => {
         if (message && (message.startsWith('/jira create ') || message === '/jira create')) {
+            if (!isInstanceInstalled(this.store.getState())) {
+                sendEphemeralPost(this.store, 'There is not Jira instance installed. Please contact your system administrator.');
+                return Promise.resolve({});
+            }
             if (!isUserConnected(this.store.getState())) {
                 sendEphemeralPost(this.store, 'Your username is not connected to Jira. Please type `/jira connect`.');
                 return Promise.resolve({});

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -16,7 +16,7 @@ export default class Hooks {
                 return Promise.resolve({});
             }
             if (!isUserConnected(this.store.getState())) {
-                sendEphemeralPost(this.store, 'Your username is not connected to Jira. Please type `/jira connect`.');
+                sendEphemeralPost(this.store, 'Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.');
                 return Promise.resolve({});
             }
             const description = message.slice(12).trim();


### PR DESCRIPTION
#### Summary
- Check on the client-side whether the user is connected. If they aren't, send an ephemeral message.
- Also checks if the instance is connected (because if the instance is deleted while a user is connected, then the user tries to create, it would just hang).

PM review: 
The messages are: 
- `There is no Jira instance installed. Please contact your system administrator.`
- `Your username is not connected to Jira. Please type '/jira connect'.`

Links:
- Fixes: [MM-15786](https://mattermost.atlassian.net/browse/MM-15786)