### PR TITLE
MM-17129: HTTP and attachment size limits

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -38,22 +38,22 @@
         "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
         "default": "system_admin",
         "options": [
-            {
-                "display_name": "All Users",
-                "value": "users"
-            },
-            {
-                "display_name": "Channel, Team and System Admins",
-                "value": "channel_admin"
-            },
-            {
-                "display_name": "Team and System Admins",
-                "value": "team_admin"
-            },
-            {
-                "display_name": "System Admins",
-                "value": "system_admin"
-            }
+          {
+            "display_name": "All Users",
+            "value": "users"
+          },
+          {
+            "display_name": "Channel, Team and System Admins",
+            "value": "channel_admin"
+          },
+          {
+            "display_name": "Team and System Admins",
+            "value": "team_admin"
+          },
+          {
+            "display_name": "System Admins",
+            "value": "system_admin"
+          }
         ]
       },
       {

--- a/plugin.json
+++ b/plugin.json
@@ -38,22 +38,22 @@
         "help_text": "Mattermost users that can subscribe channels to Jira tickets.",
         "default": "system_admin",
         "options": [
-          {
-            "display_name": "All Users",
-            "value": "users"
-          },
-          {
-            "display_name": "Channel, Team and System Admins",
-            "value": "channel_admin"
-          },
-          {
-            "display_name": "Team and System Admins",
-            "value": "team_admin"
-          },
-          {
-            "display_name": "System Admins",
-            "value": "system_admin"
-          }
+            {
+                "display_name": "All Users",
+                "value": "users"
+            },
+            {
+                "display_name": "Channel, Team and System Admins",
+                "value": "channel_admin"
+            },
+            {
+                "display_name": "Team and System Admins",
+                "value": "team_admin"
+            },
+            {
+                "display_name": "System Admins",
+                "value": "system_admin"
+            }
         ]
       },
       {

--- a/server/http.go
+++ b/server/http.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -175,4 +176,35 @@ func (p *Plugin) respondSpecialTemplate(w http.ResponseWriter, key string, statu
 			errors.WithMessage(err, "failed to write response")
 	}
 	return status, nil
+}
+
+type roundtripper struct {
+	http.RoundTripper
+	limit ByteSize
+}
+
+func (rt roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := rt.RoundTripper.RoundTrip(r)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.LimitReader(resp.Body, int64(rt.limit)),
+		Closer: resp.Body,
+	}
+
+	return resp, err
+}
+
+func (p *Plugin) limitResponseClient(c *http.Client) *http.Client {
+	client := *c
+	rt := c.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	client.Transport = roundtripper{rt, p.getConfig().maxAttachmentSize}
+	return &client
 }

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -147,7 +147,7 @@ func (jci jiraCloudInstance) getJIRAClientForUser(jiraUser JIRAUser) (*jira.Clie
 	}
 
 	httpClient := oauth2Conf.Client(context.Background())
-
+	httpClient = jci.GetPlugin().limitResponseClient(httpClient)
 	jiraClient, err := jira.NewClient(httpClient, oauth2Conf.BaseURL)
 	return jiraClient, httpClient, err
 }
@@ -161,7 +161,8 @@ func (jci jiraCloudInstance) getJIRAClientForServer() (*jira.Client, error) {
 		BaseURL:      jci.AtlassianSecurityContext.BaseURL,
 	}
 
-	return jira.NewClient(jwtConf.Client(), jwtConf.BaseURL)
+	httpClient := jci.GetPlugin().limitResponseClient(jwtConf.Client())
+	return jira.NewClient(httpClient, jwtConf.BaseURL)
 }
 
 func (jci jiraCloudInstance) parseHTTPRequestJWT(r *http.Request) (*jwt.Token, string, error) {

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -110,6 +110,7 @@ func (jsi jiraServerInstance) GetJIRAClient(jiraUser JIRAUser) (returnClient *ji
 
 	token := oauth1.NewToken(jiraUser.Oauth1AccessToken, jiraUser.Oauth1AccessSecret)
 	httpClient := oauth1Config.Client(oauth1.NoContext, token)
+	httpClient = jsi.GetPlugin().limitResponseClient(httpClient)
 	jiraClient, err := jira.NewClient(httpClient, jsi.GetURL())
 	if err != nil {
 		return nil, err

--- a/server/issue.go
+++ b/server/issue.go
@@ -480,35 +480,6 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	jiraComment.Body = permalinkMessage
 	jiraComment.Body += post.Message
 
-	// Upload file attachments in the foreground to minimize the webhook noise produced by commenting
-	// then updating the comment for each attachment.
-	if len(post.FileIds) > 0 {
-		for _, fileId := range post.FileIds {
-			info, ae := api.GetFileInfo(fileId)
-			if ae != nil {
-				continue
-			}
-			// TODO: large file support? Ignoring errors for now is good enough...
-			byteData, ae := api.ReadFile(info.Path)
-			if ae != nil {
-				notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, attach.IssueKey)
-				continue
-			}
-
-			attachments, _, err2 := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
-
-			if err2 != nil {
-				notifyOnFailedAttachment(ji, err2.Error(), mattermostUserId, info.Path, attach.IssueKey)
-				continue
-			}
-			if attachments != nil {
-				// There will only ever be one attachment at a time.
-				attachment := (*attachments)[0]
-				jiraComment.Body += "\n\nAttachment: !" + attachment.Filename + "!"
-			}
-		}
-	}
-
 	commentAdded, _, err := jiraClient.Issue.AddComment(attach.IssueKey, &jiraComment)
 	if err != nil {
 		if strings.Contains(err.Error(), "you do not have the permission to comment on this issue") {
@@ -519,6 +490,51 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 		// The error was not a permissions error; it was unanticipated. Return it to the client.
 		return http.StatusInternalServerError,
 			errors.WithMessage(err, "failed to attach the comment, postId: "+attach.PostId)
+	}
+
+	if len(post.FileIds) > 0 {
+		go func() {
+			updated := false
+
+			// Upload the files
+			for _, fileId := range post.FileIds {
+				info, ae := api.GetFileInfo(fileId)
+				if ae != nil {
+					continue
+				}
+				// TODO: large file support? Ignoring errors for now is good enough...
+				byteData, ae := api.ReadFile(info.Path)
+				if ae != nil {
+					notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, attach.IssueKey)
+					continue
+				}
+
+				attachments, _, err := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
+
+				if err != nil {
+					notifyOnFailedAttachment(ji, err.Error(), mattermostUserId, info.Path, attach.IssueKey)
+					continue
+				}
+				if attachments != nil {
+					// There will only ever be one attachment at a time.
+					attachment := (*attachments)[0]
+					jiraComment.Body += "\n\nAttachment: !" + attachment.Filename + "!"
+					updated = true
+				}
+			}
+
+			// Update the comment
+			if updated {
+				jiraComment.ID = commentAdded.ID
+				_, _, err := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
+				if err != nil {
+					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
+
+					// Report the error to the user so they know they have to upload the file on their own.
+					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)
+				}
+			}
+		}()
 	}
 
 	rootId := attach.PostId

--- a/server/issue.go
+++ b/server/issue.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
 )
 
 func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
@@ -183,28 +184,15 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			errors.WithMessage(appErr, "failed to create notification post "+create.PostId)
 	}
 
-	// Upload file attachments in the background
-	if post != nil && len(post.FileIds) > 0 {
-		go func() {
-			for _, fileId := range post.FileIds {
-				info, ae := api.GetFileInfo(fileId)
-				if ae != nil {
-					continue
-				}
-				// TODO: large file support? Ignoring errors for now is good enough...
-				byteData, ae := api.ReadFile(info.Path)
-				if ae != nil {
-					notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, created.Key)
-					return
-				}
-				_, _, e := jiraClient.Issue.PostAttachment(created.ID, bytes.NewReader(byteData), info.Name)
-				if e != nil {
-					notifyOnFailedAttachment(ji, e.Error(), mattermostUserId, info.Path, created.Key)
-					return
-				}
+	go func() {
+		conf := ji.GetPlugin().getConfig()
+		for _, fileId := range post.FileIds {
+			mattermostName, _, e := attachFileToIssue(api, jiraClient, created.ID, fileId, conf.maxAttachmentSize)
+			if e != nil {
+				notifyOnFailedAttachment(ji, mattermostUserId, created.Key, e, "file: %s", mattermostName)
 			}
-		}()
-	}
+		}
+	}()
 
 	userBytes, err := json.Marshal(created)
 	if err != nil {
@@ -492,50 +480,28 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			errors.WithMessage(err, "failed to attach the comment, postId: "+attach.PostId)
 	}
 
-	if len(post.FileIds) > 0 {
-		go func() {
-			updated := false
-
-			// Upload the files
-			for _, fileId := range post.FileIds {
-				info, ae := api.GetFileInfo(fileId)
-				if ae != nil {
-					continue
-				}
-				// TODO: large file support? Ignoring errors for now is good enough...
-				byteData, ae := api.ReadFile(info.Path)
-				if ae != nil {
-					notifyOnFailedAttachment(ji, ae.Error(), mattermostUserId, info.Path, attach.IssueKey)
-					continue
-				}
-
-				attachments, _, err2 := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
-
-				if err2 != nil {
-					notifyOnFailedAttachment(ji, err2.Error(), mattermostUserId, info.Path, attach.IssueKey)
-					continue
-				}
-				if attachments != nil {
-					// There will only ever be one attachment at a time.
-					attachment := (*attachments)[0]
-					jiraComment.Body += "\n\nAttachment: !" + attachment.Filename + "!"
-					updated = true
-				}
+	go func() {
+		conf := ji.GetPlugin().getConfig()
+		extraText := ""
+		for _, fileId := range post.FileIds {
+			mattermostName, jiraName, e := attachFileToIssue(api, jiraClient, attach.IssueKey, fileId, conf.maxAttachmentSize)
+			if e != nil {
+				notifyOnFailedAttachment(ji, mattermostUserId, attach.IssueKey, e, "file: %s", mattermostName)
 			}
 
-			// Update the comment
-			if updated {
-				jiraComment.ID = commentAdded.ID
-				_, _, err2 := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
-				if err2 != nil {
-					ji.GetPlugin().API.LogError("failed to update comment: "+err2.Error(), "issue", attach.IssueKey)
+			extraText += "\n\nAttachment: !" + jiraName + "!"
+		}
+		if extraText == "" {
+			return
+		}
 
-					// Report the error to the user so they know they have to update the comment on their own.
-					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)
-				}
-			}
-		}()
-	}
+		jiraComment.ID = commentAdded.ID
+		jiraComment.Body += extraText
+		_, _, err = jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
+		if err != nil {
+			notifyOnFailedAttachment(ji, mattermostUserId, attach.IssueKey, err, "failed to completely update comment with attachments")
+		}
+	}()
 
 	rootId := attach.PostId
 	parentId := ""
@@ -573,11 +539,12 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 	return http.StatusOK, nil
 }
 
-func notifyOnFailedAttachment(ji Instance, err, mattermostUserId, path, issueKey string) {
-	ji.GetPlugin().API.LogError("failed to attach file to issue: "+err, "file", path, "issue", issueKey)
+func notifyOnFailedAttachment(ji Instance, mattermostUserId, issueKey string, err error, format string, args ...interface{}) {
+	msg := "Failed to attach to issue: " + issueKey + ", " + fmt.Sprintf(format, args...)
 
-	// Report the error to the user so they know they have to upload the file on their own.
-	_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to attach file: %s, to issue: %s. Please notify your system administrator.", path, issueKey)
+	ji.GetPlugin().API.LogError(fmt.Sprintf("%s: %v", msg, err), "issue", issueKey)
+	_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId,
+		"%s. Please notify your system administrator.\n- Error: %v", msg, err)
 }
 
 func buildCreateQuery(ji Instance, project *jira.Project, issue *jira.Issue) *http.Request {
@@ -815,4 +782,30 @@ func userFriendlyJiraError(resp *jira.Response, err error) error {
 		message += fmt.Sprintf(" - %s\n", m)
 	}
 	return errors.New(message)
+}
+
+// Upload file attachments in the background
+func attachFileToIssue(api plugin.API, jiraClient *jira.Client, issueKey, fileId string, maxSize ByteSize) (mattermostName, jiraName string, err error) {
+	fileinfo, appErr := api.GetFileInfo(fileId)
+	if appErr != nil {
+		return "", "", appErr
+	}
+	if ByteSize(fileinfo.Size) > maxSize {
+		return fileinfo.Name, "", errors.Errorf("Maximum attachment size %v exceeded, file size %v", maxSize, ByteSize(fileinfo.Size))
+	}
+	fileBytes, appErr := api.ReadFile(fileinfo.Path)
+	if appErr != nil {
+		return fileinfo.Name, "", appErr
+	}
+
+	attachments, _, err := jiraClient.Issue.PostAttachment(issueKey, bytes.NewReader(fileBytes), fileinfo.Name)
+	if err != nil {
+		return fileinfo.Name, "", err
+	}
+	if attachments == nil || len(*attachments) == 0 {
+		return fileinfo.Name, "", errors.New("unreachable error, attaching file" + fileinfo.Name)
+	}
+	// There will only ever be one attachment at a time.
+	attachment := (*attachments)[0]
+	return fileinfo.Name, attachment.Filename, nil
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -530,7 +530,7 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 				if err != nil {
 					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
 
-					// Report the error to the user so they know they have to upload the file on their own.
+					// Report the error to the user so they know they have to update the comment on their own.
 					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)
 				}
 			}

--- a/server/issue.go
+++ b/server/issue.go
@@ -509,10 +509,10 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 					continue
 				}
 
-				attachments, _, err := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
+				attachments, _, err2 := jiraClient.Issue.PostAttachment(attach.IssueKey, bytes.NewReader(byteData), info.Name)
 
-				if err != nil {
-					notifyOnFailedAttachment(ji, err.Error(), mattermostUserId, info.Path, attach.IssueKey)
+				if err2 != nil {
+					notifyOnFailedAttachment(ji, err2.Error(), mattermostUserId, info.Path, attach.IssueKey)
 					continue
 				}
 				if attachments != nil {
@@ -526,9 +526,9 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			// Update the comment
 			if updated {
 				jiraComment.ID = commentAdded.ID
-				_, _, err := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
-				if err != nil {
-					ji.GetPlugin().API.LogError("failed to update comment: "+err.Error(), "issue", attach.IssueKey)
+				_, _, err2 := jiraClient.Issue.UpdateComment(attach.IssueKey, &jiraComment)
+				if err2 != nil {
+					ji.GetPlugin().API.LogError("failed to update comment: "+err2.Error(), "issue", attach.IssueKey)
 
 					// Report the error to the user so they know they have to update the comment on their own.
 					_, _ = ji.GetPlugin().CreateBotDMtoMMUserId(mattermostUserId, "Failed to update comment to issue %s with file attachments. Please notify your system administrator.", attach.IssueKey)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -50,7 +50,7 @@ type externalConfig struct {
 
 const currentInstanceTTL = 1 * time.Second
 
-const defaultMaxAttachmentSize = 10 * 1024 * 1024 // 10Mb
+const defaultMaxAttachmentSize = ByteSize(10 * 1024 * 1024) // 10Mb
 
 type config struct {
 	// externalConfig caches values from the plugin's settings in the server's config.json
@@ -114,12 +114,13 @@ func (p *Plugin) OnConfigurationChange() error {
 		return errors.WithMessage(err, "failed to load plugin configuration")
 	}
 
-	maxAttachmentSize, err := ParseByteSize(ec.MaxAttachmentSize)
-	if err != nil {
-		return errors.WithMessage(err, "failed to load plugin configuration")
-	}
-	if maxAttachmentSize <= 0 {
-		maxAttachmentSize = defaultMaxAttachmentSize
+	ec.MaxAttachmentSize = strings.TrimSpace(ec.MaxAttachmentSize)
+	maxAttachmentSize := defaultMaxAttachmentSize
+	if len(ec.MaxAttachmentSize) > 0 {
+		maxAttachmentSize, err = ParseByteSize(ec.MaxAttachmentSize)
+		if err != nil {
+			return errors.WithMessage(err, "failed to load plugin configuration")
+		}
 	}
 
 	p.updateConfig(func(conf *config) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -42,6 +42,10 @@ type externalConfig struct {
 
 	// Comma separated list of jira groups with permission. Empty is all.
 	GroupsAllowedToEditJiraSubscriptions string
+
+	// Maximum attachment size allowed to be uploaded to Jira, can be a
+	// number, optionally followed by one of [b, kb, mb, gb, tb]
+	MaxAttachmentSize string
 }
 
 const currentInstanceTTL = 1 * time.Second
@@ -57,6 +61,9 @@ type config struct {
 	// of a value. A nil value means there is no instance available.
 	currentInstance        Instance
 	currentInstanceExpires time.Time
+
+	// Maximum attachment size allowed to be uploaded to Jira
+	maxAttachmentSize ByteSize
 }
 
 type Plugin struct {
@@ -105,8 +112,14 @@ func (p *Plugin) OnConfigurationChange() error {
 		return errors.WithMessage(err, "failed to load plugin configuration")
 	}
 
+	maxAttachmentSize, err := ParseByteSize(ec.MaxAttachmentSize)
+	if err != nil {
+		return errors.WithMessage(err, "failed to load plugin configuration")
+	}
+
 	p.updateConfig(func(conf *config) {
 		conf.externalConfig = ec
+		conf.maxAttachmentSize = maxAttachmentSize
 	})
 
 	return nil

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -50,6 +50,8 @@ type externalConfig struct {
 
 const currentInstanceTTL = 1 * time.Second
 
+const defaultMaxAttachmentSize = 10 * 1024 * 1024 // 10Mb
+
 type config struct {
 	// externalConfig caches values from the plugin's settings in the server's config.json
 	externalConfig
@@ -115,6 +117,9 @@ func (p *Plugin) OnConfigurationChange() error {
 	maxAttachmentSize, err := ParseByteSize(ec.MaxAttachmentSize)
 	if err != nil {
 		return errors.WithMessage(err, "failed to load plugin configuration")
+	}
+	if maxAttachmentSize <= 0 {
+		maxAttachmentSize = defaultMaxAttachmentSize
 	}
 
 	p.updateConfig(func(conf *config) {

--- a/server/utils.go
+++ b/server/utils.go
@@ -80,6 +80,34 @@ func (p *Plugin) CreateBotDMPost(ji Instance, userId, message, postType string) 
 	return post, nil
 }
 
+func (p *Plugin) CreateBotDMtoMMUserId(mattermostUserId, format string, args ...interface{}) (post *model.Post, returnErr error) {
+	defer func() {
+		if returnErr != nil {
+			returnErr = errors.WithMessage(returnErr,
+				fmt.Sprintf("failed to create DMError to user %v: ", mattermostUserId))
+		}
+	}()
+
+	conf := p.getConfig()
+	channel, appErr := p.API.GetDirectChannel(mattermostUserId, conf.botUserID)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	post = &model.Post{
+		UserId:    conf.botUserID,
+		ChannelId: channel.Id,
+		Message:   fmt.Sprintf(format, args...),
+	}
+
+	_, appErr = p.API.CreatePost(post)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	return post, nil
+}
+
 func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) error {
 	appErr := p.currentInstanceStore.StoreCurrentJIRAInstance(ji)
 	if appErr != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -15,6 +16,69 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 )
+
+type ByteSize int64
+
+const sizeB = ByteSize(1)
+const sizeKb = 1024 * sizeB
+const sizeMb = 1024 * sizeKb
+const sizeGb = 1024 * sizeMb
+const sizeTb = 1024 * sizeGb
+
+var sizeUnits = []ByteSize{sizeTb, sizeGb, sizeMb, sizeKb, sizeB}
+var sizeSuffixes = []string{"Tb", "Gb", "Mb", "Kb", "b"}
+
+func (size ByteSize) String() string {
+	if size == 0 {
+		return "0"
+	}
+	for i, u := range sizeUnits {
+		if size < u {
+			continue
+		}
+		if u == sizeB {
+			return strconv.FormatInt(int64(size), 10) + sizeSuffixes[i]
+		}
+
+		s := strconv.FormatInt(int64((size*10+u/2)/u), 10)
+		l := len(s)
+		switch {
+		case l < 2:
+			return "n/a"
+		case s[l-1] == '0':
+			return s[:l-1] + sizeSuffixes[i]
+		default:
+			return s[:l-1] + "." + s[l-1:] + sizeSuffixes[i]
+		}
+	}
+	return "n/a"
+}
+
+func ParseByteSize(str string) (ByteSize, error) {
+	u := sizeB
+	str = strings.ToLower(str)
+	for i, s := range sizeSuffixes {
+		if strings.HasSuffix(str, strings.ToLower(s)) {
+			str = str[:len(str)-len(s)]
+			u = sizeUnits[i]
+			break
+		}
+	}
+
+	n, err := strconv.ParseInt(str, 10, 64)
+	if err == nil {
+		return ByteSize(n) * u, nil
+	}
+	numerr := err.(*strconv.NumError)
+	if numerr.Err != strconv.ErrSyntax {
+		return 0, err
+	}
+	fl, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return 0, err
+	}
+	return ByteSize(fl * float64(u)), nil
+}
 
 func normalizeInstallURL(jiraURL string) (string, error) {
 	u, err := url.Parse(jiraURL)

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -41,3 +41,51 @@ func TestNormalizeInstallURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		str     string
+		want    ByteSize
+		wantErr bool
+	}{
+		// Happy path
+		{"1234567890123456789", 1234567890123456789, false},
+		{"1234567890123456789b", 1234567890123456789, false},
+		{"4", 4, false},
+		{"4B", 4, false},
+		{"1234b", 1234, false},
+		{"1234.0b", 1234, false},
+		{"1Kb", 1024, false},
+		{"12kb", 12 * 1024, false},
+		{"1.23Kb", 1259, false},
+		{"1234.0kb", 1263616, false},
+		{"1234Mb", 1293942784, false},
+		{"1.234Mb", 1293942, false},
+		{"1234Gb", 1324997410816, false},
+		{"1.234Gb", 1324997410, false},
+		{"1234Tb", 1356797348675584, false},
+		{"1.234tb", 1356797348675, false},
+
+		// Errors
+		{"AA", 0, true},
+		{"1..00kb", 0, true},
+		{" 1.00b", 0, true},
+		{"1AA", 0, true},
+		{"1.0AA", 0, true},
+		{"1/2", 0, true},
+		{"0x10", 0, true},
+		{"88888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			got, err := ParseByteSize(tt.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseByteSize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseByteSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary:
- Adds a **hidden** config `MaxAttachmentSize`, defaults to 10Mb
- Limits upload-able attachment size
- Limits Jira HTTP response size
- Added a convenience `type ByteSize` to work with size values in config
- Includes, and effectively refactors https://github.com/mattermost/mattermost-plugin-jira/pull/248

#### Tickets:
https://mattermost.atlassian.net/browse/MM-17129
https://mattermost.atlassian.net/browse/MM-17133