### PR TITLE
MM-15943 remove divider above plugin menu items

### DIFF
--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -74,10 +74,6 @@ export default class CreateIssuePostMenuAction extends PureComponent {
         return (
             <React.Fragment>
                 <li
-                    className='MenuItem__divider'
-                    role='menuitem'
-                />
-                <li
                     className='MenuItem'
                     role='menuitem'
                 >


### PR DESCRIPTION
#### Summary
Remove divider between normal menu items and plugin menu items on dot menu. Is now rendered in the main web app.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/11054
https://mattermost.atlassian.net/browse/MM-15943

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/3264