### PR TITLE
[MM-16763] Delete subscription button added to channel subscription modal

### DIFF
--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -22,4 +22,5 @@ export default {
     CLOSE_CHANNEL_SETTINGS: `${PluginId}_close_channel_settings`,
 
     RECEIVED_CHANNEL_SUBSCRIPTIONS: `${PluginId}_recevied_channel_subscriptions`,
+    DELETED_CHANNEL_SUBSCRIPTION: `${PluginId}_deleted_channel_subscription`,
 };

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -157,15 +157,20 @@ export const editChannelSubscription = (subscription) => {
     };
 };
 
-export const deleteChannelSubscription = (subscriptionId) => {
+export const deleteChannelSubscription = (subscription) => {
     return async (dispatch, getState) => {
         const baseUrl = getPluginServerRoute(getState());
         try {
-            const data = await doFetch(`${baseUrl}/api/v2/subscriptions/channel/${subscriptionId}`, {
+            await doFetch(`${baseUrl}/api/v2/subscriptions/channel/${subscription.id}`, {
                 method: 'delete',
             });
 
-            return {data};
+            dispatch({
+                type: ActionTypes.DELETED_CHANNEL_SUBSCRIPTION,
+                data: subscription,
+            });
+
+            return {data: subscription};
         } catch (error) {
             return {error};
         }

--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
@@ -80,6 +80,14 @@ export default class ChannelSettingsModalInner extends PureComponent {
         this.setState({filters});
     };
 
+    deleteChannelSubscription = (e) => {
+        if (this.props.channelSubscriptions && this.props.channelSubscriptions.length > 0) {
+            const sub = this.props.channelSubscriptions[0];
+            this.props.deleteChannelSubscription(sub);
+        }
+        this.handleClose(e);
+    }
+
     handleCreate = (e) => {
         if (e && e.preventDefault) {
             e.preventDefault();
@@ -175,6 +183,8 @@ export default class ChannelSettingsModalInner extends PureComponent {
             );
         }
 
+        const showDeleteButton = Boolean(this.props.channelSubscriptions && this.props.channelSubscriptions.length > 0);
+
         return (
             <form
                 role='form'
@@ -187,13 +197,21 @@ export default class ChannelSettingsModalInner extends PureComponent {
                 <Modal.Footer>
                     <FormButton
                         type='button'
-                        btnClass='btn-default'
+                        btnClass='btn-link'
                         defaultMessage='Cancel'
                         onClick={this.handleClose}
                     />
+                    {showDeleteButton && (
+                        <FormButton
+                            type='button'
+                            btnClass='btn-danger'
+                            defaultMessage='Delete'
+                            onClick={this.deleteChannelSubscription}
+                        />
+                    )}
                     <FormButton
                         type='submit'
-                        btnClass='btn btn-primary'
+                        btnClass='btn-primary'
                         saving={this.state.submitting}
                         defaultMessage='Set Subscription'
                         savingMessage='Setting'

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -116,6 +116,16 @@ const channelSubscripitons = (state = {}, action) => {
         nextState[action.channelId] = action.data;
         return nextState;
     }
+    case ActionTypes.DELETED_CHANNEL_SUBSCRIPTION: {
+        const sub = action.data;
+        const newSubs = state[sub.channel_id].concat([]);
+        newSubs.splice(newSubs.findIndex((s) => s.id === sub.id), 1);
+
+        return {
+            ...state,
+            [sub.channel_id]: newSubs,
+        };
+    }
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary

This PR adds functionality to delete a channel subscription from the edit subscription modal.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16763

![image](https://user-images.githubusercontent.com/6913320/61284688-7a901100-a78d-11e9-88da-30fe23c932cd.png)

Opening modal again after subscription has been deleted:
![image](https://user-images.githubusercontent.com/6913320/61284732-93002b80-a78d-11e9-90b9-be42b194257f.png)

