### PR TITLE
MM-17268: Update display names for RolesAllowedToEditJiraSubscriptions

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -39,7 +39,7 @@
         "default": "system_admin",
         "options": [
             {
-                "display_name": "All Users",
+                "display_name": "All users",
                 "value": "users"
             },
             {

--- a/plugin.json
+++ b/plugin.json
@@ -35,7 +35,7 @@
         "key": "RolesAllowedToEditJiraSubscriptions",
         "display_name": "Mattermost Roles Allowed to Edit Jira Subscriptions",
         "type": "radio",
-        "help_text": "Mattermost users who can subscribe channels to Jira tickets. \\n**Note:** In Team edition, there is no Channel Admin role.  In Enterprise Editions, Channel Admins are those given the “Manage Channel Settings” permission in the active Permissions Scheme. They “can rename channels and edit channel header and purposes” (see [the documentation](https://docs.mattermost.com/deployment/advanced-permissions.html#public-and-private-channel-management) for more info).",
+        "help_text": "Mattermost users who can subscribe channels to Jira tickets.",
         "default": "system_admin",
         "options": [
             {
@@ -43,11 +43,11 @@
                 "value": "users"
             },
             {
-                "display_name": "Channel, Team and System Admins",
+                "display_name": "Users who can manage channel settings",
                 "value": "channel_admin"
             },
             {
-                "display_name": "Team and System Admins",
+                "display_name": "Users who can manage teams",
                 "value": "team_admin"
             },
             {


### PR DESCRIPTION
Notes:
- Follow-up to concerns raised at https://mattermost.atlassian.net/browse/MM-17268 about what exactly the options for the RolesAllowedToEditJiraSubscriptions settings do.
- Proposal was posted here https://community-release.mattermost.com/core/pl/wb7ymm7jztfc7y6q9895ocpyse
- Partially reverts https://github.com/mattermost/mattermost-plugin-jira/pull/251

If other functional changes should be done, let me know.