### PR TITLE
[MM-17507] Fix issue where empty changelog value shows up as ~~~~

### DIFF
--- a/server/testdata/webhook-issue-updated-multiple-values.json
+++ b/server/testdata/webhook-issue-updated-multiple-values.json
@@ -1,0 +1,222 @@
+{
+  "timestamp": 1550286471789,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_updated",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": "2019-02-15T19:07:41.418-0800",
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i0000r:r",
+      "customfield_10023": null,
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10026": null,
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:07:51.756-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "customfield_10007": null,
+      "security": null,
+      "customfield_10008": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "customfield_10009": null,
+      "summary": "Unit test summary 1",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10000": "{}",
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "11151",
+    "items": [
+      {
+        "field": "Fix Version",
+        "fieldtype": "jira",
+        "fieldId": "fixVersions",
+        "from": "10000",
+        "fromString": "v1",
+        "to": "10001",
+        "toString": "v2"
+      },
+      {
+        "field":            "assignee",
+        "fieldtype":        "jira",
+        "fieldId":          "assignee",
+        "from":             null,
+        "fromString":       null,
+        "to":               "5cedcb4355a88a0fc86388ba",
+        "toString":         "Test User",
+        "tmpFromAccountId": null,
+        "tmpToAccountId":   "5cedcb4355a88a0fc86388ba"
+      },
+      {
+        "field": "QA Steps",
+        "fieldtype": "custom",
+        "fieldId": "customfield_10072",
+        "from": null,
+        "fromString": null,
+        "to": null,
+        "toString": "Make sure it does the thing."
+      }
+    ]
+  }
+}

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -167,6 +167,29 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedHeadline: `Test User updated priority from "High" to "Low" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  true,
 		},
+		"issue multiple values": {
+			Request:                 testWebhookRequest("webhook-issue-updated-multiple-values.json"),
+			ExpectedHeadline:        `Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedSlackAttachment: true,
+			ExpectedFields: []*model.SlackAttachmentField{
+				{
+					Title: "",
+					Value: "**Fix Version:** ~~v1~~ v2",
+					Short: false,
+				},
+				{
+					Title: "",
+					Value: "**Assignee:** ~~_nobody_~~ Test User",
+					Short: false,
+				},
+				{
+					Title: "",
+					Value: "**QA Steps:** ~~None~~ Make sure it does the thing.",
+					Short: false,
+				},
+			},
+			CurrentInstance: true,
+		},
 		"issue raised priority": {
 			Request:          testWebhookRequest("webhook-issue-updated-raised-priority.json"),
 			ExpectedHeadline: `Test User updated priority from "Low" to "High" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -394,6 +394,16 @@ func mergeWebhookEvents(events []*webhook) Webhook {
 
 	for _, event := range events {
 		merged.eventTypes = merged.eventTypes.Union(event.eventTypes)
+
+		fromWithDefault := event.fieldInfo.from
+		if fromWithDefault == "" {
+			fromWithDefault = "None"
+		}
+		toWithDefault := event.fieldInfo.to
+		if toWithDefault == "" {
+			toWithDefault = "None"
+		}
+
 		strikePre := "~~"
 		strikePost := "~~"
 		if event.fieldInfo.name == "description" {
@@ -401,7 +411,7 @@ func mergeWebhookEvents(events []*webhook) Webhook {
 			strikePost = ""
 		}
 		msg := "**" + strings.Title(event.fieldInfo.name) + ":** " + strikePre +
-			event.fieldInfo.from + strikePost + " " + event.fieldInfo.to
+			fromWithDefault + strikePost + " " + toWithDefault
 		merged.fields = append(merged.fields, &model.SlackAttachmentField{
 			Value: msg,
 			Short: false,

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -134,12 +134,12 @@ func parseWebhookChangeLog(jwh *JiraWebhook) Webhook {
 		case field == "issuetype":
 			event = parseWebhookUpdatedField(jwh, eventUpdatedIssuetype, field, fieldId, fromWithDefault, toWithDefault)
 		case field == "Fix Version":
-			event = parseWebhookUpdatedField(jwh, eventUpdatedFixVersion, field, fieldId, from, to)
+			event = parseWebhookUpdatedField(jwh, eventUpdatedFixVersion, field, fieldId, fromWithDefault, toWithDefault)
 		case field == "reporter":
 			event = parseWebhookUpdatedField(jwh, eventUpdatedReporter, field, fieldId, fromWithDefault, toWithDefault)
 		case strings.HasPrefix(fieldId, "customfield_"):
 			eventType := fmt.Sprintf("event_updated_%s", fieldId)
-			event = parseWebhookUpdatedField(jwh, eventType, field, fieldId, from, to)
+			event = parseWebhookUpdatedField(jwh, eventType, field, fieldId, fromWithDefault, toWithDefault)
 		}
 
 		if event != nil {
@@ -394,16 +394,6 @@ func mergeWebhookEvents(events []*webhook) Webhook {
 
 	for _, event := range events {
 		merged.eventTypes = merged.eventTypes.Union(event.eventTypes)
-
-		fromWithDefault := event.fieldInfo.from
-		if fromWithDefault == "" {
-			fromWithDefault = "None"
-		}
-		toWithDefault := event.fieldInfo.to
-		if toWithDefault == "" {
-			toWithDefault = "None"
-		}
-
 		strikePre := "~~"
 		strikePost := "~~"
 		if event.fieldInfo.name == "description" {
@@ -411,7 +401,7 @@ func mergeWebhookEvents(events []*webhook) Webhook {
 			strikePost = ""
 		}
 		msg := "**" + strings.Title(event.fieldInfo.name) + ":** " + strikePre +
-			fromWithDefault + strikePost + " " + toWithDefault
+			event.fieldInfo.from + strikePost + " " + event.fieldInfo.to
 		merged.fields = append(merged.fields, &model.SlackAttachmentField{
 			Value: msg,
 			Short: false,


### PR DESCRIPTION
#### Summary

This PR fixes the issue where the multiple changelog view applies a strikethrough to a blank value, resulting in "~~~~" being shown in the post. Instead, now we show a strikethrough "None", consistent with the single changelog view.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17507