### PR TITLE
[MM-17285] Subscribe modal causes blank screen on desktop

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
@@ -39,7 +39,7 @@ export default class ChannelSettingsModalInner extends PureComponent {
         channel: PropTypes.object.isRequired,
         theme: PropTypes.object.isRequired,
         jiraProjectMetadata: PropTypes.object.isRequired,
-        jiraIssueMetadata: PropTypes.object.isRequired,
+        jiraIssueMetadata: PropTypes.object,
         channelSubscriptions: PropTypes.array.isRequired,
         createChannelSubscription: PropTypes.func.isRequired,
         deleteChannelSubscription: PropTypes.func.isRequired,

--- a/webapp/src/components/setup_ui/setup_ui.jsx
+++ b/webapp/src/components/setup_ui/setup_ui.jsx
@@ -11,8 +11,8 @@ import JiraIcon from 'components/icon';
 // SetupUI is a dummy Root component that we use to detect when the user has logged in
 export default class SetupUI extends PureComponent {
     static propTypes = {
-        userConnected: PropTypes.bool.isRequired,
-        instanceInstalled: PropTypes.bool.isRequired,
+        userConnected: PropTypes.bool,
+        instanceInstalled: PropTypes.bool,
         registry: PropTypes.object.isRequired,
         openChannelSettings: PropTypes.func.isRequired,
     };

--- a/webapp/src/utils/jira_issue_metadata.jsx
+++ b/webapp/src/utils/jira_issue_metadata.jsx
@@ -1,6 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This is a replacement for the Array.flat() function which will be polyfilled by Babel
+// in our 5.16 release. Remove this and replace with .flat() then.
+const flatten = (arr) => {
+    return arr.reduce((acc, val) => acc.concat(val), []);
+};
+
 export function getProjectValues(metadata) {
     if (!metadata) {
         return [];
@@ -26,7 +32,7 @@ export function getIssueValues(metadata, projectKey) {
 }
 
 export function getIssueValuesForMultipleProjects(metadata, projectKeys) {
-    const issueValues = projectKeys.map((project) => getIssueValues(metadata, project)).flat().filter(Boolean);
+    const issueValues = flatten(projectKeys.map((project) => getIssueValues(metadata, project))).filter(Boolean);
 
     const issueTypeHash = {};
     issueValues.forEach((issueType) => {
@@ -49,12 +55,12 @@ export function getCustomFieldValuesForProjects(metadata, projectKeys) {
         return [];
     }
 
-    const issueTypes = projectKeys.map((key) => getIssueTypes(metadata, key)).flat();
+    const issueTypes = flatten(projectKeys.map((key) => getIssueTypes(metadata, key)));
 
     const customFieldHash = {};
-    const fields = issueTypes.map((issueType) =>
+    const fields = flatten(issueTypes.map((issueType) =>
         Object.keys(issueType.fields).map((key) => ({...issueType.fields[key], key}))
-    ).flat().filter(Boolean);
+    )).filter(Boolean);
 
     for (const field of fields) {
         if (field.key.startsWith('customfield')) {


### PR DESCRIPTION
#### Summary
- We were using `Array.flat()` which isn't polyfilled by Babel until core-js 3, which we won't have until 5.16. So, this PR manually polyfills the function.
- Unrelated cleanup: some props were marked as `required` but were being fetched async (so were often nil when the component was loaded) causing red in the console. I want to clean that up.

#### Link
- Fixes [MM-17285](https://mattermost.atlassian.net/browse/MM-17285)