### PR TITLE
Webapp should read plugin id from manifest

### DIFF
--- a/webapp/src/plugin_id.js
+++ b/webapp/src/plugin_id.js
@@ -1,1 +1,2 @@
-export default 'jira';
+import {id} from './manifest';
+export default id;


### PR DESCRIPTION
This PR makes the webapp read from config instead of hardcoding the plugin id.

The reason for this PR is so we can run different versions of a plugin on the same server by toggling them enabled/disabled.