### PR TITLE
[MM-15913] Update UX when creating issues for projects that require a…

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -26,10 +26,11 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	api := ji.GetPlugin().API
 
 	create := &struct {
-		PostId      string           `json:"post_id"`
-		CurrentTeam string           `json:"current_team"`
-		ChannelId   string           `json:"channel_id"`
-		Fields      jira.IssueFields `json:"fields"`
+		RequiredFieldsNotCovered []string         `json:"required_fields_not_covered"`
+		PostId                   string           `json:"post_id"`
+		CurrentTeam              string           `json:"current_team"`
+		ChannelId                string           `json:"channel_id"`
+		Fields                   jira.IssueFields `json:"fields"`
 	}{}
 	err := json.NewDecoder(r.Body).Decode(&create)
 	if err != nil {
@@ -75,18 +76,61 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 		}
 	}
 
-	created, resp, err := jiraClient.Issue.Create(&jira.Issue{
-		Fields: &create.Fields,
-	})
+	rootId := create.PostId
+	parentId := ""
+	if post.ParentId != "" {
+		// the original post was a reply
+		rootId = post.RootId
+		parentId = create.PostId
+	}
 
-	// For now, if we are not attaching to a post, leave postId blank (this will only affect the error message)
-	postId := ""
+	issue := &jira.Issue{
+		Fields: &create.Fields,
+	}
+
 	channelId := create.ChannelId
 	if post != nil {
 		channelId = post.ChannelId
-		postId = create.PostId
 	}
 
+	project, resp, err := jiraClient.Project.Get(issue.Fields.Project.Key)
+	if err != nil {
+		message := "failed to get the project, postId: " + create.PostId
+		if resp != nil {
+			bb, _ := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			message += ", details:" + string(bb)
+		}
+
+		return http.StatusInternalServerError, errors.WithMessage(err, message)
+	}
+
+	if len(create.RequiredFieldsNotCovered) > 0 {
+
+		req := buildCreateQuery(ji, project, issue)
+
+		message := "The project you tried to create an issue for has **required fields** this plugin does not yet support:"
+
+		var fieldsString string
+		for _, v := range create.RequiredFieldsNotCovered {
+			fieldsString = fieldsString + fmt.Sprintf("- %+v\n", v)
+		}
+
+		reply := &model.Post{
+			Message:   fmt.Sprintf("[Please create your Jira issue manually](%v). %v\n%v", req.URL.String(), message, fieldsString),
+			ChannelId: post.ChannelId,
+			RootId:    rootId,
+			ParentId:  parentId,
+			UserId:    ji.GetPlugin().getConfig().botUserID,
+		}
+		_ = api.SendEphemeralPost(mattermostUserId, reply)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, "{}")
+		return http.StatusOK, nil
+	}
+
+	created, resp, err := jiraClient.Issue.Create(issue)
 	if err != nil {
 		message := "failed to create the issue, postId: " + create.PostId + ", channelId: " + channelId
 		if resp != nil {
@@ -95,6 +139,21 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			message += ", details:" + string(bb)
 		}
 		return http.StatusInternalServerError, errors.WithMessage(err, message)
+	}
+
+	// Reply to the post with the issue link that was created
+	reply := &model.Post{
+		// TODO: Why is this not created.Self?
+		Message:   fmt.Sprintf("Created a Jira issue %v/browse/%v", ji.GetURL(), created.Key),
+		ChannelId: post.ChannelId,
+		RootId:    rootId,
+		ParentId:  parentId,
+		UserId:    mattermostUserId,
+	}
+	_, appErr = api.CreatePost(reply)
+	if appErr != nil {
+		return http.StatusInternalServerError,
+			errors.WithMessage(appErr, "failed to create notification post "+create.PostId)
 	}
 
 	// Upload file attachments in the background
@@ -122,39 +181,16 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 		}()
 	}
 
-	rootId := create.PostId
-	parentId := ""
-	if post.ParentId != "" {
-		// the original post was a reply
-		rootId = post.RootId
-		parentId = create.PostId
-	}
-
-	// Reply to the post with the issue link that was created
-	reply := &model.Post{
-		// TODO: Why is this not created.Self?
-		Message:   fmt.Sprintf("Created a Jira issue %v/browse/%v", ji.GetURL(), created.Key),
-		ChannelId: channelId,
-		RootId:    rootId,
-		ParentId:  parentId,
-		UserId:    mattermostUserId,
-	}
-	_, appErr = api.CreatePost(reply)
-	if appErr != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(appErr, "failed to create notification post, postId: "+postId+", channelId: "+channelId)
-	}
-
 	userBytes, err := json.Marshal(created)
 	if err != nil {
 		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to marshal response, postId: "+postId+", channelId: "+channelId)
+			errors.WithMessage(err, "failed to marshal response, postId: "+create.PostId+", channelId: "+channelId)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(userBytes)
 	if err != nil {
 		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to write response, postId: "+postId+", channelId: "+channelId)
+			errors.WithMessage(err, "failed to write response, postId: "+create.PostId+", channelId: "+channelId)
 	}
 	return http.StatusOK, nil
 }
@@ -375,6 +411,46 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			errors.WithMessage(err, "failed to write response "+attach.PostId)
 	}
 	return http.StatusOK, nil
+}
+
+func buildCreateQuery(ji Instance, project *jira.Project, issue *jira.Issue) *http.Request {
+
+	url := fmt.Sprintf("%v/secure/CreateIssueDetails!init.jspa", ji.GetURL())
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("we've found the errro = %+v\n", err)
+	}
+
+	q := req.URL.Query()
+	q.Add("pid", project.ID)
+	q.Add("issuetype", issue.Fields.Type.ID)
+	q.Add("summary", issue.Fields.Summary)
+	q.Add("description", issue.Fields.Description)
+
+	// if no priority, ID field does not exist
+	if issue.Fields.Priority != nil {
+		q.Add("priority", issue.Fields.Priority.ID)
+	}
+
+	// add custom fields
+	for k, v := range issue.Fields.Unknowns {
+
+		strV, ok := v.(string)
+		if ok {
+			q.Add(k, strV)
+		}
+
+		if mapV, ok := v.(map[string]interface{}); ok {
+			if id, ok := mapV["id"].(string); ok {
+				q.Add(k, id)
+			}
+		}
+
+	}
+
+	req.URL.RawQuery = q.Encode()
+
+	return req
 }
 
 func getPermaLink(ji Instance, postId string, currentTeam string) string {

--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -45,17 +45,6 @@ export default class JiraField extends React.Component {
     renderCreateFields() {
         const field = this.props.field;
 
-        // only allow these custom types until handle further types
-        if (field.schema.custom &&
-              (field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textarea' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:textfield' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:select' &&
-               field.schema.custom !== 'com.pyxis.greenhopper.jira:gh-epic-label' &&
-               field.schema.custom !== 'com.atlassian.jira.plugin.system.customfieldtypes:project')
-        ) {
-            return null;
-        }
-
         if (field.schema.system === 'description') {
             return (
                 <Input

--- a/webapp/src/components/jira_fields.jsx
+++ b/webapp/src/components/jira_fields.jsx
@@ -12,15 +12,19 @@ export default class JiraFields extends React.Component {
         onChange: PropTypes.func.isRequired,
         values: PropTypes.object,
         isFilter: PropTypes.bool,
+        allowedFields: PropTypes.object.isRequired,
+        allowedSchemaCustom: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
     };
 
     render() {
-        if (!this.props.fields) {
+        const {allowedFields, allowedSchemaCustom, fields} = this.props;
+
+        if (!fields) {
             return null;
         }
 
-        let fieldNames = Object.keys(this.props.fields);
+        let fieldNames = Object.keys(fields);
         const fullLength = fieldNames.length;
         fieldNames = fieldNames.filter((name) => name !== 'summary');
         if (fullLength > fieldNames.length) {
@@ -32,11 +36,22 @@ export default class JiraFields extends React.Component {
             if (fieldName === 'project' || fieldName === 'issuetype') {
                 return null;
             }
+
+            // only allow these some custom types until handle further types
+            if (fields[fieldName].schema.custom && !allowedSchemaCustom.includes(fields[fieldName].schema.custom)) {
+                return null;
+            }
+
+            // only allow some default Jira fields until handle further types
+            if (!fields[fieldName].schema.custom && !allowedFields.includes(fieldName)) {
+                return null;
+            }
+
             return (
                 <JiraField
                     key={fieldName}
                     id={fieldName}
-                    field={this.props.fields[fieldName]}
+                    field={fields[fieldName]}
                     obeyRequired={true}
                     onChange={this.props.onChange}
                     value={this.props.values && this.props.values[fieldName]}

--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
@@ -8,7 +8,7 @@ import {Modal} from 'react-bootstrap';
 import ReactSelectSetting from 'components/react_select_setting';
 import FormButton from 'components/form_button';
 import Loading from 'components/loading';
-import {getProjectValues, getIssueValuesForMultipleProjects} from 'jira_issue_metadata';
+import {getProjectValues, getIssueValuesForMultipleProjects} from 'utils/jira_issue_metadata';
 
 const JiraEventOptions = [
     {value: 'jira:issue_created', label: 'Issue Created'},

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -62,7 +62,50 @@ export default class CreateIssueModal extends PureComponent {
         }
     }
 
+    allowedFields = [
+        'project',
+        'issuetype',
+        'priority',
+        'description',
+        'summary',
+    ]
+
+    allowedSchemaCustom = [
+        'com.atlassian.jira.plugin.system.customfieldtypes:textarea',
+        'com.atlassian.jira.plugin.system.customfieldtypes:textfield',
+        'com.atlassian.jira.plugin.system.customfieldtypes:select',
+        'com.atlassian.jira.plugin.system.customfieldtypes:project',
+
+        // 'com.pyxis.greenhopper.jira:gh-epic-link',
+
+        // epic label is 'Epic Name' for cloud instance
+        'com.pyxis.greenhopper.jira:gh-epic-label',
+    ];
+
+    getFieldsNotCovered() {
+        const {jiraIssueMetadata} = this.props;
+        const myfields = getFields(jiraIssueMetadata, this.state.projectKey, this.state.issueType);
+
+        const fieldsNotCovered = [];
+
+        Object.keys(myfields).forEach((key) => {
+            if (myfields[key].required) {
+                if ((!myfields[key].schema.custom && !this.allowedFields.includes(key)) ||
+                     (myfields[key].schema.custom && !this.allowedSchemaCustom.includes(myfields[key].schema.custom))
+                ) {
+                    if (!fieldsNotCovered.includes(key)) {
+                        // fieldsNotCovered.push([key, myfields[key].name]);
+                        fieldsNotCovered.push(myfields[key].name);
+                    }
+                }
+            }
+        });
+        return fieldsNotCovered;
+    }
+
     handleCreate = (e) => {
+        const requiredFieldsNotCovered = this.getFieldsNotCovered();
+
         if (e && e.preventDefault) {
             e.preventDefault();
         }
@@ -75,6 +118,7 @@ export default class CreateIssueModal extends PureComponent {
             current_team: this.props.currentTeam.name,
             fields: this.state.fields,
             channel_id: channelId,
+            required_fields_not_covered: requiredFieldsNotCovered,
         };
 
         this.setState({submitting: true});
@@ -191,6 +235,8 @@ export default class CreateIssueModal extends PureComponent {
                         fields={getFields(jiraIssueMetadata, this.state.projectKey, this.state.issueType)}
                         onChange={this.handleFieldChange}
                         values={this.state.fields}
+                        allowedFields={this.allowedFields}
+                        allowedSchemaCustom={this.allowedSchemaCustom}
                         theme={theme}
                     />
                     <br/>


### PR DESCRIPTION
…dditional fields (#119)

* - new prop in json object tells server to post link to create issue page
  in jira.
- getFieldsNotCovered() determines if any required Jira fields are
  outside realm of fields and returns array of fieldnames not
  supported
  - compares jirametadata fields to hardcoded list of fieldnames
    currently supported
  - currently passes arrays as props to jiraFields. will remove
- Issue with adding jiraIssue Struct as encoded query in link
  - query attributes are Capitalized and link requires lower case.
    (mostly). example Priority needs to be priority
  - write / find something to convert all struct keys to
    lowercase
  - can hardcode to get current set of supported fields working and fix
    in Jira 2.1
  - Link is posting to MM, but query params need to be automated
    - trying to use populated jiraIssue struct

* fill query string from allowed fields for now
  - refactor to its own function

* Small clean up and nit fix from review
Break up if statement for custom fields and allowed field names. Was
easier for debugging

* - convert message to ephemeral post when user non handled required fields
  are found
- add non-handled required fields as list in message

* for ephemeeral message, bost as Jira Bot, not system

* Remove extra period after colon

* Get botUserId through getConfig Method, not actual field name (conf)

* remove console.log.  Was causing make test / build failure