### PR TITLE
[MM-17234]  Users are not receiving DMs for jira @mentions

### DIFF
--- a/server/webhook_worker.go
+++ b/server/webhook_worker.go
@@ -13,12 +13,22 @@ func (ww webhookWorker) work() {
 	for bb := range ww.workQueue {
 		wh, err := ParseWebhook(bb)
 		if err != nil {
-			ww.p.errorf("webhookWorker id: %d, error parsing webhook, err: %v", ww.id, err)
+			// Don't log an error if we're just ignoring the webhook.
+			if err != ErrWebhookIgnored {
+				ww.p.errorf("webhookWorker id: %d, error parsing webhook, err: %v", ww.id, err)
+			}
+			continue
+		}
+
+		_, _, err = wh.PostNotifications(ww.p)
+		if err != nil {
+			ww.p.errorf("WebhookWorker id: %d, error posting notifications, err: %v", ww.id, err)
 		}
 
 		channelIds, err := ww.p.getChannelsSubscribed(wh.(*webhook))
 		if err != nil {
 			ww.p.errorf("webhookWorker id: %d, error getting channel's subscribed, err: %v", ww.id, err)
+			continue
 		}
 
 		botUserId := ww.p.getUserID()
@@ -27,11 +37,6 @@ func (ww webhookWorker) work() {
 			if _, _, err1 := wh.PostToChannel(ww.p, channelId, botUserId); err1 != nil {
 				ww.p.errorf("WebhookWorker id: %d, error posting to channel, err: %v", ww.id, err)
 			}
-		}
-
-		_, _, err = wh.PostNotifications(ww.p)
-		if err != nil {
-			ww.p.errorf("WebhookWorker id: %d, error posting notifications, err: %v", ww.id, err)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
- Bug fix for async workers. Need to continue on an error so that we don't try to dereference or cast a nil pointer later on in the function.
- This was causing the plugin to crash when the comment edited webhook returned an `ErrWebhookIgnored`, causing the linked ticket.
- Good catch by @DHaussermann 

#### Links
- Fixes [MM-17234](https://mattermost.atlassian.net/browse/MM-17234)