### PR TITLE
[MM-15902] When `/jira install` changes the instance, the UI is stuck in the previous state

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -166,6 +166,7 @@ export const fetchChannelSubscriptions = (channelId) => {
         return {data};
     };
 };
+
 export function getSettings(getState) {
     let data;
     const baseUrl = getPluginServerRoute(getState());
@@ -236,6 +237,9 @@ export const closeChannelSettings = () => {
 
 export function handleInstanceStatusChange(store) {
     return (msg) => {
+        // Update the user's UI state when the instance state changes
+        getConnected()(store.dispatch, store.getState);
+
         if (!msg.data) {
             return;
         }


### PR DESCRIPTION
#### Summary
- Problem: Using "/Jira install" to replace the current Jira instance causes incorrect post menu options in Mattermost client
- Solution: send a getConnected request when the instance state changes

#### Links
- Fixes [MM-15902](https://mattermost.atlassian.net/browse/MM-15902)