### PR TITLE
Edit `/jira view` help text

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -16,7 +16,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira assign <issue-key> <assignee>` - Change the assignee of a Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira view <issue-key>` - View a Jira issue\n" +
+	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
 	"  * [value] can be `on` or `off`\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -16,7 +16,7 @@ const helpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
 	"* `/jira assign <issue-key> <assignee>` - Change the assignee of a Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira view <issue-key>` or `/jira <issue-key>` - View a Jira issue\n" +
+	"* `/jira view <issue-key>` - View a Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
 	"  * [value] can be `on` or `off`\n" +


### PR DESCRIPTION
Made a change as we don't support `/jira <issue-key>` anymore

`/jira view <issue-key>` ~~or `/jira <issue-key>`~~ - View a Jira issue