### PR TITLE
[MM-17318] Fix for multiple icons is working, but not sure why

### DIFF
--- a/webapp/src/components/setup_ui/setup_ui.jsx
+++ b/webapp/src/components/setup_ui/setup_ui.jsx
@@ -15,6 +15,8 @@ export default class SetupUI extends PureComponent {
         instanceInstalled: PropTypes.bool.isRequired,
         registry: PropTypes.object.isRequired,
         openChannelSettings: PropTypes.func.isRequired,
+        haveSetupUI: PropTypes.bool.isRequired,
+        finishedSetupUI: PropTypes.func.isRequired,
     };
 
     registerHeaderButton = () => {
@@ -29,7 +31,10 @@ export default class SetupUI extends PureComponent {
         if (this.props.instanceInstalled && this.props.userConnected) {
             this.registerHeaderButton();
         }
-        setupUI();
+        if (!this.props.haveSetupUI) {
+            setupUI();
+            this.props.finishedSetupUI();
+        }
     }
 
     componentDidUpdate() {

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -46,12 +46,25 @@ const setupUILater = (registry, store) => async () => {
 };
 
 export default class Plugin {
+    finishedSetupUI = () => {
+        this.haveSetupUI = true;
+    };
+
     async initialize(registry, store) {
         setupUI = setupUILater(registry, store);
+        this.haveSetupUI = false;
 
         // Register the dummy component, which will call setupUI when it is activated (i.e., when the user logs in)
         registry.registerRootComponent(
-            () => <SetupUI registry={registry}/>
-        );
+            () => {
+                return (
+                    <SetupUI
+                        registry={registry}
+                        setupUI={setupUI}
+                        haveSetupUI={this.haveSetupUI}
+                        finishedSetupUI={this.finishedSetupUI}
+                    />
+                );
+            });
     }
 }


### PR DESCRIPTION
#### Summary
- `componentDidMount` was being called many more times than expected. But the `setupUI` function was failing at the `registry.registerReducer`. This meant we were not showing multiple icons by accident. 
- Now we're explicitly flagging when we've set up the UI.
- tested: disconnecting/reconnecting, installing, uninstalling -- these all make the icons appear/disappear as expected because those are handled through websockets events

#### Link
- Fixes [MM-17318](https://mattermost.atlassian.net/browse/MM-17318)