### PR TITLE
[MM-17295] Attach as comment should also append file attachments

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -480,35 +480,6 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	jiraComment.Body = permalinkMessage
 	jiraComment.Body += post.Message
 
-	// Upload file attachments in the foreground to minimize the webhook noise produced by commenting
-	// then updating the comment for each attachment.
-	if len(post.FileIds) > 0 {
-		for _, fileId := range post.FileIds {
-			info, ae := api.GetFileInfo(fileId)
-			if ae != nil {
-				continue
-			}
-			// TODO: large file support? Ignoring errors for now is good enough...
-			byteData, ae := api.ReadFile(info.Path)
-			if ae != nil {
-				notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, attach.IssueKey)
-				continue
-			}
-
-			attachments, _, err2 := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
-
-			if err2 != nil {
-				notifyOnFailedAttachment(ji, err2.Error(), mattermostUserId, info.Path, attach.IssueKey)
-				continue
-			}
-			if attachments != nil {
-				// There will only ever be one attachment at a time.
-				attachment := (*attachments)[0]
-				jiraComment.Body += "\n\nAttachment: !" + attachment.Filename + "!"
-			}
-		}
-	}
-
 	commentAdded, _, err := jiraClient.Issue.AddComment(attach.IssueKey, &jiraComment)
 	if err != nil {
 		if strings.Contains(err.Error(), "you do not have the permission to comment on this issue") {
@@ -519,6 +490,51 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 		// The error was not a permissions error; it was unanticipated. Return it to the client.
 		return http.StatusInternalServerError,
 			errors.WithMessage(err, "failed to attach the comment, postId: "+attach.PostId)
+	}
+
+	if len(post.FileIds) > 0 {
+		go func() {
+			updated := false
+
+			// Upload the files
+			for _, fileId := range post.FileIds {
+				info, ae := api.GetFileInfo(fileId)
+				if ae != nil {
+					continue
+				}
+				// TODO: large file support? Ignoring errors for now is good enough...
+				byteData, ae := api.ReadFile(info.Path)
+				if ae != nil {
+					notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, attach.IssueKey)
+					continue
+				}
+
+				attachments, _, err := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
+
+				if err != nil {
+					notifyOnFailedAttachment(ji, err.Error(), mattermostUserId, info.Path, attach.IssueKey)
+					continue
+				}
+				if attachments != nil {
+					// There will only ever be one attachment at a time.
+					attachment := (*attachments)[0]
+					jiraComment.Body += "\n\nAttachment: !" + attachment.Filename + "!"
+					updated = true
+				}
+			}
+
+			// Update the comment
+			if updated {
+				jiraComment.ID = commentAdded.ID
+				_, _, err := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
+				if err != nil {
+					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
+
+					// Report the error to the user so they know they have to upload the file on their own.
+					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)
+				}
+			}
+		}()
 	}
 
 	rootId := attach.PostId

--- a/server/issue.go
+++ b/server/issue.go
@@ -530,7 +530,7 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 				if err != nil {
 					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
 
-					// Report the error to the user so they know they have to upload the file on their own.
+					// Report the error to the user so they know they have to update the comment on their own.
 					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)
 				}
 			}

--- a/server/issue.go
+++ b/server/issue.go
@@ -509,10 +509,10 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 					continue
 				}
 
-				attachments, _, err := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
+				attachments, _, err2 := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
 
-				if err != nil {
-					notifyOnFailedAttachment(ji, err.Error(), mattermostUserId, info.Path, attach.IssueKey)
+				if err2 != nil {
+					notifyOnFailedAttachment(ji, err2.Error(), mattermostUserId, info.Path, attach.IssueKey)
 					continue
 				}
 				if attachments != nil {
@@ -526,9 +526,9 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			// Update the comment
 			if updated {
 				jiraComment.ID = commentAdded.ID
-				_, _, err := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
-				if err != nil {
-					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
+				_, _, err2 := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
+				if err2 != nil {
+					ji.GetPlugin().API.LogError("failed to update comment: "+err2.Error(), "issue", attach.IssueKey)
 
 					// Report the error to the user so they know they have to update the comment on their own.
 					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)

--- a/server/utils.go
+++ b/server/utils.go
@@ -80,6 +80,34 @@ func (p *Plugin) CreateBotDMPost(ji Instance, userId, message, postType string) 
 	return post, nil
 }
 
+func (p *Plugin) CreateBotDMtoMMUserId(mattermostUserId, format string, args ...interface{}) (post *model.Post, returnErr error) {
+	defer func() {
+		if returnErr != nil {
+			returnErr = errors.WithMessage(returnErr,
+				fmt.Sprintf("failed to create DMError to user %v: ", mattermostUserId))
+		}
+	}()
+
+	conf := p.getConfig()
+	channel, appErr := p.API.GetDirectChannel(mattermostUserId, conf.botUserID)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	post = &model.Post{
+		UserId:    conf.botUserID,
+		ChannelId: channel.Id,
+		Message:   fmt.Sprintf(format, args...),
+	}
+
+	_, appErr = p.API.CreatePost(post)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	return post, nil
+}
+
 func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) error {
 	appErr := p.currentInstanceStore.StoreCurrentJIRAInstance(ji)
 	if appErr != nil {


### PR DESCRIPTION
#### Summary
- We are now uploading file attachments when attaching a post to an issue.
- It's a little awkward to do it with Jira, you have to upload the attachment to the original issue, then add a reference to the attachment as text in the comment. 
- Looks like:
![image](https://user-images.githubusercontent.com/1490756/61915484-a9874f00-af12-11e9-8df5-3d74abf0a706.png)

PM review:
- We're sending back notifications when the file attachments fail or when the comment fails to be updated. Line 534, and 580

#### Links
- Fixes: [MM-17295](https://mattermost.atlassian.net/browse/MM-17295)