### PR TITLE
MM-16933 Attach comment notifications for edited comments

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -214,8 +214,17 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
+	attachCommentNotifications(wh)
+
+	return wh, nil
+}
+
+func attachCommentNotifications(wh *webhook) {
+	jwh := wh.JiraWebhook
+	commentAuthor := mdUser(&jwh.Comment.UpdateAuthor)
+
 	message := fmt.Sprintf("%s mentioned you on %s:\n>%s",
-		jwh.mdUser(), jwh.mdKeySummaryLink(), jwh.Comment.Body)
+		commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body)
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {
 		// don't mention the author of the comment
 		if u == jwh.User.Name {
@@ -238,7 +247,7 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
 	if jwh.Issue.Fields.Assignee == nil || jwh.Issue.Fields.Assignee.Name == jwh.User.Name ||
 		(jwh.Issue.Fields.Assignee.AccountID != "" && jwh.Comment.UpdateAuthor.AccountID != "" && jwh.Issue.Fields.Assignee.AccountID == jwh.Comment.UpdateAuthor.AccountID) {
-		return wh, nil
+		return
 	}
 
 	wh.notifications = append(wh.notifications, webhookNotification{
@@ -248,8 +257,6 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 		postType:      PostTypeComment,
 		commentSelf:   jwh.Comment.Self,
 	})
-
-	return wh, nil
 }
 
 func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {
@@ -272,12 +279,15 @@ func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {
 }
 
 func parseWebhookCommentUpdated(jwh *JiraWebhook) Webhook {
-	return &webhook{
+	wh := &webhook{
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventUpdatedComment),
 		headline:    fmt.Sprintf("%s edited comment in %s", mdUser(&jwh.Comment.UpdateAuthor), jwh.mdKeySummaryLink()),
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
+
+	attachCommentNotifications(wh)
+	return wh
 }
 
 func parseWebhookAssigned(jwh *JiraWebhook, from, to string) *webhook {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -182,7 +182,7 @@ func parseWebhookCreated(jwh *JiraWebhook) Webhook {
 		wh.fields = fields
 	}
 
-	attachNotificationForAssignee(wh)
+	appendNotificationForAssignee(wh)
 
 	return wh
 }
@@ -216,12 +216,13 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
-	attachCommentNotifications(wh)
+	appendCommentNotifications(wh)
 
 	return wh, nil
 }
 
-func attachCommentNotifications(wh *webhook) {
+// appendCommentNotifications modifies wh
+func appendCommentNotifications(wh *webhook) {
 	jwh := wh.JiraWebhook
 	commentAuthor := mdUser(&jwh.Comment.UpdateAuthor)
 
@@ -288,7 +289,7 @@ func parseWebhookCommentUpdated(jwh *JiraWebhook) Webhook {
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
-	attachCommentNotifications(wh)
+	appendCommentNotifications(wh)
 	return wh
 }
 
@@ -304,13 +305,13 @@ func parseWebhookAssigned(jwh *JiraWebhook, from, to string) *webhook {
 	}
 	wh.fieldInfo = webhookField{"assignee", "assignee", fromFixed, toFixed}
 
-	attachNotificationForAssignee(wh)
+	appendNotificationForAssignee(wh)
 
 	return wh
 }
 
-// attachNotificationForAssignee modifies wh
-func attachNotificationForAssignee(wh *webhook) {
+// appendNotificationForAssignee modifies wh
+func appendNotificationForAssignee(wh *webhook) {
 	jwh := wh.JiraWebhook
 	if jwh.Issue.Fields.Assignee == nil {
 		return


### PR DESCRIPTION
#### Summary
- refactor comment_created notifications and reuse for edited comments
- fixed an issue where we weren't adding the commentAuthor to the notification. A notification looked like:
![image](https://user-images.githubusercontent.com/1490756/61497832-f311f000-a98e-11e9-8eb7-7a4d71a14b72.png)
Now looks like:
![image](https://user-images.githubusercontent.com/1490756/61497841-fad19480-a98e-11e9-98f3-de9940e373b6.png)

#### Links
[MM-16933](https://mattermost.atlassian.net/browse/MM-16933)