### PR TITLE
[MM-17105] Prevent channel settings modal from closing when click outside of it

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.jsx
@@ -57,6 +57,7 @@ export default class ChannelSettingsModal extends PureComponent {
                 show={Boolean(this.props.channel)}
                 onHide={this.handleClose}
                 onExited={this.handleClose}
+                backdrop='static'
                 bsSize='large'
             >
                 <Modal.Header closeButton={true}>


### PR DESCRIPTION
### Summary

When the `Channel Jira Settings` modal is open, disable it from closing when clicking outside of it.

### Ticket
https://mattermost.atlassian.net/browse/MM-17105