### PR TITLE
Make channel subscriptions instance-specific

### DIFF
--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"crypto/md5"
+	"fmt"
+
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
 )
@@ -14,8 +17,18 @@ type jiraTestInstance struct {
 
 var _ Instance = (*jiraTestInstance)(nil)
 
+const (
+	mockCurrentInstanceURL = "http://jiraTestInstanceURL.some"
+)
+
+func keyWithMockInstance(key string) string {
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s", mockCurrentInstanceURL, key)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
 func (jti jiraTestInstance) GetURL() string {
-	return "http://jiraTestInstanceURL.some"
+	return mockCurrentInstanceURL
 }
 func (jti jiraTestInstance) GetMattermostKey() string {
 	return "jiraTestInstanceMattermostKey"

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -303,15 +303,15 @@ func TestGetChannelsSubscribed(t *testing.T) {
 				conf.Secret = "somesecret"
 			})
 			p.SetAPI(api)
+			p.currentInstanceStore = mockCurrentInstanceStore{p}
 
-			var existingBytes []byte
-			var err error
-			existingBytes, err = json.Marshal(tc.Subs)
+			subscriptionBytes, err := json.Marshal(tc.Subs)
 			assert.Nil(t, err)
 
-			api.On("KVGet", JIRA_SUBSCRIPTIONS_KEY).Return(existingBytes, nil)
+			subKey := keyWithMockInstance(JIRA_SUBSCRIPTIONS_KEY)
+			api.On("KVGet", subKey).Return(subscriptionBytes, nil)
 
-			api.On("KVSet", JIRA_SUBSCRIPTIONS_KEY, mock.MatchedBy(func(data []byte) bool {
+			api.On("KVSet", subKey, mock.MatchedBy(func(data []byte) bool {
 				return true
 			})).Return(nil)
 


### PR DESCRIPTION
#### Summary

This PR changes how the channel subscriptions are stored in the KV Store.

Instead of being stored at the key `JIRA_SUBSCRIPTIONS_KEY`, each instance's subscriptions will now be stored with their own key in the KV store. So when we access an instance's subscriptions we will use `store.keyWithInstance(ji, JIRA_SUBSCRIPTIONS_KEY)` for the key.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16940