### PR TITLE
[MM-17369] Support filters for other issue fields

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -575,6 +575,56 @@ func getPermaLink(ji Instance, postId string, currentTeam string) string {
 	return fmt.Sprintf("%v/%v/pl/%v", ji.GetPlugin().GetSiteURL(), currentTeam, postId)
 }
 
+func (p *Plugin) getIssueDataForCloudWebhook(issueKey string) (*jira.Issue, error) {
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	jci, ok := ji.(*jiraCloudInstance)
+	if !ok {
+		return nil, errors.New("Must be a JIRA Cloud instance, is " + ji.GetType())
+	}
+
+	jiraClient, err := jci.getJIRAClientForServer()
+	if err != nil {
+		return nil, err
+	}
+
+	issue, resp, err := jiraClient.Issue.Get(issueKey, nil)
+	if err != nil {
+		switch {
+		case resp == nil:
+			return nil, errors.WithMessage(userFriendlyJiraError(nil, err),
+				"request to Jira failed")
+
+		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized:
+			return nil, errors.New(`We couldn't find the issue key, or the cloud "bot" client does not have the appropriate permissions to view the issue.`)
+		}
+	}
+
+	return issue, nil
+}
+
+func getIssueFieldValue(issue *jira.Issue, key string) string {
+	m, exists := issue.Fields.Unknowns.Value(key)
+	if !exists || m == nil {
+		return ""
+	}
+
+	// Only support single value selects at the moment
+	v, ok := m.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	value, ok := v["id"].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
 func (p *Plugin) getIssueAsSlackAttachment(ji Instance, jiraUser JIRAUser, issueKey string) ([]*model.SlackAttachment, error) {
 	jiraClient, err := ji.GetJIRAClient(jiraUser)
 	if err != nil {

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -310,6 +310,106 @@ func TestGetChannelsSubscribed(t *testing.T) {
 			}),
 			ChannelIds: []string{},
 		},
+		"with custom field filter": {
+			WebhookTestData: "webhook-issue-created-custom-field.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId1",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_created"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10001"),
+						Fields: []FieldFilter{
+							{
+								Id:    "customfield_10076",
+								Value: NewStringSet("10039"),
+							},
+						},
+					},
+				},
+			}),
+			ChannelIds: []string{"sampleChannelId1"},
+		},
+		"with custom field filter, no match": {
+			WebhookTestData: "webhook-issue-created-custom-field.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId1",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_created"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10001"),
+						Fields: []FieldFilter{
+							{
+								Id:    "customfield_10076",
+								Value: NewStringSet("10040"),
+							},
+						},
+					},
+				},
+			}),
+			ChannelIds: []string{},
+		},
+		"with security field filter": {
+			WebhookTestData: "webhook-issue-created-security.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId1",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_created"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10001"),
+						Fields: []FieldFilter{
+							{
+								Id:    "security",
+								Value: NewStringSet("10000"),
+							},
+						},
+					},
+				},
+			}),
+			ChannelIds: []string{"sampleChannelId1"},
+		},
+		"with security field filter, no match": {
+			WebhookTestData: "webhook-issue-created-security.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId1",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_created"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10001"),
+						Fields: []FieldFilter{
+							{
+								Id:    "security",
+								Value: NewStringSet("10001"),
+							},
+						},
+					},
+				},
+			}),
+			ChannelIds: []string{},
+		},
+		"no selected security field filter, but exists in issue": {
+			WebhookTestData: "webhook-issue-created-security.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId1",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_created"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10001"),
+						Fields:     []FieldFilter{},
+					},
+				},
+			}),
+			ChannelIds: []string{},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			api := &plugintest.API{}

--- a/server/testdata/webhook-issue-created-custom-field.json
+++ b/server/testdata/webhook-issue-created-custom-field.json
@@ -1,0 +1,243 @@
+{
+  "timestamp": 1550286113023,
+  "webhookEvent": "jira:issue_created",
+  "issue_event_type_name": "issue_created",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": null,
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 0,
+        "isWatching": true
+      },
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i00067:",
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10023": null,
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "customfield_10026": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "aggregatetimeoriginalestimate": null,
+      "timeestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:01:52.971-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "security": null,
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "attachment": [],
+      "customfield_10009": null,
+      "aggregatetimeestimate": null,
+      "summary": "Unit test summary",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "customfield_10000": "{}",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "customfield_10076": {
+        "self": "https://mmtest.atlassian.net/rest/api/2/customFieldOption/10039",
+        "value": "1",
+        "id": "10039"
+      },
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10222",
+    "items": [
+      {
+        "field": "description",
+        "fieldtype": "jira",
+        "fieldId": "description",
+        "from": null,
+        "fromString": null,
+        "to": null,
+        "toString": "Unit test description, not that long"
+      },
+      {
+        "field": "priority",
+        "fieldtype": "jira",
+        "fieldId": "priority",
+        "from": null,
+        "fromString": null,
+        "to": "2",
+        "toString": "High"
+      },
+      {
+        "field": "reporter",
+        "fieldtype": "jira",
+        "fieldId": "reporter",
+        "from": null,
+        "fromString": null,
+        "to": "admin",
+        "toString": "Test User"
+      },
+      {
+        "field": "Status",
+        "fieldtype": "jira",
+        "fieldId": "status",
+        "from": null,
+        "fromString": null,
+        "to": "10001",
+        "toString": "To Do"
+      },
+      {
+        "field": "summary",
+        "fieldtype": "jira",
+        "fieldId": "summary",
+        "from": null,
+        "fromString": null,
+        "to": null,
+        "toString": "Unit test summary"
+      }
+    ]
+  }
+}

--- a/server/testdata/webhook-issue-created-security.json
+++ b/server/testdata/webhook-issue-created-security.json
@@ -1,0 +1,248 @@
+{
+  "timestamp": 1550286113023,
+  "webhookEvent": "jira:issue_created",
+  "issue_event_type_name": "issue_created",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": null,
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 0,
+        "isWatching": true
+      },
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i00067:",
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10023": null,
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "customfield_10026": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "aggregatetimeoriginalestimate": null,
+      "timeestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:01:52.971-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "security": {
+        "self": "https://mmtest.atlassian.net/rest/api/2/securitylevel/10000",
+        "id": "10000",
+        "description": "",
+        "name": "Everyone"
+      },
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "attachment": [],
+      "customfield_10009": null,
+      "aggregatetimeestimate": null,
+      "summary": "Unit test summary",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "customfield_10000": "{}",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "customfield_10076": {
+        "self": "https://mmtest.atlassian.net/rest/api/2/customFieldOption/10039",
+        "value": "1",
+        "id": "10039"
+      },
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10222",
+    "items": [
+      {
+        "field": "description",
+        "fieldtype": "jira",
+        "fieldId": "description",
+        "from": null,
+        "fromString": null,
+        "to": null,
+        "toString": "Unit test description, not that long"
+      },
+      {
+        "field": "priority",
+        "fieldtype": "jira",
+        "fieldId": "priority",
+        "from": null,
+        "fromString": null,
+        "to": "2",
+        "toString": "High"
+      },
+      {
+        "field": "reporter",
+        "fieldtype": "jira",
+        "fieldId": "reporter",
+        "from": null,
+        "fromString": null,
+        "to": "admin",
+        "toString": "Test User"
+      },
+      {
+        "field": "Status",
+        "fieldtype": "jira",
+        "fieldId": "status",
+        "from": null,
+        "fromString": null,
+        "to": "10001",
+        "toString": "To Do"
+      },
+      {
+        "field": "summary",
+        "fieldtype": "jira",
+        "fieldId": "summary",
+        "from": null,
+        "fromString": null,
+        "to": null,
+        "toString": "Unit test summary"
+      }
+    ]
+  }
+}

--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -54,11 +54,15 @@ export default class JiraField extends React.Component {
     }
 
     componentDidMount() {
-        this.props.addValidate(this.props.id, this.ref);
+        if (this.props.addValidate) {
+            this.props.addValidate(this.props.id, this.ref);
+        }
     }
 
     componentWillUnmount() {
-        this.props.removeValidate(this.props.id);
+        if (this.props.removeValidate) {
+            this.props.removeValidate(this.props.id);
+        }
     }
 
     makeReactSelectValue = (allowedValue) => {
@@ -146,21 +150,25 @@ export default class JiraField extends React.Component {
 
         if (field.allowedValues && field.allowedValues.length) {
             const options = field.allowedValues.map(this.makeReactSelectValue);
-            let value;
+            let value = [];
             if (this.props.value) {
                 value = options.filter((option) => this.props.value.includes(option.value));
             }
 
             return (
                 <ReactSelectSetting
-                    key={field.key}
+                    ref={this.ref}
+                    key={this.props.id}
                     name={field.key}
                     label={field.name}
                     options={options}
-                    required={this.props.obeyRequired && field.required}
-                    onChange={this.handleChange}
+                    required={false}
+                    onChange={this.props.onChange}
                     isMulti={true}
                     value={value}
+                    components={{Option: JiraField.IconOption}}
+                    theme={this.props.theme}
+                    isClearable={true}
                 />
             );
         }


### PR DESCRIPTION
#### Summary

This PR adds functionality to filter on custom fields (like Mattermost Team) and Security Level.

Tested on cloud and server

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17369

There are some steps to setting up Security Level on Jira's side:
- Modify issue permission scheme
    - Add a new role to "Set Issue Security". Set to "Application access - Jira Core" for server or "Application access - Jira Software" for cloud
- Edit issue security scheme
    - For each relevant Security Level, add a new role. Set to "Application access - Jira Core" for server or "Application access - Jira Software" for cloud
- Edit project's issue security settings to use this scheme

Screenshot:

![image](https://user-images.githubusercontent.com/6913320/61977402-64b7f280-afbc-11e9-929b-e7f74143dd4f.png)
