### PR TITLE
MM-17312 Mentions in comments only work sometimes

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -113,7 +113,7 @@ func parseJIRAUsernamesFromText(text string) []string {
 	usernameMap := map[string]bool{}
 	usernames := []string{}
 
-	var re = regexp.MustCompile(`(?m)\[~([a-zA-Z0-9-_.\+]+)\]`)
+	var re = regexp.MustCompile(`(?m)\[~([a-zA-Z0-9-_.:\+]+)\]`)
 	for _, match := range re.FindAllString(text, -1) {
 		name := match[:len(match)-1]
 		name = name[2:]

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -101,10 +101,11 @@ func (wh *webhook) PostNotifications(p *Plugin) ([]*model.Post, int, error) {
 		var mattermostUserId string
 		var err error
 
-		if notification.jiraUsername != "" {
-			mattermostUserId, err = p.userStore.LoadMattermostUserId(ji, notification.jiraUsername)
-		} else {
+		// prefer accountId to username when looking up UserIds
+		if notification.jiraAccountID != "" {
 			mattermostUserId, err = p.userStore.LoadMattermostUserId(ji, notification.jiraAccountID)
+		} else {
+			mattermostUserId, err = p.userStore.LoadMattermostUserId(ji, notification.jiraUsername)
 		}
 		if err != nil {
 			continue

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -249,7 +249,7 @@ func appendCommentNotifications(wh *webhook) {
 	// Don't send a notification to the assignee if they don't exist, or if are also the author.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
 	if jwh.Issue.Fields.Assignee == nil || jwh.Issue.Fields.Assignee.Name == jwh.User.Name ||
-		(jwh.Issue.Fields.Assignee.AccountID != "" && jwh.Comment.UpdateAuthor.AccountID != "" && jwh.Issue.Fields.Assignee.AccountID == jwh.Comment.UpdateAuthor.AccountID) {
+		(jwh.Issue.Fields.Assignee.AccountID != "" && jwh.Issue.Fields.Assignee.AccountID == jwh.Comment.UpdateAuthor.AccountID) {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
- Comment updates from Cloud include user names, so when we were looking up MM UserIds we were trying to look up by user name. But... we store cloud users by accountId. So prefer accountId.

#### Links
- Fixes a bug found by Dylan: [MM-17312](https://mattermost.atlassian.net/browse/MM-17312) 