### PR TITLE
[MM-17134] Jira connect does not tell you if user has already been mapped

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -101,6 +101,10 @@ func executeConnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, arg
 		return p.responsef(header, "There is no Jira instance installed. Please contact your system administrator.")
 	}
 
+	if jiraUser, err := p.userStore.LoadJIRAUser(instance, header.UserId); err == nil && len(jiraUser.Key()) != 0 {
+		return p.responsef(header, "You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.")
+	}
+
 	redirectURL, err := instance.GetUserConnectURL(header.UserId)
 	if err != nil {
 		return p.responsef(header, "Command failed, please contact your system administrator: %v", err)

--- a/server/command.go
+++ b/server/command.go
@@ -101,7 +101,8 @@ func executeConnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, arg
 		return p.responsef(header, "There is no Jira instance installed. Please contact your system administrator.")
 	}
 
-	if jiraUser, err := p.userStore.LoadJIRAUser(instance, header.UserId); err == nil && len(jiraUser.Key()) != 0 {
+	jiraUser, err := p.userStore.LoadJIRAUser(instance, header.UserId)
+	if err == nil && len(jiraUser.Key()) != 0 {
 		return p.responsef(header, "You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.")
 	}
 

--- a/server/user.go
+++ b/server/user.go
@@ -58,7 +58,8 @@ func httpUserConnect(ji Instance, w http.ResponseWriter, r *http.Request) (int, 
 	}
 
 	// Users shouldn't be able to make multiple connections.
-	if jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId); err == nil && len(jiraUser.Key()) != 0 {
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId)
+	if err == nil && len(jiraUser.Key()) != 0 {
 		return http.StatusBadRequest, errors.New("You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.")
 	}
 

--- a/server/user.go
+++ b/server/user.go
@@ -59,7 +59,7 @@ func httpUserConnect(ji Instance, w http.ResponseWriter, r *http.Request) (int, 
 
 	// Users shouldn't be able to make multiple connections.
 	if jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId); err == nil && len(jiraUser.Key()) != 0 {
-		return http.StatusBadRequest, errors.New("Already connected to a JIRA account. Please use /jira disconnect to disconnect.")
+		return http.StatusBadRequest, errors.New("You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.")
 	}
 
 	redirectURL, err := ji.GetUserConnectURL(mattermostUserId)


### PR DESCRIPTION
#### Summary

This PR fixes the case where the plugin redirects the user to Jira when the user's Mattermost account is already connected.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17134