### PR TITLE
MM-15927 ChangeLog parsing should scan and post all supported events (pt 2)

### DIFF
--- a/server/webhook_http.go
+++ b/server/webhook_http.go
@@ -38,6 +38,7 @@ const (
 	eventUpdatedStatus
 	eventUpdatedSummary
 	eventUpdatedIssuetype
+	eventUpdatedReporter
 )
 
 const maskLegacy = eventCreated |

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -164,7 +164,7 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue rank": {
 			Request:          testWebhookRequest("webhook-issue-updated-rank.json"),
-			ExpectedHeadline: "Test User updated Rank from \"\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User updated Rank from \"none\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue reopened": {
@@ -359,7 +359,7 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue rank - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-rank.json"),
-			ExpectedHeadline: "Test User updated Rank from \"\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User updated Rank from \"none\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue reopened - no Instance": {


### PR DESCRIPTION
#### Summary
- An update to #216 after @jasonblais pointed out another way multiple events can be sent (press edit on an issue).
- Added "reporter" changelog event
- Changed how description is formatted so it makes more sense (and a strikethrough won't work if there's markdown formatting in the description)

UX, looks like:
![image](https://user-images.githubusercontent.com/1490756/61251955-fce6e980-a729-11e9-8b3d-df52ea56b4dd.png)

#### Links
- [MM-15927](https://mattermost.atlassian.net/browse/MM-15927)
- updates: #216 
