### PR TITLE
[MM-17510] Make `/jira connect` open in a popup for desktop app

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -96,22 +96,7 @@ func executeConnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, arg
 		return p.help(header)
 	}
 
-	instance, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
-	if err != nil {
-		return p.responsef(header, "There is no Jira instance installed. Please contact your system administrator.")
-	}
-
-	jiraUser, err := p.userStore.LoadJIRAUser(instance, header.UserId)
-	if err == nil && len(jiraUser.Key()) != 0 {
-		return p.responsef(header, "You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.")
-	}
-
-	redirectURL, err := instance.GetUserConnectURL(header.UserId)
-	if err != nil {
-		return p.responsef(header, "Command failed, please contact your system administrator: %v", err)
-	}
-
-	return p.responseRedirect(redirectURL)
+	return p.responsef(header, "Please connect your account using the desktop or browser client.")
 }
 
 func executeDisconnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -44,7 +44,6 @@ type CommandHandler struct {
 
 var jiraCommandHandler = CommandHandler{
 	handlers: map[string]CommandHandlerFunc{
-		"connect":          executeConnect,
 		"disconnect":       executeDisconnect,
 		"install/cloud":    executeInstallCloud,
 		"install/server":   executeInstallServer,
@@ -89,14 +88,6 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArg
 		return p.help(commandArgs), nil
 	}
 	return jiraCommandHandler.Handle(p, c, commandArgs, args[1:]...), nil
-}
-
-func executeConnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	if len(args) != 0 {
-		return p.help(header)
-	}
-
-	return p.responsef(header, "Please connect your account using the desktop or browser client.")
 }
 
 func executeDisconnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -3,6 +3,7 @@
 
 import {openCreateModalWithoutPost, sendEphemeralPost} from '../actions';
 import {isUserConnected, isInstanceInstalled} from '../selectors';
+import PluginId from 'plugin_id';
 
 export default class Hooks {
     constructor(store) {
@@ -23,6 +24,20 @@ export default class Hooks {
             this.store.dispatch(openCreateModalWithoutPost(description, contextArgs.channel_id));
             return Promise.resolve({});
         }
+
+        if (message && (message.startsWith('/jira connect') || message === '/jira connect')) {
+            if (!isInstanceInstalled(this.store.getState())) {
+                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
+                return Promise.resolve({});
+            }
+            if (isUserConnected(this.store.getState())) {
+                sendEphemeralPost(this.store, 'You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.');
+                return Promise.resolve({});
+            }
+            window.open('/plugins/' + PluginId + '/user/connect', '_blank');
+            return Promise.resolve({});
+        }
+
         return Promise.resolve({message, args: contextArgs});
     }
 }


### PR DESCRIPTION
#### Summary

This PR makes it so when the `/jira connect` command is run in the desktop app, the redirect opens in a popup, rather than the browser.

This makes the server-side `connect` command useless, as it is now handled client-side. Should the command be outright removed from the server? 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17510