### PR TITLE
[MM-16528] Currently selected options in single select list are not highlighted

### DIFF
--- a/webapp/src/utils/styles.js
+++ b/webapp/src/utils/styles.js
@@ -31,7 +31,7 @@ export const getStyleForReactSelect = (theme) => {
         }),
         option: (provided, state) => ({
             ...provided,
-            background: state.isSelected ? changeOpacity(theme.centerChannelColor, 0.12) : theme.centerChannelBg,
+            background: state.isFocused ? changeOpacity(theme.centerChannelColor, 0.12) : theme.centerChannelBg,
             color: theme.centerChannelColor,
             '&:hover': {
                 background: changeOpacity(theme.centerChannelColor, 0.12),


### PR DESCRIPTION
#### Summary
- Tracked the problem down to CSS. 
- One word change fixes it.

Asaad: 
- Would this break how you expect the UX to work? We're not highlighting the item that's already selected (the one already in the text area of the select box) we're highlighting the item that they are hovering over or currently cursoring through.

#### Links
- Fixes [MM-16528](https://mattermost.atlassian.net/browse/MM-16528)