### PR TITLE
[MM-17250] reset user.Name to nil value before passing to UpdateAssignee method.

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -675,11 +675,10 @@ func (p *Plugin) assignJiraIssue(mmUserId, issueKey, assignee string) (string, e
 
 	// From Jira error: query parameters 'accountId' and 'username' are mutually exclusive.
 	// Here, we must choose one and one only and nil the other user field.
-	// Choosing user.AccountID over user.Name.
+	// Choosing user.AccountID over user.Name, but check if AccountId is empty.
+	// For server instances, AccountID is empty
 	if user.AccountID != "" {
 		user.Name = ""
-	} else {
-		user.AccountID = ""
 	}
 
 	if _, err := jiraClient.Issue.UpdateAssignee(issueKey, user); err != nil {

--- a/server/issue.go
+++ b/server/issue.go
@@ -673,6 +673,11 @@ func (p *Plugin) assignJiraIssue(mmUserId, issueKey, assignee string) (string, e
 	// user is array of one object
 	user := jiraUsers[0]
 
+	// From Jira error: query parameters 'accountId' and 'username' are mutually exclusive.
+	// Here, we must choose one and one only and nil the other user field.
+	// Choosing user.AccountID over user.Name.
+	user.Name = ""
+
 	if _, err := jiraClient.Issue.UpdateAssignee(issueKey, user); err != nil {
 		return "", err
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -630,7 +630,7 @@ func (p *Plugin) assignJiraIssue(mmUserId, issueKey, assignee string) (string, e
 	}
 
 	// Get list of assignable assignees
-	url := fmt.Sprintf("rest/api/3/user/assignable/search?issueKey=%s&query=%s", issueKey, assignee)
+	url := fmt.Sprintf("rest/api/2/user/assignable/search?issueKey=%s&username=%s", issueKey, assignee)
 	req, err := jiraClient.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -676,7 +676,11 @@ func (p *Plugin) assignJiraIssue(mmUserId, issueKey, assignee string) (string, e
 	// From Jira error: query parameters 'accountId' and 'username' are mutually exclusive.
 	// Here, we must choose one and one only and nil the other user field.
 	// Choosing user.AccountID over user.Name.
-	user.Name = ""
+	if user.AccountID != "" {
+		user.Name = ""
+	} else {
+		user.AccountID = ""
+	}
 
 	if _, err := jiraClient.Issue.UpdateAssignee(issueKey, user); err != nil {
 		return "", err


### PR DESCRIPTION
### Summary 

When assigning a user to a ticket, the API returns an error if both `user.AccountId` and `user.Name` is defined on the single user. 

To fix this, I nulled the `user.Name` field of the user struct before calling `jiraClient.Issue.UpdateAssignee()`

Note other error handling functions of the `/jira assign` slash commands worked as expected.  This is because the errors are handled inside the server code, before calling the Jira API function.

### Ticket
https://mattermost.atlassian.net/browse/MM-17250