### PR TITLE
Introduce `/jira subscribe` command to open channel subscriptions modal

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -17,7 +17,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
 	"* `/jira view <issue-key>` or `/jira <issue-key>` - View a Jira issue\n" +
-	"* `/jira subscribe` - Create or edit a subscription for this channel\n" +
+	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
 	"  * [value] can be `on` or `off`\n" +
@@ -571,7 +571,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Jira",
 		Description:      "Integration with Jira.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: connect, disconnect, create, transition, view, settings, install cloud/server, uninstall cloud/server, help",
+		AutoCompleteDesc: "Available commands: connect, disconnect, create, transition, view, subscribe, settings, install cloud/server, uninstall cloud/server, help",
 		AutoCompleteHint: "[command]",
 	}
 }

--- a/server/command.go
+++ b/server/command.go
@@ -17,6 +17,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
 	"* `/jira view <issue-key>` or `/jira <issue-key>` - View a Jira issue\n" +
+	"* `/jira subscribe` - Create or edit a subscription for this channel\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
 	"  * [value] can be `on` or `off`\n" +

--- a/webapp/src/components/setup_ui/setup_ui.jsx
+++ b/webapp/src/components/setup_ui/setup_ui.jsx
@@ -4,53 +4,18 @@
 import {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
-import JiraIcon from 'components/icon';
-
 // SetupUI is a dummy Root component that we use to detect when the user has logged in
 export default class SetupUI extends PureComponent {
     static propTypes = {
-        userConnected: PropTypes.bool,
-        instanceInstalled: PropTypes.bool,
-        registry: PropTypes.object.isRequired,
-        openChannelSettings: PropTypes.func.isRequired,
         haveSetupUI: PropTypes.bool.isRequired,
         finishedSetupUI: PropTypes.func.isRequired,
         setupUI: PropTypes.func.isRequired,
-        setHeaderButtonId: PropTypes.func.isRequired,
-        headerButtonId: PropTypes.string.isRequired,
-    };
-
-    registerHeaderButton = () => {
-        const id = this.props.registry.registerChannelHeaderButtonAction(
-            <JiraIcon/>,
-            (channel) => this.props.openChannelSettings(channel.id),
-            'Jira',
-        );
-        this.props.setHeaderButtonId(id);
     };
 
     componentDidMount() {
-        if (this.props.instanceInstalled && this.props.userConnected && this.props.headerButtonId === '') {
-            this.registerHeaderButton();
-        }
         if (!this.props.haveSetupUI) {
             this.props.setupUI();
             this.props.finishedSetupUI();
-        }
-    }
-
-    componentDidUpdate() {
-        if (!this.props.userConnected || !this.props.instanceInstalled) {
-            if (this.props.headerButtonId !== '') {
-                this.props.registry.unregisterComponent(this.props.headerButtonId);
-                this.props.setHeaderButtonId('');
-            }
-        }
-
-        if (this.props.userConnected && this.props.instanceInstalled) {
-            if (this.props.headerButtonId === '') {
-                this.registerHeaderButton();
-            }
         }
     }
 

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {openCreateModalWithoutPost, sendEphemeralPost} from '../actions';
+import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
 import {isUserConnected, isInstanceInstalled} from '../selectors';
 
 export default class Hooks {
@@ -23,6 +23,20 @@ export default class Hooks {
             this.store.dispatch(openCreateModalWithoutPost(description, contextArgs.channel_id));
             return Promise.resolve({});
         }
+
+        if (message && (message.startsWith('/jira subscribe ') || message === '/jira subscribe')) {
+            if (!isInstanceInstalled(this.store.getState())) {
+                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
+                return Promise.resolve({});
+            }
+            if (!isUserConnected(this.store.getState())) {
+                sendEphemeralPost(this.store, 'Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.');
+                return Promise.resolve({});
+            }
+            this.store.dispatch(openChannelSettings(contextArgs.channel_id));
+            return Promise.resolve({});
+        }
+
         return Promise.resolve({message, args: contextArgs});
     }
 }


### PR DESCRIPTION
#### Summary

Since the channel subscriptions modal does not feature everything we think it needs to for all end-users of an organization, we have decided to remove the channel subscriptions button from the channel header for now, and instead have a `/jira subscribe` command to open the modal. This is also an attempt to make it less intrusive for users that have only one plugin button in the channel header.

See the conversation about this decision here: https://community-release.mattermost.com/core/pl/agm7ar97opnf9g83h97pfwhkke

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17583

I've removed some code that sets up the channel header button, but left the code that the parent component has to hook it up. The former was to make the linter happy, the latter was to make it easier to set up whatever component we need to open the modal in the follow up release, where we improve the channel subscriptions.