### PR TITLE
MM-16925: Fixed leaks of message bodies with jiraClient

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "jira",
   "name": "Jira",
   "description": "Atlassian Jira plugin for Mattermost.",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "jira",
-	Version: "2.0.6",
+	Version: "2.0.7",
 }

--- a/server/user_server.go
+++ b/server/user_server.go
@@ -70,10 +70,12 @@ func httpOAuth1Complete(jsi *jiraServerInstance, w http.ResponseWriter, r *http.
 		return http.StatusInternalServerError, err
 	}
 
-	juser, _, err := jiraClient.User.GetSelf()
+	juser, resp, err := jiraClient.User.GetSelf()
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
+	defer CloseJiraResponse(resp)
+
 	jiraUser.User = *juser
 	jiraUser.UserKey = juser.Name
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -49,3 +49,9 @@ func getUserURL(user *jira.User) string {
 	// TODO is this right?
 	return user.Self
 }
+
+func CloseJiraResponse(resp *jira.Response) {
+	if resp != nil && resp.Response != nil {
+		resp.Body.Close()
+	}
+}

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'jira';
-export const version = '2.0.6';
+export const version = '2.0.7';


### PR DESCRIPTION
Ticket: https://mattermost.atlassian.net/browse/MM-16925

Many Jira client APIs return a response object that we were throwing away or not Closing otherwise. That was likely a mistake. I am not sure that this was the cause of the customer-reported issue, but it appears to be a (significant) leak nonetheless.

cc @amyblais - I am leaving the decisions to the PMs, but we may want to put this in 5.13