### PR TITLE
[MM-17750] Support Jira Server `issue_resolved` event

### DIFF
--- a/server/testdata/webhook-server-issue-updated-closed.json
+++ b/server/testdata/webhook-server-issue-updated-closed.json
@@ -1,0 +1,320 @@
+{
+    "timestamp": 1565752078358,
+    "webhookEvent": "jira:issue_updated",
+    "issue_event_type_name": "issue_closed",
+    "user": {
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+        "name": "admin",
+        "key": "admin",
+        "emailAddress": "test@example.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "Asia/Kuala_Lumpur"
+    },
+    "issue": {
+        "id": "10300",
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300",
+        "key": "TES-4",
+        "fields": {
+            "issuetype": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10004",
+                "id": "10004",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+                "name": "Bug",
+                "subtask": false,
+                "avatarId": 10303
+            },
+            "components": [],
+            "timespent": 180,
+            "timeoriginalestimate": null,
+            "description": "Unit test summary 1",
+            "project": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/project/10100",
+                "id": "10100",
+                "key": "TES",
+                "name": "Mattermost TEST",
+                "avatarUrls": {
+                    "48x48": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?avatarId=10324",
+                    "24x24": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&avatarId=10324",
+                    "16x16": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&avatarId=10324",
+                    "32x32": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&avatarId=10324"
+                }
+            },
+            "fixVersions": [],
+            "aggregatetimespent": 180,
+            "resolution": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/resolution/10000",
+                "id": "10000",
+                "description": "Work has been completed on this issue.",
+                "name": "Done"
+            },
+            "timetracking": {
+                "remainingEstimate": "0m",
+                "timeSpent": "3m",
+                "remainingEstimateSeconds": 0,
+                "timeSpentSeconds": 180
+            },
+            "customfield_10105": "0|i0001b:",
+            "attachment": [],
+            "aggregatetimeestimate": 0,
+            "resolutiondate": "2019-08-14T11:03:02.179+0800",
+            "workratio": -1,
+            "summary": "Unit test summary 1",
+            "lastViewed": "2019-08-14T11:07:58.286+0800",
+            "watches": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/watchers",
+                "watchCount": 1,
+                "isWatching": true
+            },
+            "creator": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "subtasks": [],
+            "created": "2019-08-13T06:14:23.580+0800",
+            "reporter": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@55978f01[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@20c026a3[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@15881981[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@34dcc0ad[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1f64727[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@e83e341[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5b12a701[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@919dd66[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3ae57c1d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2bed19eb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@65099938[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@22bc9a12[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "aggregateprogress": {
+                "progress": 180,
+                "total": 180,
+                "percent": 100
+            },
+            "priority": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "customfield_10101": null,
+            "labels": [],
+            "environment": null,
+            "timeestimate": 0,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "duedate": null,
+            "progress": {
+                "progress": 180,
+                "total": 180,
+                "percent": 100
+            },
+            "comment": {
+                "comments": [],
+                "maxResults": 0,
+                "total": 0,
+                "startAt": 0
+            },
+            "issuelinks": [],
+            "votes": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 3,
+                "worklogs": [
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10100",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-13T06:33:40.431+0800",
+                        "updated": "2019-08-13T06:33:40.431+0800",
+                        "started": "2019-08-13T06:33:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10100",
+                        "issueId": "10300"
+                    },
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10200",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-14T10:55:11.917+0800",
+                        "updated": "2019-08-14T10:55:11.917+0800",
+                        "started": "2019-08-14T10:55:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10200",
+                        "issueId": "10300"
+                    },
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10201",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-14T11:03:02.179+0800",
+                        "updated": "2019-08-14T11:03:02.179+0800",
+                        "started": "2019-08-14T11:02:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10201",
+                        "issueId": "10300"
+                    }
+                ]
+            },
+            "assignee": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "updated": "2019-08-14T11:07:58.354+0800",
+            "status": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/status/6",
+                "description": "The issue is considered finished, the resolution is correct. Issues which are closed can be reopened.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/statuses/closed.png",
+                "name": "Closed",
+                "id": "6",
+                "statusCategory": {
+                    "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/3",
+                    "id": 3,
+                    "key": "done",
+                    "colorName": "green",
+                    "name": "Done"
+                }
+            }
+        }
+    },
+    "changelog": {
+        "id": "10511",
+        "items": [
+            {
+                "field": "status",
+                "fieldtype": "jira",
+                "from": "5",
+                "fromString": "Resolved",
+                "to": "6",
+                "toString": "Closed"
+            }
+        ]
+    }
+}

--- a/server/testdata/webhook-server-issue-updated-in-progress.json
+++ b/server/testdata/webhook-server-issue-updated-in-progress.json
@@ -1,0 +1,274 @@
+{
+    "timestamp": 1565751753680,
+    "webhookEvent": "jira:issue_updated",
+    "issue_event_type_name": "issue_work_started",
+    "user": {
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+        "name": "admin",
+        "key": "admin",
+        "emailAddress": "test@example.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "Asia/Kuala_Lumpur"
+    },
+    "issue": {
+        "id": "10300",
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300",
+        "key": "TES-4",
+        "fields": {
+            "issuetype": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10004",
+                "id": "10004",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+                "name": "Bug",
+                "subtask": false,
+                "avatarId": 10303
+            },
+            "components": [],
+            "timespent": 120,
+            "timeoriginalestimate": null,
+            "description": "Unit test summary 1",
+            "project": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/project/10100",
+                "id": "10100",
+                "key": "TES",
+                "name": "Mattermost TEST",
+                "avatarUrls": {
+                    "48x48": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?avatarId=10324",
+                    "24x24": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&avatarId=10324",
+                    "16x16": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&avatarId=10324",
+                    "32x32": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&avatarId=10324"
+                }
+            },
+            "fixVersions": [],
+            "aggregatetimespent": 120,
+            "resolution": null,
+            "timetracking": {
+                "remainingEstimate": "0m",
+                "timeSpent": "2m",
+                "remainingEstimateSeconds": 0,
+                "timeSpentSeconds": 120
+            },
+            "customfield_10105": "0|i0001b:",
+            "attachment": [],
+            "aggregatetimeestimate": 0,
+            "resolutiondate": null,
+            "workratio": -1,
+            "summary": "Unit test summary 1",
+            "lastViewed": "2019-08-14T11:02:33.663+0800",
+            "watches": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/watchers",
+                "watchCount": 1,
+                "isWatching": true
+            },
+            "creator": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "subtasks": [],
+            "created": "2019-08-13T06:14:23.580+0800",
+            "reporter": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2f995140[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7969b50b[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@319b00a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@56e2a70[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3c4c3cfc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2de975c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ba9218a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1fe0ab25[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4216cff9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3484c490[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@168316fb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@ca03e8d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "aggregateprogress": {
+                "progress": 120,
+                "total": 120,
+                "percent": 100
+            },
+            "priority": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "customfield_10101": null,
+            "labels": [],
+            "environment": null,
+            "timeestimate": 0,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "duedate": null,
+            "progress": {
+                "progress": 120,
+                "total": 120,
+                "percent": 100
+            },
+            "comment": {
+                "comments": [],
+                "maxResults": 0,
+                "total": 0,
+                "startAt": 0
+            },
+            "issuelinks": [],
+            "votes": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 2,
+                "worklogs": [
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10100",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-13T06:33:40.431+0800",
+                        "updated": "2019-08-13T06:33:40.431+0800",
+                        "started": "2019-08-13T06:33:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10100",
+                        "issueId": "10300"
+                    },
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10200",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-14T10:55:11.917+0800",
+                        "updated": "2019-08-14T10:55:11.917+0800",
+                        "started": "2019-08-14T10:55:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10200",
+                        "issueId": "10300"
+                    }
+                ]
+            },
+            "assignee": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "updated": "2019-08-14T11:02:33.678+0800",
+            "status": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/status/3",
+                "description": "This issue is being actively worked on at the moment by the assignee.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/statuses/inprogress.png",
+                "name": "In Progress",
+                "id": "3",
+                "statusCategory": {
+                    "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/4",
+                    "id": 4,
+                    "key": "indeterminate",
+                    "colorName": "yellow",
+                    "name": "In Progress"
+                }
+            }
+        }
+    },
+    "changelog": {
+        "id": "10508",
+        "items": [
+            {
+                "field": "status",
+                "fieldtype": "jira",
+                "from": "4",
+                "fromString": "Reopened",
+                "to": "3",
+                "toString": "In Progress"
+            }
+        ]
+    }
+}

--- a/server/testdata/webhook-server-issue-updated-reopened.json
+++ b/server/testdata/webhook-server-issue-updated-reopened.json
@@ -1,0 +1,282 @@
+{
+    "timestamp": 1565751703657,
+    "webhookEvent": "jira:issue_updated",
+    "issue_event_type_name": "issue_reopened",
+    "user": {
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+        "name": "admin",
+        "key": "admin",
+        "emailAddress": "test@example.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "Asia/Kuala_Lumpur"
+    },
+    "issue": {
+        "id": "10300",
+        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300",
+        "key": "TES-4",
+        "fields": {
+            "issuetype": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10004",
+                "id": "10004",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+                "name": "Bug",
+                "subtask": false,
+                "avatarId": 10303
+            },
+            "components": [],
+            "timespent": 120,
+            "timeoriginalestimate": null,
+            "description": "Unit test summary 1",
+            "project": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/project/10100",
+                "id": "10100",
+                "key": "TES",
+                "name": "Mattermost TEST",
+                "avatarUrls": {
+                    "48x48": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?avatarId=10324",
+                    "24x24": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&avatarId=10324",
+                    "16x16": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&avatarId=10324",
+                    "32x32": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&avatarId=10324"
+                }
+            },
+            "fixVersions": [],
+            "aggregatetimespent": 120,
+            "resolution": null,
+            "timetracking": {
+                "remainingEstimate": "0m",
+                "timeSpent": "2m",
+                "remainingEstimateSeconds": 0,
+                "timeSpentSeconds": 120
+            },
+            "customfield_10105": "0|i0001b:",
+            "attachment": [],
+            "aggregatetimeestimate": 0,
+            "resolutiondate": null,
+            "workratio": -1,
+            "summary": "Unit test summary 1",
+            "lastViewed": "2019-08-14T11:01:43.567+0800",
+            "watches": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/watchers",
+                "watchCount": 1,
+                "isWatching": true
+            },
+            "creator": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "subtasks": [],
+            "created": "2019-08-13T06:14:23.580+0800",
+            "reporter": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@326d5177[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3476e016[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@24addff7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2758ed24[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e6df2c3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7c631a72[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@36fb306e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@562aca58[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2720c1b4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4374ffa8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2ce3dfe8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2c1ba826[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "aggregateprogress": {
+                "progress": 120,
+                "total": 120,
+                "percent": 100
+            },
+            "priority": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "customfield_10101": null,
+            "labels": [],
+            "environment": null,
+            "timeestimate": 0,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "duedate": null,
+            "progress": {
+                "progress": 120,
+                "total": 120,
+                "percent": 100
+            },
+            "comment": {
+                "comments": [],
+                "maxResults": 0,
+                "total": 0,
+                "startAt": 0
+            },
+            "issuelinks": [],
+            "votes": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 2,
+                "worklogs": [
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10100",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-13T06:33:40.431+0800",
+                        "updated": "2019-08-13T06:33:40.431+0800",
+                        "started": "2019-08-13T06:33:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10100",
+                        "issueId": "10300"
+                    },
+                    {
+                        "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10200",
+                        "author": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "updateAuthor": {
+                            "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                            "name": "admin",
+                            "key": "admin",
+                            "emailAddress": "test@example.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                            },
+                            "displayName": "admin",
+                            "active": true,
+                            "timeZone": "Asia/Kuala_Lumpur"
+                        },
+                        "comment": "",
+                        "created": "2019-08-14T10:55:11.917+0800",
+                        "updated": "2019-08-14T10:55:11.917+0800",
+                        "started": "2019-08-14T10:55:00.000+0800",
+                        "timeSpent": "1m",
+                        "timeSpentSeconds": 60,
+                        "id": "10200",
+                        "issueId": "10300"
+                    }
+                ]
+            },
+            "assignee": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                "name": "admin",
+                "key": "admin",
+                "emailAddress": "test@example.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                },
+                "displayName": "admin",
+                "active": true,
+                "timeZone": "Asia/Kuala_Lumpur"
+            },
+            "updated": "2019-08-14T11:01:43.647+0800",
+            "status": {
+                "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/status/4",
+                "description": "This issue was once resolved, but the resolution was deemed incorrect. From here issues are either marked assigned or resolved.",
+                "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/statuses/reopened.png",
+                "name": "Reopened",
+                "id": "4",
+                "statusCategory": {
+                    "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "To Do"
+                }
+            }
+        }
+    },
+    "changelog": {
+        "id": "10507",
+        "items": [
+            {
+                "field": "resolution",
+                "fieldtype": "jira",
+                "from": "10000",
+                "fromString": "Done",
+                "to": null,
+                "toString": null
+            },
+            {
+                "field": "status",
+                "fieldtype": "jira",
+                "from": "5",
+                "fromString": "Resolved",
+                "to": "4",
+                "toString": "Reopened"
+            }
+        ]
+    }
+}

--- a/server/testdata/webhook-server-issue-updated-resolved.json
+++ b/server/testdata/webhook-server-issue-updated-resolved.json
@@ -1,0 +1,232 @@
+{
+  "timestamp": 1565652182025,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_resolved",
+  "user": {
+      "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+      "name": "admin",
+      "key": "admin",
+      "emailAddress": "admin@admin.com",
+      "avatarUrls": {
+          "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+          "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+          "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+          "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+      },
+      "displayName": "Test User",
+      "active": true,
+      "timeZone": "Asia/Kuala_Lumpur"
+  },
+  "issue": {
+      "id": "10300",
+      "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300",
+      "key": "TES-4",
+      "fields": {
+          "issuetype": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10004",
+              "id": "10004",
+              "description": "A problem which impairs or prevents the functions of the product.",
+              "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+              "name": "Bug",
+              "subtask": false,
+              "avatarId": 10303
+          },
+          "components": [],
+          "timespent": 60,
+          "timeoriginalestimate": null,
+          "description": null,
+          "project": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/project/10100",
+              "id": "10100",
+              "key": "TES",
+              "name": "Mattermost TEST",
+              "avatarUrls": {
+                  "48x48": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?avatarId=10324",
+                  "24x24": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&avatarId=10324",
+                  "16x16": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&avatarId=10324",
+                  "32x32": "http://some-instance-test.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&avatarId=10324"
+              }
+          },
+          "fixVersions": [],
+          "aggregatetimespent": 60,
+          "resolution": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/resolution/10000",
+              "id": "10000",
+              "description": "Work has been completed on this issue.",
+              "name": "Done"
+          },
+          "timetracking": {
+              "remainingEstimate": "0m",
+              "timeSpent": "1m",
+              "remainingEstimateSeconds": 0,
+              "timeSpentSeconds": 60
+          },
+          "customfield_10105": "0|i0001b:",
+          "attachment": [],
+          "aggregatetimeestimate": 0,
+          "resolutiondate": "2019-08-13T07:23:01.890+0800",
+          "workratio": -1,
+          "summary": "Unit test summary 1",
+          "lastViewed": "2019-08-13T07:23:01.867+0800",
+          "watches": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/watchers",
+              "watchCount": 1,
+              "isWatching": true
+          },
+          "creator": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+              "name": "admin",
+              "key": "admin",
+              "emailAddress": "admin@admin.com",
+              "avatarUrls": {
+                  "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                  "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                  "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                  "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+              },
+              "displayName": "admin",
+              "active": true,
+              "timeZone": "Asia/Kuala_Lumpur"
+          },
+          "subtasks": [],
+          "created": "2019-08-13T06:14:23.580+0800",
+          "reporter": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+              "name": "admin",
+              "key": "admin",
+              "emailAddress": "admin@admin.com",
+              "avatarUrls": {
+                  "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                  "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                  "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                  "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+              },
+              "displayName": "admin",
+              "active": true,
+              "timeZone": "Asia/Kuala_Lumpur"
+          },
+          "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@107a9dde[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f60c664[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@139262c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@38539389[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@43471925[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@489c1628[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5c4151[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@24375508[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5fc2fe9a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@77c79e1c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@15731f7c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@bf297cf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+          "aggregateprogress": {
+              "progress": 60,
+              "total": 60,
+              "percent": 100
+          },
+          "priority": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+              "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+              "name": "Medium",
+              "id": "3"
+          },
+          "customfield_10100": null,
+          "customfield_10101": null,
+          "labels": [],
+          "environment": null,
+          "timeestimate": 0,
+          "aggregatetimeoriginalestimate": null,
+          "versions": [],
+          "duedate": null,
+          "progress": {
+              "progress": 60,
+              "total": 60,
+              "percent": 100
+          },
+          "comment": {
+              "comments": [],
+              "maxResults": 0,
+              "total": 0,
+              "startAt": 0
+          },
+          "issuelinks": [],
+          "votes": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/TES-4/votes",
+              "votes": 0,
+              "hasVoted": false
+          },
+          "worklog": {
+              "startAt": 0,
+              "maxResults": 20,
+              "total": 1,
+              "worklogs": [
+                  {
+                      "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10300/worklog/10100",
+                      "author": {
+                          "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                          "name": "admin",
+                          "key": "admin",
+                          "emailAddress": "admin@admin.com",
+                          "avatarUrls": {
+                              "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                              "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                              "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                              "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                          },
+                          "displayName": "admin",
+                          "active": true,
+                          "timeZone": "Asia/Kuala_Lumpur"
+                      },
+                      "updateAuthor": {
+                          "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=admin",
+                          "name": "admin",
+                          "key": "admin",
+                          "emailAddress": "admin@admin.com",
+                          "avatarUrls": {
+                              "48x48": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=48",
+                              "24x24": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=24",
+                              "16x16": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=16",
+                              "32x32": "https://www.gravatar.com/avatar/64e1b8d34f425d19e1ee2ea7236d3028?d=mm&s=32"
+                          },
+                          "displayName": "admin",
+                          "active": true,
+                          "timeZone": "Asia/Kuala_Lumpur"
+                      },
+                      "comment": "",
+                      "created": "2019-08-13T06:33:40.431+0800",
+                      "updated": "2019-08-13T06:33:40.431+0800",
+                      "started": "2019-08-13T06:33:00.000+0800",
+                      "timeSpent": "1m",
+                      "timeSpentSeconds": 60,
+                      "id": "10100",
+                      "issueId": "10300"
+                  }
+              ]
+          },
+          "assignee": null,
+          "updated": "2019-08-13T07:23:01.993+0800",
+          "status": {
+              "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/status/5",
+              "description": "A resolution has been taken, and it is awaiting verification by reporter. From here issues are either reopened, or are closed.",
+              "iconUrl": "http://some-instance-test.centralus.cloudapp.azure.com:8080/images/icons/statuses/resolved.png",
+              "name": "Resolved",
+              "id": "5",
+              "statusCategory": {
+                  "self": "http://some-instance-test.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/3",
+                  "id": 3,
+                  "key": "done",
+                  "colorName": "green",
+                  "name": "Done"
+              }
+          }
+      }
+  },
+  "changelog": {
+      "id": "10414",
+      "items": [
+          {
+              "field": "status",
+              "fieldtype": "jira",
+              "from": "3",
+              "fromString": "In Progress",
+              "to": "5",
+              "toString": "Resolved"
+          },
+          {
+              "field": "resolution",
+              "fieldtype": "jira",
+              "from": null,
+              "fromString": null,
+              "to": "10000",
+              "toString": "Done"
+          }
+      ]
+  }
+}

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -254,6 +254,34 @@ func TestWebhookHTTP(t *testing.T) {
 			},
 			CurrentInstance: true,
 		},
+		"SERVER issue reopened": {
+			Request:                 testWebhookRequest("webhook-server-issue-updated-reopened.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline:        "Test User updated bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedFields: []*model.SlackAttachmentField{
+				{
+					Title: "",
+					Value: "**Reopened:** ~~Done~~ Open",
+					Short: false,
+				},
+				{
+					Title: "",
+					Value: "**Status:** ~~Resolved~~ Reopened",
+					Short: false,
+				},
+			},
+			CurrentInstance: true,
+		},
+		"SERVER issue in progress": {
+			Request:          testWebhookRequest("webhook-server-issue-updated-in-progress.json"),
+			ExpectedHeadline: "Test User updated status from \"Reopened\" to \"In Progress\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+		},
+		"SERVER issue closed": {
+			Request:          testWebhookRequest("webhook-server-issue-updated-closed.json"),
+			ExpectedHeadline: "Test User updated status from \"Resolved\" to \"Closed\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+
+			CurrentInstance: true,
+		},
 		"issue sprint": {
 			Request:          testWebhookRequest("webhook-issue-updated-sprint.json"),
 			ExpectedHeadline: "Test User updated Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -236,6 +236,24 @@ func TestWebhookHTTP(t *testing.T) {
 			},
 			CurrentInstance: true,
 		},
+		"SERVER issue resolved": {
+			Request:                 testWebhookRequest("webhook-server-issue-updated-resolved.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline:        "Test User updated bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedFields: []*model.SlackAttachmentField{
+				{
+					Title: "",
+					Value: "**Status:** ~~In Progress~~ Resolved",
+					Short: false,
+				},
+				{
+					Title: "",
+					Value: "**Resolved:** ~~Open~~ Done",
+					Short: false,
+				},
+			},
+			CurrentInstance: true,
+		},
 		"issue sprint": {
 			Request:          testWebhookRequest("webhook-issue-updated-sprint.json"),
 			ExpectedHeadline: "Test User updated Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -58,7 +58,7 @@ func ParseWebhook(bb []byte) (wh Webhook, err error) {
 		switch jwh.IssueEventTypeName {
 		case "issue_assigned":
 			wh = parseWebhookAssigned(jwh, jwh.ChangeLog.Items[0].FromString, jwh.ChangeLog.Items[0].ToString)
-		case "issue_updated", "issue_generic", "issue_resolved":
+		case "issue_updated", "issue_generic", "issue_resolved", "issue_closed", "issue_work_started", "issue_reopened":
 			wh = parseWebhookChangeLog(jwh)
 		case "issue_commented":
 			wh, err = parseWebhookCommentCreated(jwh)


### PR DESCRIPTION
#### Summary

This PR adds in the functionality to support the `issue_resolved` sub-event type when parsing the Jira Server webhook.

Edit: `issue_closed`, `issue_reopened`, and `issue_work_started` are also now supported.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17750

[https://github.com/mattermost/mattermost-plugin-jira/issues/272 ](https://github.com/mattermost/mattermost-plugin-jira/issues/272)
[https://github.com/mattermost/mattermost-plugin-jira/issues/277 ](https://github.com/mattermost/mattermost-plugin-jira/issues/277)
