### PR TITLE
[MM-17131] Create slash command does not work to open the modal

### DIFF
--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -231,7 +231,7 @@ export default class CreateIssueModal extends PureComponent {
     };
 
     render() {
-        const {post, visible, theme, jiraIssueMetadata, jiraProjectMetadata} = this.props;
+        const {visible, theme, jiraIssueMetadata, jiraProjectMetadata} = this.props;
         const {error, getMetaDataError, submitting} = this.state;
         const style = getStyle(theme);
 
@@ -308,7 +308,7 @@ export default class CreateIssueModal extends PureComponent {
                 </div>
             );
             footer = footerClose;
-        } else if (!post || !jiraProjectMetadata || !jiraProjectMetadata.projects) {
+        } else if (!jiraProjectMetadata || !jiraProjectMetadata.projects) {
             component = <Loading/>;
         } else {
             const issueOptions = getIssueValues(jiraProjectMetadata, this.state.projectKey);


### PR DESCRIPTION
#### Summary
- Fixed a merge mistake/regression
- We shouldn't require a post object to stop the `loading` component --- the `/jira create` slash command opens the model without a post object.

#### Links
- Fixes [MM-17131](https://mattermost.atlassian.net/browse/MM-17131)