### PR TITLE
[MM-16508] Fixes notifications on master; and for Jira Cloud's recent changes

### DIFF
--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/andygrunwald/go-jira"
-	"github.com/dgrijalva/jwt-go"
+	jira "github.com/andygrunwald/go-jira"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -60,6 +60,8 @@ func httpACUserInteractive(jci *jiraCloudInstance, w http.ResponseWriter, r *htt
 	if !ok {
 		return http.StatusBadRequest, errors.New("invalid JWT: no user data")
 	}
+
+	accountId, _ := user["accountId"].(string)
 	userKey, _ := user["userKey"].(string)
 	username, _ := user["username"].(string)
 	displayName, _ := user["displayName"].(string)
@@ -67,8 +69,14 @@ func httpACUserInteractive(jci *jiraCloudInstance, w http.ResponseWriter, r *htt
 	mmToken := r.Form.Get(argMMToken)
 	uinfo := JIRAUser{
 		User: jira.User{
-			Key:  userKey,
-			Name: username,
+			AccountID:   accountId,
+			Key:         userKey,
+			Name:        username,
+			DisplayName: displayName,
+		},
+		// Set default settings the first time a user connects
+		Settings: &UserSettings{
+			Notifications: true,
 		},
 	}
 	mattermostUserId := r.Header.Get("Mattermost-User-ID")

--- a/server/utils.go
+++ b/server/utils.go
@@ -41,8 +41,7 @@ func normalizeInstallURL(jiraURL string) (string, error) {
 	return strings.TrimSuffix(u.String(), "/"), nil
 }
 
-func (p *Plugin) CreateBotDMPost(ji Instance, userId, message,
-	postType string) (post *model.Post, returnErr error) {
+func (p *Plugin) CreateBotDMPost(ji Instance, userId, message, postType string) (post *model.Post, returnErr error) {
 	defer func() {
 		if returnErr != nil {
 			returnErr = errors.WithMessage(returnErr,
@@ -71,12 +70,6 @@ func (p *Plugin) CreateBotDMPost(ji Instance, userId, message,
 		ChannelId: channel.Id,
 		Message:   message,
 		Type:      postType,
-		Props: map[string]interface{}{
-			"from_webhook":      "true",
-			"override_username": botUserName,
-			// TODO: to be fixed in MM-16508
-			//"override_icon_url": pluginIconURL(),
-		},
 	}
 
 	_, appErr = p.API.CreatePost(post)

--- a/server/webhook_http.go
+++ b/server/webhook_http.go
@@ -126,9 +126,9 @@ func httpWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	wh.PostNotifications(p, ji)
+	_, statusCode, err := wh.PostNotifications(p, ji)
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return statusCode, err
 	}
 
 	// Skip events we don't need to post
@@ -137,7 +137,7 @@ func httpWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error)
 	}
 
 	// Post the event to the subscribed channel
-	_, statusCode, err := wh.PostToChannel(p, channel.Id, p.getUserID())
+	_, statusCode, err = wh.PostToChannel(p, channel.Id, p.getUserID())
 	if err != nil {
 		return statusCode, err
 	}


### PR DESCRIPTION
#### Summary
- Jira Cloud will only send accountID soon, so start mapping that to MattermostID in the store
- send notifications based on either username (Server) or accountId (Cloud)
- fix notifications on master
- Requires users to disconnect and connect for us to map the accountId -> MattermostID

#### Links
- Fixes [MM-16508](https://mattermost.atlassian.net/browse/MM-16508)