### PR TITLE
MM-16881 Add ability to restrict permissions of subscribe.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -31,8 +31,8 @@
         "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations."
       },
       {
-        "key": "SubscriptionEditorsMattermostRoles",
-        "display_name": "Subscription Editors Mattermost Roles",
+        "key": "RolesAllowedToEditJiraSubscriptions",
+        "display_name": "Roles Allowed to Edit Jira Subscriptions",
         "type": "radio",
         "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
         "default": "system_admin",
@@ -56,8 +56,8 @@
         ]
       },
       {
-        "key": "SubscriptionEditorsJiraGroups",
-        "display_name": "Subscription Editors Jira Groups",
+        "key": "GroupsAllowedToEditJiraSubscriptions",
+        "display_name": "Groups Allowed to Edit Jira Subscriptions",
         "type": "text",
         "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
         "default": ""

--- a/plugin.json
+++ b/plugin.json
@@ -32,7 +32,7 @@
       },
       {
         "key": "RolesAllowedToEditJiraSubscriptions",
-        "display_name": "Roles Allowed to Edit Jira Subscriptions",
+        "display_name": "Mattermost Roles Allowed to Edit Jira Subscriptions",
         "type": "radio",
         "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
         "default": "system_admin",
@@ -57,7 +57,7 @@
       },
       {
         "key": "GroupsAllowedToEditJiraSubscriptions",
-        "display_name": "Groups Allowed to Edit Jira Subscriptions",
+        "display_name": "Jira Groups Allowed to Edit Jira Subscriptions",
         "type": "text",
         "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
         "default": ""

--- a/plugin.json
+++ b/plugin.json
@@ -28,13 +28,13 @@
         "display_name": "Webhook Secret",
         "type": "generated",
         "help_text": "The secret used to authenticate the webhook to Mattermost.",
-        "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations."
+        "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations."
       },
       {
         "key": "SubscriptionEditorsMattermostRoles",
         "display_name": "Subscription Editors Mattermost Roles",
         "type": "radio",
-        "help_text": "Mattermost users that can subscribe channels to jira tickets.",
+        "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
         "default": "system_admin",
         "options": [
             {
@@ -59,7 +59,7 @@
         "key": "SubscriptionEditorsJiraGroups",
         "display_name": "Subscription Editors Jira Groups",
         "type": "text",
-        "help_text": "Comma separated list of Group Names. List the JIRA user groups who can create subscriptions. If none are specified, any JIRA user can create a subscription.",
+        "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
         "default": ""
       }
     ],

--- a/plugin.json
+++ b/plugin.json
@@ -29,6 +29,38 @@
         "type": "generated",
         "help_text": "The secret used to authenticate the webhook to Mattermost.",
         "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations."
+      },
+      {
+        "key": "MattermostSubscriptionPermission",
+        "display_name": "Mattermost Subscription Permission",
+        "type": "radio",
+        "help_text": "Mattermost users that can subscribe channels to jira tickets.",
+        "default": "system_admin",
+        "options": [
+            {
+                "display_name": "All Users",
+                "value": "users"
+            },
+            {
+                "display_name": "Channel Admins",
+                "value": "channel_admin"
+            },
+            {
+                "display_name": "Team Admins",
+                "value": "team_admin"
+            },
+            {
+                "display_name": "System Administrators",
+                "value": "system_admin"
+            }
+        ]
+      },
+      {
+        "key": "JiraGroupsPermission",
+        "display_name": "JIRA Groups Permission",
+        "type": "text",
+        "help_text": "Comma separated list of jira groups who can create subscriptions. If empty, all jira groups can create subscriptions.",
+        "default": ""
       }
     ],
     "footer": "Use this webhook URL to set up the Jira integration. See [documentation](https://about.mattermost.com/default-jira-plugin) to learn more.\n\n`https://SITEURL/plugins/jira/webhook?secret=WEBHOOKSECRET&team=TEAMURL&channel=CHANNELURL`"

--- a/plugin.json
+++ b/plugin.json
@@ -31,8 +31,8 @@
         "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations."
       },
       {
-        "key": "MattermostSubscriptionPermission",
-        "display_name": "Mattermost Subscription Permission",
+        "key": "SubscriptionEditorsMattermostRoles",
+        "display_name": "Subscription Editors Mattermost Roles",
         "type": "radio",
         "help_text": "Mattermost users that can subscribe channels to jira tickets.",
         "default": "system_admin",
@@ -56,10 +56,10 @@
         ]
       },
       {
-        "key": "JiraGroupsPermission",
-        "display_name": "JIRA Groups Permission",
+        "key": "SubscriptionEditorsJiraGroups",
+        "display_name": "Subscription Editors Jira Groups",
         "type": "text",
-        "help_text": "Comma separated list of jira groups who can create subscriptions. If empty, all jira groups can create subscriptions.",
+        "help_text": "Comma separated list of Group Names. List the JIRA user groups who can create subscriptions. If none are specified, any JIRA user can create a subscription.",
         "default": ""
       }
     ],

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -34,10 +34,10 @@ type externalConfig struct {
 	Secret string `json:"secret"`
 
 	// What MM roles that can create subscriptions
-	SubscriptionEditorsMattermostRoles string
+	RolesAllowedToEditJiraSubscriptions string
 
 	// Comma separated list of jira groups with permission. Empty is all.
-	SubscriptionEditorsJiraGroups string
+	GroupsAllowedToEditJiraSubscriptions string
 }
 
 const currentInstanceTTL = 1 * time.Second

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -32,6 +32,12 @@ type externalConfig struct {
 
 	// Legacy 1.x Webhook secret
 	Secret string `json:"secret"`
+
+	// What MM users can create subscriptions
+	MattermostSubscriptionPermission string
+
+	// Comma separated list of jira groups with permission. Empty is all.
+	JiraGroupsPermission string
 }
 
 const currentInstanceTTL = 1 * time.Second

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -33,11 +33,11 @@ type externalConfig struct {
 	// Legacy 1.x Webhook secret
 	Secret string `json:"secret"`
 
-	// What MM users can create subscriptions
-	MattermostSubscriptionPermission string
+	// What MM roles that can create subscriptions
+	SubscriptionEditorsMattermostRoles string
 
 	// Comma separated list of jira groups with permission. Empty is all.
-	JiraGroupsPermission string
+	SubscriptionEditorsJiraGroups string
 }
 
 const currentInstanceTTL = 1 * time.Second

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -283,7 +283,7 @@ func inAllowedGroup(inGroups []*jira.UserGroup, allowedGroups []string) bool {
 func (p *Plugin) hasPermissionToManageSubscription(userId, channelId string) error {
 	cfg := p.getConfig()
 
-	switch cfg.SubscriptionEditorsMattermostRoles {
+	switch cfg.RolesAllowedToEditJiraSubscriptions {
 	case "team_admin":
 		if !p.API.HasPermissionToChannel(userId, channelId, model.PERMISSION_MANAGE_TEAM) {
 			return errors.New("is not team admin")
@@ -312,7 +312,7 @@ func (p *Plugin) hasPermissionToManageSubscription(userId, channelId string) err
 		}
 	}
 
-	if cfg.SubscriptionEditorsJiraGroups != "" {
+	if cfg.GroupsAllowedToEditJiraSubscriptions != "" {
 		ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
 		if err != nil {
 			return errors.Wrap(err, "could not load jira instance")
@@ -341,7 +341,7 @@ func (p *Plugin) hasPermissionToManageSubscription(userId, channelId string) err
 			return errors.Wrap(err, "error in request to get user groups, body:"+string(body))
 		}
 
-		allowedGroups := strings.Split(cfg.SubscriptionEditorsJiraGroups, ",")
+		allowedGroups := strings.Split(cfg.GroupsAllowedToEditJiraSubscriptions, ",")
 		if !inAllowedGroup(groups, allowedGroups) {
 			return errors.New("not in allowed jira user groups")
 		}

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -7,9 +7,11 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
+	"github.com/andygrunwald/go-jira"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
 )
@@ -265,6 +267,86 @@ func (p *Plugin) editChannelSubscription(modifiedSubscription *ChannelSubscripti
 	})
 }
 
+func inAllowedGroup(inGroups []*jira.UserGroup, allowedGroups []string) bool {
+	for _, inGroup := range inGroups {
+		for _, allowedGroup := range allowedGroups {
+			if strings.TrimSpace(inGroup.Name) == strings.TrimSpace(allowedGroup) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasPermissionToManageSubscription checks if MM user has permission to manage subscriptions in given channel.
+// returns nil if the user has permission and a discriptive error otherwise.
+func (p *Plugin) hasPermissionToManageSubscription(userId, channelId string) error {
+	cfg := p.getConfig()
+
+	if cfg.MattermostSubscriptionPermission == "team_admin" {
+		if !p.API.HasPermissionToChannel(userId, channelId, model.PERMISSION_MANAGE_TEAM) {
+			return errors.New("is not team admin")
+		}
+	} else if cfg.MattermostSubscriptionPermission == "channel_admin" {
+		channel, appErr := p.API.GetChannel(channelId)
+		if appErr != nil {
+			return errors.Wrap(appErr, "unable to get channel to check permission")
+		}
+		if channel.Type == model.CHANNEL_OPEN {
+			if !p.API.HasPermissionToChannel(userId, channelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+				return errors.New("is not channel admin")
+			}
+		} else if channel.Type == model.CHANNEL_PRIVATE {
+			if !p.API.HasPermissionToChannel(userId, channelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+				return errors.New("is not channel admin")
+			}
+		} else {
+			return errors.New("can only subscribe in public and private channels")
+		}
+	} else if cfg.MattermostSubscriptionPermission != "users" {
+		if !p.API.HasPermissionTo(userId, model.PERMISSION_MANAGE_SYSTEM) {
+			return errors.New("is not system admin")
+		}
+	}
+
+	if cfg.JiraGroupsPermission != "" {
+		ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+		if err != nil {
+			return errors.Wrap(err, "could not load jira instance")
+		}
+
+		jiraUser, err := p.userStore.LoadJIRAUser(ji, userId)
+		if err != nil {
+			return errors.Wrap(err, "could not load jira user")
+		}
+
+		jiraClient, err := ji.GetJIRAClient(jiraUser)
+		if err != nil {
+			return errors.Wrap(err, "could not get jira client")
+		}
+
+		req, err := jiraClient.NewRequest("GET", "rest/api/3/user/groups?key="+jiraUser.Key, nil)
+		if err != nil {
+			return errors.Wrap(err, "error creating request")
+		}
+
+		var groups []*jira.UserGroup
+		resp, err := jiraClient.Do(req, &groups)
+		if err != nil {
+			body, _ := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			return errors.Wrap(err, "error in request to get user groups, body:"+string(body))
+		}
+
+		allowedGroups := strings.Split(cfg.JiraGroupsPermission, ",")
+		if !inAllowedGroup(groups, allowedGroups) {
+			return errors.New("not in allowed jira user groups")
+		}
+	}
+
+	return nil
+}
+
 func (p *Plugin) atomicModify(key string, modify func(initialValue []byte) ([]byte, error)) error {
 	readModify := func() ([]byte, []byte, error) {
 		initialBytes, appErr := p.API.KVGet(key)
@@ -341,12 +423,7 @@ func httpSubscribeWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (in
 	return http.StatusOK, nil
 }
 
-func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
-	mattermostUserId := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserId == "" {
-		return http.StatusUnauthorized, errors.New("not authorized")
-	}
-
+func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	subscription := ChannelSubscription{}
 	err := json.NewDecoder(r.Body).Decode(&subscription)
 	if err != nil {
@@ -362,6 +439,10 @@ func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
 	}
 
+	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
+	}
+
 	if err := p.addChannelSubscription(&subscription); err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -372,12 +453,7 @@ func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 	return http.StatusOK, nil
 }
 
-func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
-	mattermostUserId := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserId == "" {
-		return http.StatusUnauthorized, errors.New("not authorized")
-	}
-
+func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	subscription := ChannelSubscription{}
 	err := json.NewDecoder(r.Body).Decode(&subscription)
 	if err != nil {
@@ -387,6 +463,10 @@ func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Reque
 	if len(subscription.ChannelId) != 26 ||
 		len(subscription.Id) != 26 {
 		return http.StatusBadRequest, fmt.Errorf("Channel subscription invalid")
+	}
+
+	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
 	if _, err := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId); err != nil {
@@ -403,12 +483,7 @@ func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Reque
 	return http.StatusOK, nil
 }
 
-func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
-	mattermostUserId := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserId == "" {
-		return http.StatusUnauthorized, errors.New("not authorized")
-	}
-
+func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	subscriptionId := strings.TrimPrefix(r.URL.Path, routeAPISubscriptionsChannel+"/")
 	if len(subscriptionId) != 26 {
 		return http.StatusBadRequest, errors.New("bad subscription id")
@@ -417,6 +492,10 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 	subscription, err := p.getChannelSubscription(subscriptionId)
 	if err != nil {
 		return http.StatusBadRequest, errors.Wrap(err, "bad subscription id")
+	}
+
+	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
 	if _, err := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId); err != nil {
@@ -433,12 +512,7 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 	return http.StatusOK, nil
 }
 
-func httpChannelGetSubscriptions(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
-	mattermostUserId := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserId == "" {
-		return http.StatusUnauthorized, errors.New("not authorized")
-	}
-
+func httpChannelGetSubscriptions(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	channelId := strings.TrimPrefix(r.URL.Path, routeAPISubscriptionsChannel+"/")
 	if len(channelId) != 26 {
 		return http.StatusBadRequest, errors.New("bad channel id")
@@ -446,6 +520,10 @@ func httpChannelGetSubscriptions(p *Plugin, w http.ResponseWriter, r *http.Reque
 
 	if _, err := p.API.GetChannelMember(channelId, mattermostUserId); err != nil {
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
+	}
+
+	if err := p.hasPermissionToManageSubscription(mattermostUserId, channelId); err != nil {
+		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
 	subscriptions, err := p.getSubscriptionsForChannel(channelId)
@@ -465,15 +543,20 @@ func httpChannelGetSubscriptions(p *Plugin, w http.ResponseWriter, r *http.Reque
 }
 
 func httpChannelSubscriptions(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
+	mattermostUserId := r.Header.Get("Mattermost-User-Id")
+	if mattermostUserId == "" {
+		return http.StatusUnauthorized, errors.New("not authorized")
+	}
+
 	switch r.Method {
 	case http.MethodPost:
-		return httpChannelCreateSubscription(p, w, r)
+		return httpChannelCreateSubscription(p, w, r, mattermostUserId)
 	case http.MethodDelete:
-		return httpChannelDeleteSubscription(p, w, r)
+		return httpChannelDeleteSubscription(p, w, r, mattermostUserId)
 	case http.MethodGet:
-		return httpChannelGetSubscriptions(p, w, r)
+		return httpChannelGetSubscriptions(p, w, r, mattermostUserId)
 	case http.MethodPut:
-		return httpChannelEditSubscription(p, w, r)
+		return httpChannelEditSubscription(p, w, r, mattermostUserId)
 	default:
 		return http.StatusMethodNotAllowed, fmt.Errorf("Request: " + r.Method + " is not allowed.")
 	}

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -181,6 +181,11 @@ export const fetchChannelSubscriptions = (channelId) => {
                 method: 'get',
             });
         } catch (error) {
+            dispatch({
+                type: ActionTypes.RECEIVED_CHANNEL_SUBSCRIPTIONS,
+                channelId,
+                data: error,
+            });
             return {error};
         }
 

--- a/webapp/src/client/index.js
+++ b/webapp/src/client/index.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 export const doFetch = async (url, options) => {
     const {data} = await doFetchWithResponse(url, options);
@@ -28,5 +29,9 @@ export const doFetchWithResponse = async (url, options = {}) => {
 
     data = await response.text();
 
-    throw new Error(data);
+    throw new ClientError(Client4.url, {
+        message: data || '',
+        status_code: response.status,
+        url,
+    });
 };

--- a/webapp/src/components/modals/channel_settings/channel_settings.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.jsx
@@ -39,7 +39,7 @@ export default class ChannelSettingsModal extends PureComponent {
             if (this.props.channelSubscriptions instanceof Error) {
                 inner = (
                     <Modal.Body>
-                        {'You do not have permission to access Jira subscirptions in this channel.'}
+                        {'You do not have permission to access Jira subscriptions in this channel.'}
                     </Modal.Body>
                 );
             } else {

--- a/webapp/src/components/modals/channel_settings/channel_settings.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.jsx
@@ -36,11 +36,19 @@ export default class ChannelSettingsModal extends PureComponent {
     render() {
         let inner = <Loading/>;
         if (this.props.channelSubscriptions && this.props.jiraProjectMetadata) {
-            inner = (
-                <ChannelSettingsModalInner
-                    {...this.props}
-                />
-            );
+            if (this.props.channelSubscriptions instanceof Error) {
+                inner = (
+                    <Modal.Body>
+                        {'You do not have permission to access Jira subscirptions in this channel.'}
+                    </Modal.Body>
+                );
+            } else {
+                inner = (
+                    <ChannelSettingsModalInner
+                        {...this.props}
+                    />
+                );
+            }
         }
 
         return (


### PR DESCRIPTION
Implements these settings in the system console for JIRA:
![image](https://user-images.githubusercontent.com/3191642/61231827-c1c0c800-a6e1-11e9-9414-329b68b39223.png)

Shows this when you don't have permissions to manage:
![image](https://user-images.githubusercontent.com/3191642/61231884-e1f08700-a6e1-11e9-9ca7-b383c0dc1d66.png)

It's not ideal. When we implement the proper UI for this, we should show existing subscriptions, but restrict editing instead of just showing an error.
Hiding the button would be more work and may be a performance problem, so I avoided that.

@aaronrothschild Looking for PM review of the in the screenshots above.