### PR TITLE
[MM-16108] streamlined createIssueMetadata to support 5000+ projects

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -18,7 +18,8 @@ import (
 
 const (
 	routeAPICreateIssue            = "/api/v2/create-issue"
-	routeAPIGetCreateIssueMetadata = "/api/v2/get-create-issue-metadata"
+	routeAPIGetCreateIssueMetadata = "/api/v2/get-create-issue-metadata-for-project"
+	routeAPIGetJiraProjectMetadata = "/api/v2/get-jira-project-metadata"
 	routeAPIGetSearchIssues        = "/api/v2/get-search-issues"
 	routeAPIAttachCommentToIssue   = "/api/v2/attach-comment-to-issue"
 	routeAPIUserInfo               = "/api/v2/userinfo"
@@ -56,7 +57,9 @@ func handleHTTPRequest(p *Plugin, w http.ResponseWriter, r *http.Request) (int, 
 	case routeAPICreateIssue:
 		return withInstance(p.currentInstanceStore, w, r, httpAPICreateIssue)
 	case routeAPIGetCreateIssueMetadata:
-		return withInstance(p.currentInstanceStore, w, r, httpAPIGetCreateIssueMetadata)
+		return withInstance(p.currentInstanceStore, w, r, httpAPIGetCreateIssueMetadataForProject)
+	case routeAPIGetJiraProjectMetadata:
+		return withInstance(p.currentInstanceStore, w, r, httpAPIGetJiraProjectMetadata)
 	case routeAPIGetSearchIssues:
 		return withInstance(p.currentInstanceStore, w, r, httpAPIGetSearchIssues)
 	case routeAPIAttachCommentToIssue:

--- a/server/issue.go
+++ b/server/issue.go
@@ -336,36 +336,33 @@ func httpAPIGetJiraProjectMetadata(ji Instance, w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", "application/json")
 
-	type issueType struct {
-		Value string `json:"value"`
-		Label string `json:"label"`
-	}
-	type project struct {
+	// Generic option, used in the options list in react-select
+	type option struct {
 		Value string `json:"value"`
 		Label string `json:"label"`
 	}
 	type projectMetadata struct {
-		Projects          []project              `json:"projects"`
-		IssuesPerProjects map[string][]issueType `json:"issues_per_project"`
+		Projects          []option            `json:"projects"`
+		IssuesPerProjects map[string][]option `json:"issues_per_project"`
 	}
 
 	var bb []byte
 	if len(cimd.Projects) == 0 {
 		bb = []byte(`{"error": "You do not have permission to create issues in any projects. Please contact your Jira admin."}`)
 	} else {
-		projects := make([]project, 0, len(cimd.Projects))
-		issues := make(map[string][]issueType, len(cimd.Projects))
+		projects := make([]option, 0, len(cimd.Projects))
+		issues := make(map[string][]option, len(cimd.Projects))
 		for _, prj := range cimd.Projects {
-			projects = append(projects, project{
+			projects = append(projects, option{
 				Value: prj.Key,
 				Label: prj.Name,
 			})
-			issueTypes := make([]issueType, 0, len(prj.IssueTypes))
+			issueTypes := make([]option, 0, len(prj.IssueTypes))
 			for _, issue := range prj.IssueTypes {
 				if issue.Subtasks {
 					continue
 				}
-				issueTypes = append(issueTypes, issueType{
+				issueTypes = append(issueTypes, option{
 					Value: issue.Id,
 					Label: issue.Name,
 				})

--- a/server/issue.go
+++ b/server/issue.go
@@ -239,7 +239,70 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	return http.StatusOK, nil
 }
 
-func httpAPIGetCreateIssueMetadata(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
+func httpAPIGetCreateIssueMetadataForProject(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
+	if r.Method != http.MethodGet {
+		return http.StatusMethodNotAllowed,
+			errors.New("Request: " + r.Method + " is not allowed, must be GET")
+	}
+
+	mattermostUserId := r.Header.Get("Mattermost-User-Id")
+	if mattermostUserId == "" {
+		return http.StatusUnauthorized, errors.New("not authorized")
+	}
+
+	projectKey := r.FormValue("project-key")
+	if projectKey == "" {
+		return http.StatusBadRequest, errors.New("project-key query param is required")
+	}
+
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	jiraClient, err := ji.GetJIRAClient(jiraUser)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	cimd, resp, err := jiraClient.Issue.GetCreateMetaWithOptions(&jira.GetQueryOptions{
+		Expand:      "projects.issuetypes.fields",
+		ProjectKeys: projectKey,
+	})
+	if err != nil {
+		message := "failed to get CreateIssue metadata"
+		if resp != nil {
+			bb, _ := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			message += ", details:" + string(bb)
+		}
+		return http.StatusInternalServerError,
+			errors.WithMessage(err, message)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	var bb []byte
+	if len(cimd.Projects) == 0 {
+		bb = []byte(`{"error": "You do not have permission to create issues in that project. Please contact your Jira admin."}`)
+	} else {
+		bb, err = json.Marshal(cimd)
+		if err != nil {
+			return http.StatusInternalServerError,
+				errors.WithMessage(err, "failed to marshal response")
+		}
+	}
+
+	_, err = w.Write(bb)
+	if err != nil {
+		return http.StatusInternalServerError,
+			errors.WithMessage(err, "failed to write response")
+	}
+
+	return http.StatusOK, nil
+}
+
+func httpAPIGetJiraProjectMetadata(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
 	if r.Method != http.MethodGet {
 		return http.StatusMethodNotAllowed,
 			errors.New("Request: " + r.Method + " is not allowed, must be GET")
@@ -260,9 +323,7 @@ func httpAPIGetCreateIssueMetadata(ji Instance, w http.ResponseWriter, r *http.R
 		return http.StatusInternalServerError, err
 	}
 
-	cimd, resp, err := jiraClient.Issue.GetCreateMetaWithOptions(&jira.GetQueryOptions{
-		Expand: "projects.issuetypes.fields",
-	})
+	cimd, resp, err := jiraClient.Issue.GetCreateMetaWithOptions(nil)
 	if err != nil {
 		message := "failed to get CreateIssue metadata"
 		if resp != nil {
@@ -270,26 +331,61 @@ func httpAPIGetCreateIssueMetadata(ji Instance, w http.ResponseWriter, r *http.R
 			resp.Body.Close()
 			message += ", details:" + string(bb)
 		}
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, message)
+		return http.StatusInternalServerError, errors.WithMessage(err, message)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+
+	type issueType struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	}
+	type project struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	}
+	type projectMetadata struct {
+		Projects          []project              `json:"projects"`
+		IssuesPerProjects map[string][]issueType `json:"issues_per_project"`
+	}
 
 	var bb []byte
 	if len(cimd.Projects) == 0 {
 		bb = []byte(`{"error": "You do not have permission to create issues in any projects. Please contact your Jira admin."}`)
 	} else {
-		bb, err = json.Marshal(cimd)
+		projects := make([]project, 0, len(cimd.Projects))
+		issues := make(map[string][]issueType, len(cimd.Projects))
+		for _, prj := range cimd.Projects {
+			projects = append(projects, project{
+				Value: prj.Key,
+				Label: prj.Name,
+			})
+			issueTypes := make([]issueType, 0, len(prj.IssueTypes))
+			for _, issue := range prj.IssueTypes {
+				if issue.Subtasks {
+					continue
+				}
+				issueTypes = append(issueTypes, issueType{
+					Value: issue.Id,
+					Label: issue.Name,
+				})
+			}
+			issues[prj.Key] = issueTypes
+		}
+		payload := projectMetadata{
+			Projects:          projects,
+			IssuesPerProjects: issues,
+		}
+
+		bb, err = json.Marshal(payload)
 		if err != nil {
-			return http.StatusInternalServerError,
-				errors.WithMessage(err, "failed to marshal response")
+			return http.StatusInternalServerError, errors.WithMessage(err, "failed to marshal response")
 		}
 	}
+
 	_, err = w.Write(bb)
 	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to write response")
+		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
 
 	return http.StatusOK, nil

--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -15,6 +15,8 @@ export default {
     RECEIVED_INSTANCE_STATUS: `${PluginId}_instance_status`,
 
     RECEIVED_JIRA_ISSUE_METADATA: `${PluginId}_received_metadata`,
+    RECEIVED_JIRA_PROJECT_METADATA: `${PluginId}_received_projects`,
+    CLEAR_JIRA_ISSUE_METADATA: `${PluginId}_clear_metadata`,
 
     OPEN_CHANNEL_SETTINGS: `${PluginId}_open_channel_settings`,
     CLOSE_CHANNEL_SETTINGS: `${PluginId}_close_channel_settings`,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -46,12 +46,12 @@ export const closeAttachCommentToIssueModal = () => {
     };
 };
 
-export const fetchJiraIssueMetadata = () => {
+export const fetchJiraIssueMetadataForProject = (projectKey) => {
     return async (dispatch, getState) => {
         const baseUrl = getPluginServerRoute(getState());
         let data = null;
         try {
-            data = await doFetch(`${baseUrl}/api/v2/get-create-issue-metadata`, {
+            data = await doFetch(`${baseUrl}/api/v2/get-create-issue-metadata-for-project?project-key=${projectKey}`, {
                 method: 'get',
             });
         } catch (error) {
@@ -60,6 +60,33 @@ export const fetchJiraIssueMetadata = () => {
 
         dispatch({
             type: ActionTypes.RECEIVED_JIRA_ISSUE_METADATA,
+            data,
+        });
+
+        return {data};
+    };
+};
+
+export const clearIssueMetadata = () => {
+    return async (dispatch) => {
+        dispatch({type: ActionTypes.CLEAR_JIRA_ISSUE_METADATA});
+    };
+};
+
+export const fetchJiraProjectMetadata = () => {
+    return async (dispatch, getState) => {
+        const baseUrl = getPluginServerRoute(getState());
+        let data = null;
+        try {
+            data = await doFetch(`${baseUrl}/api/v2/get-jira-project-metadata`, {
+                method: 'get',
+            });
+        } catch (error) {
+            return {error};
+        }
+
+        dispatch({
+            type: ActionTypes.RECEIVED_JIRA_PROJECT_METADATA,
             data,
         });
 

--- a/webapp/src/components/modals/channel_settings/channel_settings.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.jsx
@@ -14,25 +14,28 @@ export default class ChannelSettingsModal extends PureComponent {
         close: PropTypes.func.isRequired,
         channel: PropTypes.object,
         channelSubscriptions: PropTypes.array,
-        jiraIssueMetadata: PropTypes.object,
-        fetchJiraIssueMetadata: PropTypes.func.isRequired,
+        jiraProjectMetadata: PropTypes.object,
+        fetchJiraProjectMetadata: PropTypes.func.isRequired,
         fetchChannelSubscriptions: PropTypes.func.isRequired,
-    }
+    };
+
     componentDidUpdate(prevProps) {
         if (this.props.channel && (!prevProps.channel || this.props.channel.id !== prevProps.channel.id)) {
-            this.props.fetchJiraIssueMetadata();
+            this.props.fetchJiraProjectMetadata();
             this.props.fetchChannelSubscriptions(this.props.channel.id);
         }
     }
+
     handleClose = (e) => {
         if (e && e.preventDefault) {
             e.preventDefault();
         }
         this.props.close();
     };
+
     render() {
         let inner = <Loading/>;
-        if (this.props.channelSubscriptions && this.props.jiraIssueMetadata) {
+        if (this.props.channelSubscriptions && this.props.jiraProjectMetadata) {
             inner = (
                 <ChannelSettingsModalInner
                     {...this.props}

--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
@@ -21,7 +21,7 @@ export default class ChannelSettingsModalInner extends PureComponent {
         close: PropTypes.func.isRequired,
         channel: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
-        jiraIssueMetadata: PropTypes.object.isRequired,
+        jiraProjectMetadata: PropTypes.object.isRequired,
         channelSubscriptions: PropTypes.array.isRequired,
         createChannelSubscription: PropTypes.func.isRequired,
         deleteChannelSubscription: PropTypes.func.isRequired,
@@ -102,8 +102,8 @@ export default class ChannelSettingsModalInner extends PureComponent {
 
     render() {
         const style = getStyle(this.props.theme);
-        const projectOptions = getProjectValues(this.props.jiraIssueMetadata);
-        const issueOptions = getIssueValuesForMultipleProjects(this.props.jiraIssueMetadata, this.state.filters.project);
+        const projectOptions = getProjectValues(this.props.jiraProjectMetadata);
+        const issueOptions = getIssueValuesForMultipleProjects(this.props.jiraProjectMetadata, this.state.filters.project);
 
         let component = null;
         if (this.props.channel && this.props.channelSubscriptions) {

--- a/webapp/src/components/modals/channel_settings/index.js
+++ b/webapp/src/components/modals/channel_settings/index.js
@@ -6,8 +6,8 @@ import {bindActionCreators} from 'redux';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
-import {createChannelSubscription, fetchChannelSubscriptions, deleteChannelSubscription, editChannelSubscription, closeChannelSettings, fetchJiraIssueMetadata} from 'actions';
-import {getChannelSubscriptions, getChannelIdWithSettingsOpen, getJiraIssueMetadata} from 'selectors';
+import {createChannelSubscription, fetchChannelSubscriptions, deleteChannelSubscription, editChannelSubscription, closeChannelSettings, fetchJiraProjectMetadata} from 'actions';
+import {getChannelSubscriptions, getChannelIdWithSettingsOpen, getJiraProjectMetadata} from 'selectors';
 
 import ChannelSettingsModal from './channel_settings';
 
@@ -19,20 +19,20 @@ const mapStateToProps = (state) => {
         channel = getChannel(state, channelId);
     }
 
-    const jiraIssueMetadata = getJiraIssueMetadata(state);
+    const jiraProjectMetadata = getJiraProjectMetadata(state);
 
     const channelSubscriptions = getChannelSubscriptions(state)[channelId];
 
     return {
         channelSubscriptions,
         channel,
-        jiraIssueMetadata,
+        jiraProjectMetadata,
     };
 };
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     close: closeChannelSettings,
-    fetchJiraIssueMetadata,
+    fetchJiraProjectMetadata,
     createChannelSubscription,
     fetchChannelSubscriptions,
     deleteChannelSubscription,

--- a/webapp/src/components/modals/create_issue/index.js
+++ b/webapp/src/components/modals/create_issue/index.js
@@ -7,8 +7,8 @@ import {bindActionCreators} from 'redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
-import {closeCreateModal, createIssue, fetchJiraIssueMetadata} from 'actions';
-import {isCreateModalVisible, getCreateModal, getJiraIssueMetadata} from 'selectors';
+import {closeCreateModal, createIssue, fetchJiraIssueMetadataForProject, fetchJiraProjectMetadata, clearIssueMetadata} from 'actions';
+import {isCreateModalVisible, getCreateModal, getJiraIssueMetadata, getJiraProjectMetadata} from 'selectors';
 
 import CreateIssue from './create_issue';
 
@@ -18,10 +18,12 @@ const mapStateToProps = (state) => {
     const currentTeam = getCurrentTeam(state);
 
     const jiraIssueMetadata = getJiraIssueMetadata(state);
+    const jiraProjectMetadata = getJiraProjectMetadata(state);
 
     return {
         visible: isCreateModalVisible(state),
         jiraIssueMetadata,
+        jiraProjectMetadata,
         post,
         description,
         channelId,
@@ -32,7 +34,9 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     close: closeCreateModal,
     create: createIssue,
-    fetchJiraIssueMetadata,
+    fetchJiraIssueMetadataForProject,
+    fetchJiraProjectMetadata,
+    clearIssueMetadata,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateIssue);

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -82,6 +82,17 @@ const jiraIssueMetadata = (state = null, action) => {
     switch (action.type) {
     case ActionTypes.RECEIVED_JIRA_ISSUE_METADATA:
         return action.data;
+    case ActionTypes.CLEAR_JIRA_ISSUE_METADATA:
+        return null;
+    default:
+        return state;
+    }
+};
+
+const jiraProjectMetadata = (state = null, action) => {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_JIRA_PROJECT_METADATA:
+        return action.data;
     default:
         return state;
     }
@@ -118,6 +129,7 @@ export default combineReducers({
     attachCommentToIssueModalVisible,
     attachCommentToIssueModalForPostId,
     jiraIssueMetadata,
+    jiraProjectMetadata,
     channelIdWithSettingsOpen,
     channelSubscripitons,
 });

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -47,6 +47,8 @@ export const getAttachCommentToIssueModalForPostId = (state) => getPluginState(s
 
 export const getJiraIssueMetadata = (state) => getPluginState(state).jiraIssueMetadata;
 
+export const getJiraProjectMetadata = (state) => getPluginState(state).jiraProjectMetadata;
+
 export const getChannelIdWithSettingsOpen = (state) => getPluginState(state).channelIdWithSettingsOpen;
 
 export const getChannelSubscriptions = (state) => getPluginState(state).channelSubscripitons;

--- a/webapp/src/utils/jira_issue_metadata.jsx
+++ b/webapp/src/utils/jira_issue_metadata.jsx
@@ -6,7 +6,7 @@ export function getProjectValues(metadata) {
         return [];
     }
 
-    return metadata.projects.map((p) => ({value: p.key, label: p.name}));
+    return metadata.projects;
 }
 
 export function getIssueTypes(metadata, projectKey) {
@@ -22,31 +22,12 @@ export function getIssueValues(metadata, projectKey) {
         return [];
     }
 
-    return getIssueTypes(metadata, projectKey).map((issueType) => ({value: issueType.id, label: issueType.name}));
+    return metadata.issues_per_project[projectKey];
 }
 
 export function getIssueValuesForMultipleProjects(metadata, projectKeys) {
     return projectKeys.map((project) =>
-        getIssueValues(metadata, project)).
-        flat().
-        sort((a, b) => a.value - b.value).
-        filter((ele, i, me) => i === 0 || ele.value !== me[i - 1].value);
-}
-
-export function getIssueTypesForMultipleProjects(metadata, projectKeys) {
-    return projectKeys.map((project) =>
-        getIssueTypes(metadata, project)).
-        flat().
-        sort((a, b) => a.id - b.id).
-        filter((ele, i, me) => i === 0 || ele.id !== me[i - 1].id);
-}
-
-export function getFieldsForMultipleProjects(metadata, projectKeys) {
-    if (!metadata || !projectKeys) {
-        return [];
-    }
-
-    return getIssueTypesForMultipleProjects(metadata, projectKeys).map((issue) => issue.fields).reduce((acc, cur) => Object.assign(acc, cur), {});
+        getIssueValues(metadata, project)).flat().filter(Boolean).sort((a, b) => a.value - b.value).filter((ele, i, me) => i === 0 || ele.value !== me[i - 1].value);
 }
 
 export function getFields(metadata, projectKey, issueTypeId) {


### PR DESCRIPTION
#### Summary

- From Jira we're requesting the minimum from the create-issue-metadata rest endpoint. Even that's pretty big, but we have to request it per user to see what projects the user can create issues in. On the server we're reducing that to pre-formatted value-label arrays for the projects and issues react-select dialog boxes. 
- Together, that reduces what's sent to client (from 113Mb to 885kb)
- When a user selects a project, that's when we request the full details of its fields. But that's pretty quick and there's a loading component for that brief wait.
  - eg: Switching to a new project will erase the old jiraIssueMetadata object in the store (which replaces the fields components with the loading component), request the selected project's metadata, and display the new fields when jiraIssueMetadata is updated.
- We're no longer filtering and mapping the projects or issue lists, because they're sent pre-formatted from the server. We're now waiting solely because (apparently) react-select is not designed to display lists of 5000 items. It's a little sluggish with that many.
- The channel subscription modal had to be edited as well. I am 90% sure it's working, but needs to be tested a bit more thoroughly to make sure the new metadatas aren't breaking it.

#### Links

[MM-16108](https://mattermost.atlassian.net/browse/MM-16108)