### PR TITLE
[MM-16404] Fix Error Handling for Attach and Create issue Modals

### DIFF
--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -44,10 +44,11 @@ export default class JiraIssueSelector extends Component {
         const textSearchTerm = (textEncoded.length > 0) ? 'text ~ "' + textEncoded + '*"' : '';
         const finalQuery = textSearchTerm + ' ' + searchDefaults;
 
-        return doFetchWithResponse(this.props.fetchIssuesEndpoint + `?jql=${finalQuery}`).then(
-            ({data}) => {
-                return data;
-            });
+        doFetchWithResponse(this.props.fetchIssuesEndpoint + `?jql=${finalQuery}`).then(({data}) => {
+            return data;
+        }).catch((e) => {
+            this.setState({error: e});
+        });
     };
 
     debouncedSearchIssues = debounce(this.searchIssues, searchDebounceDelay);
@@ -64,7 +65,6 @@ export default class JiraIssueSelector extends Component {
 
     render = () => {
         const {error} = this.props;
-
         const requiredStar = (
             <span
                 className={'error-text'}
@@ -83,6 +83,20 @@ export default class JiraIssueSelector extends Component {
             );
         }
 
+        const serverError = this.state.error;
+        let errComponent;
+        if (this.state.error) {
+            errComponent = (
+                <p className='alert alert-danger'>
+                    <i
+                        className='fa fa-warning'
+                        title='Warning Icon'
+                    />
+                    <span> {serverError.toString()}</span>
+                </p>
+            );
+        }
+
         const requiredMsg = 'This field is required.';
         let validationError = null;
         if (this.props.required && this.state.invalid) {
@@ -95,6 +109,7 @@ export default class JiraIssueSelector extends Component {
 
         return (
             <div className={'form-group margin-bottom x3'}>
+                {errComponent}
                 <label
                     className={'control-label'}
                     htmlFor={'issue'}

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -27,6 +27,7 @@ const initialState = {
         },
     },
     error: null,
+    getMetaDataError: null,
 };
 
 export default class CreateIssueModal extends PureComponent {
@@ -34,8 +35,6 @@ export default class CreateIssueModal extends PureComponent {
         close: PropTypes.func.isRequired,
         create: PropTypes.func.isRequired,
         post: PropTypes.object,
-        description: PropTypes.string,
-        channelId: PropTypes.string,
         currentTeam: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         visible: PropTypes.bool.isRequired,
@@ -66,14 +65,13 @@ export default class CreateIssueModal extends PureComponent {
 
     componentDidUpdate(prevProps) {
         if (this.props.post && (!prevProps.post || this.props.post.id !== prevProps.post.id)) {
-            this.props.fetchJiraIssueMetadata();
+            this.props.fetchJiraIssueMetadata().then((fetched) => {
+                if (fetched.error) {
+                    this.setState({getMetaDataError: fetched.error.message, submitting: false});
+                }
+            });
             const fields = {...this.state.fields};
             fields.description = this.props.post.message;
-            this.setState({fields}); //eslint-disable-line react/no-did-update-set-state
-        } else if (this.props.channelId && (this.props.channelId !== prevProps.channelId || this.props.description !== prevProps.description)) {
-            this.props.fetchJiraIssueMetadata();
-            const fields = {...this.state.fields};
-            fields.description = this.props.description;
             this.setState({fields}); //eslint-disable-line react/no-did-update-set-state
         }
     }
@@ -124,9 +122,6 @@ export default class CreateIssueModal extends PureComponent {
             e.preventDefault();
         }
 
-        const {post, channelId} = this.props;
-        const postId = (post) ? post.id : '';
-
         if (!this.validator.validate()) {
             return;
         }
@@ -134,10 +129,9 @@ export default class CreateIssueModal extends PureComponent {
         const requiredFieldsNotCovered = this.getFieldsNotCovered();
 
         const issue = {
-            post_id: postId,
+            post_id: this.props.post.id,
             current_team: this.props.currentTeam.name,
             fields: this.state.fields,
-            channel_id: channelId,
             required_fields_not_covered: requiredFieldsNotCovered,
         };
 
@@ -211,28 +205,22 @@ export default class CreateIssueModal extends PureComponent {
 
     render() {
         const {post, visible, theme, jiraIssueMetadata} = this.props;
-        const {error, submitting} = this.state;
+        const {error, getMetaDataError, submitting} = this.state;
         const style = getStyle(theme);
 
         if (!visible) {
             return null;
         }
 
-        let issueError = null;
-        if (error) {
-            issueError = (
-                <React.Fragment>
-                    <p className='alert alert-danger'>
-                        <i
-                            className='fa fa-warning'
-                            title='Warning Icon'
-                        />
-                        <span> {error}</span>
-                    </p>
-                </React.Fragment>
-            );
-        }
-        let component;
+        const footerClose = (
+            <FormButton
+                type='submit'
+                btnClass='btn btn-primary'
+                defaultMessage='Close'
+                onClick={this.handleClose}
+            />
+        );
+
         let footer = (
             <React.Fragment>
                 <FormButton
@@ -251,23 +239,46 @@ export default class CreateIssueModal extends PureComponent {
             </React.Fragment>
         );
 
-        if (jiraIssueMetadata && jiraIssueMetadata.error) {
+        let issueError = null;
+        let component;
+
+        // if no getMetaDataError, show fields and allow user to input
+        // fields. An error at this point is from a server-side create
+        // issue submission and should be displayed (in addition to fields)
+        // to the user after clicking the create button.
+        if (error) {
+            issueError = (
+                <p className='alert alert-danger'>
+                    <i
+                        className='fa fa-warning'
+                        title='Warning Icon'
+                    />
+                    <span> {error}</span>
+                </p>
+            );
+        }
+
+        // if getmetadata fails, only display the error and a close button.
+        // user is not going to be able to create a ticket or even a partial
+        // ticket. likely a permissions error.
+        if (getMetaDataError) {
+            component = (
+                <p className='alert alert-danger'>
+                    <i
+                        className='fa fa-warning'
+                        title='Warning Icon'
+                    />
+                    <span> {getMetaDataError}</span>
+                </p>
+            );
+            footer = footerClose;
+        } else if (jiraIssueMetadata && jiraIssueMetadata.error) {
             component = (
                 <div style={style.modal}>
                     {jiraIssueMetadata.error}
                 </div>
             );
-
-            footer = (
-                <React.Fragment>
-                    <FormButton
-                        type='submit'
-                        btnClass='btn btn-primary'
-                        defaultMessage='Close'
-                        onClick={this.handleClose}
-                    />
-                </React.Fragment>
-            );
+            footer = footerClose;
         } else if (!post || !jiraIssueMetadata || !jiraIssueMetadata.projects) {
             component = <Loading/>;
         } else {

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -35,6 +35,8 @@ export default class CreateIssueModal extends PureComponent {
         close: PropTypes.func.isRequired,
         create: PropTypes.func.isRequired,
         post: PropTypes.object,
+        description: PropTypes.string,
+        channelId: PropTypes.string,
         currentTeam: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         visible: PropTypes.bool.isRequired,
@@ -72,6 +74,11 @@ export default class CreateIssueModal extends PureComponent {
             });
             const fields = {...this.state.fields};
             fields.description = this.props.post.message;
+            this.setState({fields}); //eslint-disable-line react/no-did-update-set-state
+        } else if (this.props.channelId && (this.props.channelId !== prevProps.channelId || this.props.description !== prevProps.description)) {
+            this.props.fetchJiraIssueMetadata();
+            const fields = {...this.state.fields};
+            fields.description = this.props.description;
             this.setState({fields}); //eslint-disable-line react/no-did-update-set-state
         }
     }
@@ -122,6 +129,9 @@ export default class CreateIssueModal extends PureComponent {
             e.preventDefault();
         }
 
+        const {post, channelId} = this.props;
+        const postId = (post) ? post.id : '';
+
         if (!this.validator.validate()) {
             return;
         }
@@ -129,9 +139,10 @@ export default class CreateIssueModal extends PureComponent {
         const requiredFieldsNotCovered = this.getFieldsNotCovered();
 
         const issue = {
-            post_id: this.props.post.id,
+            post_id: postId,
             current_team: this.props.currentTeam.name,
             fields: this.state.fields,
+            channel_id: channelId,
             required_fields_not_covered: requiredFieldsNotCovered,
         };
 


### PR DESCRIPTION
#### Summary 

This PR address error handling for create and attach issue modals

### Create Issue Modal
In the event the `/api/v2/get-create-issue-metadata` endpoint returns an error, the create issue modal will only show the error and a close button.
![image](https://user-images.githubusercontent.com/7575921/59892680-ab07a980-939f-11e9-8a51-aabc2a5e0385.png)

In the event createIssue API call to Atlassian fails, show the error, but keep the modal open and allow user to resolve the issue.
![image](https://user-images.githubusercontent.com/7575921/59892756-089bf600-93a0-11e9-8f68-bf4399fe6b56.png)

### Attach Issue Modal
Server-side errors are now shown above the `Jira Issue` drop down.  These are errors which would return from the '/api/v2/get-search-issues` endpoint.

![image](https://user-images.githubusercontent.com/7575921/59892459-c2926280-939e-11e9-8e67-b278683c2152.png)

#### Testing

Testing a an error from create issue API call is easy to test.  Using the summary field, add text >255 characters.

For the failed endpoints below, I am not sure how to test these or force these errors.  I manually added a return statement with a failure message for each.
 '/api/v2/get-search-issues`
`/api/v2/get-create-issue-metadata`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16404