### PR TITLE
[MM-17268] Subscribe permission for "Channel, Team and System Admins" treats all users as Channel Admins

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -35,7 +35,7 @@
         "key": "RolesAllowedToEditJiraSubscriptions",
         "display_name": "Mattermost Roles Allowed to Edit Jira Subscriptions",
         "type": "radio",
-        "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
+        "help_text": "Mattermost users who can subscribe channels to Jira tickets. \n**Note:** Channel Admins are those given the “Manage Channel Settings” permission in the active Permissions Scheme. They “can rename channels and edit channel header and purposes” (see [the documentation](https://docs.mattermost.com/deployment/advanced-permissions.html#public-and-private-channel-management) for more info).",
         "default": "system_admin",
         "options": [
             {

--- a/plugin.json
+++ b/plugin.json
@@ -35,7 +35,7 @@
         "key": "RolesAllowedToEditJiraSubscriptions",
         "display_name": "Mattermost Roles Allowed to Edit Jira Subscriptions",
         "type": "radio",
-        "help_text": "Mattermost users who can subscribe channels to Jira tickets. \n**Note:** Channel Admins are those given the “Manage Channel Settings” permission in the active Permissions Scheme. They “can rename channels and edit channel header and purposes” (see [the documentation](https://docs.mattermost.com/deployment/advanced-permissions.html#public-and-private-channel-management) for more info).",
+        "help_text": "Mattermost users who can subscribe channels to Jira tickets. \\n**Note:** In Team edition, there is no Channel Admin role.  In Enterprise Editions, Channel Admins are those given the “Manage Channel Settings” permission in the active Permissions Scheme. They “can rename channels and edit channel header and purposes” (see [the documentation](https://docs.mattermost.com/deployment/advanced-permissions.html#public-and-private-channel-management) for more info).",
         "default": "system_admin",
         "options": [
             {

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/andygrunwald/go-jira"
+	jira "github.com/andygrunwald/go-jira"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
 )
@@ -332,6 +332,7 @@ func (p *Plugin) hasPermissionToManageSubscription(userId, channelId string) err
 		}
 
 		allowedGroups := strings.Split(cfg.GroupsAllowedToEditJiraSubscriptions, ",")
+		allowedGroups = Map(allowedGroups, strings.TrimSpace)
 		if !inAllowedGroup(groups, allowedGroups) {
 			return errors.New("not in allowed jira user groups")
 		}

--- a/server/utils.go
+++ b/server/utils.go
@@ -142,3 +142,12 @@ func parseJIRAIssuesFromText(text string, keys []string) []string {
 
 	return issues
 }
+
+// Reference: https://gobyexample.com/collection-functions
+func Map(vs []string, f func(string) string) []string {
+	vsm := make([]string, len(vs))
+	for i, v := range vs {
+		vsm[i] = f(v)
+	}
+	return vsm
+}


### PR DESCRIPTION
#### Summary
- Working as intended. The permission that “Channel, …. Admin” means is can the user “manage channel settings”. (See the screencap)
- Protective change: trimmed the space around the allowed groups in case admins put a space after a comma.

![image](https://user-images.githubusercontent.com/1490756/61971664-9ffef500-afad-11e9-9785-a708fbeb1b3f.png)

Needs PM review:
- Added some info in the System Console to let admins know this is happening (line 38).

#### Links
- [MM-17268](https://mattermost.atlassian.net/browse/MM-17268)