### PR TITLE
[MM-17662] Check for nil post before uploading attachments

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -184,15 +184,17 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 			errors.WithMessage(appErr, "failed to create notification post "+create.PostId)
 	}
 
-	go func() {
-		conf := ji.GetPlugin().getConfig()
-		for _, fileId := range post.FileIds {
-			mattermostName, _, e := attachFileToIssue(api, jiraClient, created.ID, fileId, conf.maxAttachmentSize)
-			if e != nil {
-				notifyOnFailedAttachment(ji, mattermostUserId, created.Key, e, "file: %s", mattermostName)
+	if post != nil && len(post.FileIds) > 0 {
+		go func() {
+			conf := ji.GetPlugin().getConfig()
+			for _, fileId := range post.FileIds {
+				mattermostName, _, e := attachFileToIssue(api, jiraClient, created.ID, fileId, conf.maxAttachmentSize)
+				if e != nil {
+					notifyOnFailedAttachment(ji, mattermostUserId, created.Key, e, "file: %s", mattermostName)
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	userBytes, err := json.Marshal(created)
 	if err != nil {


### PR DESCRIPTION
#### Summary

This PR fixes the issue where we assume an issue is being created through a post rather than `/jira create`. This has come up a few times now, so we may want to restructure the function so it is not as easy to make this error.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17662