### PR TITLE
Normalize url on uninstall

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -377,7 +377,11 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 	if len(args) != 1 {
 		return p.help(header)
 	}
-	jiraURL := args[0]
+
+	jiraURL, err := normalizeInstallURL(args[0])
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
 
 	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
 	if err != nil {
@@ -423,7 +427,11 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 	if len(args) != 1 {
 		return p.help(header)
 	}
-	jiraURL := args[0]
+
+	jiraURL, err := normalizeInstallURL(args[0])
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
 
 	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
 	if err != nil {


### PR DESCRIPTION
We are normalizing the url used for the `/install` command but not the `/uninstall` command. This fixes the case where the user has a trailing slash in their url, and the uninstall fails.