### PR TITLE
[MM-17614] Handle error fetching project e.g. a project was deleted

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.jsx
@@ -107,21 +107,18 @@ export default class ChannelSettingsModalInner extends PureComponent {
     fetchProjects = (projectKeys) => {
         this.props.fetchJiraIssueMetadataForProjects(projectKeys).then((fetched) => {
             const state = {fetchingProjects: false};
-            if (fetched.error) {
-                state.getMetaDataErr = fetched.error.message;
+            state.filters = this.updateFilters(projectKeys);
+
+            const error = fetched.error || (fetched.data && fetched.data.error);
+            if (error) {
+                const message = error.message ? error.message : error;
+                state.getMetaDataErr = message;
             }
             this.setState(state);
         });
     };
 
-    handleProjectChange = (id, value) => {
-        let projects = value;
-        if (!projects) {
-            projects = [];
-        } else if (!Array.isArray(projects)) {
-            projects = [projects];
-        }
-
+    updateFilters = (projects) => {
         // Remove any irrelevant selected choices from other filters
         const issueOptions = getIssueValuesForMultipleProjects(this.props.jiraProjectMetadata, projects);
         const customFields = getCustomFieldValuesForProjects(this.props.jiraIssueMetadata, projects);
@@ -137,11 +134,22 @@ export default class ChannelSettingsModalInner extends PureComponent {
             return true;
         });
 
-        const filters = {
+        return {
             projects,
             issue_types: selectedIssueTypes,
             events: selectedEventTypes,
         };
+    }
+
+    handleProjectChange = (id, value) => {
+        let projects = value;
+        if (!projects) {
+            projects = [];
+        } else if (!Array.isArray(projects)) {
+            projects = [projects];
+        }
+
+        const filters = this.updateFilters(projects);
 
         let fetchingProjects = false;
 

--- a/webapp/src/utils/jira_issue_metadata.jsx
+++ b/webapp/src/utils/jira_issue_metadata.jsx
@@ -8,7 +8,7 @@ const flatten = (arr) => {
 };
 
 export function getProjectValues(metadata) {
-    if (!metadata) {
+    if (!metadata || !metadata.projects) {
         return [];
     }
 
@@ -16,6 +16,10 @@ export function getProjectValues(metadata) {
 }
 
 export function getIssueTypes(metadata, projectKey) {
+    if (!metadata || !metadata.projects) {
+        return [];
+    }
+
     const project = metadata.projects.find((proj) => proj.key === projectKey);
     if (!project) {
         return [];
@@ -24,7 +28,7 @@ export function getIssueTypes(metadata, projectKey) {
 }
 
 export function getIssueValues(metadata, projectKey) {
-    if (!metadata || !projectKey) {
+    if (!metadata || !metadata.issues_per_project || !projectKey) {
         return [];
     }
 
@@ -32,6 +36,10 @@ export function getIssueValues(metadata, projectKey) {
 }
 
 export function getIssueValuesForMultipleProjects(metadata, projectKeys) {
+    if (!metadata || !metadata.projects || !projectKeys) {
+        return [];
+    }
+
     const issueValues = flatten(projectKeys.map((project) => getIssueValues(metadata, project))).filter(Boolean);
 
     const issueTypeHash = {};


### PR DESCRIPTION
#### Summary

This PR lets the webapp gracefully handle when a project is missing from an existing channel subscription. The modal would normally crash in this case. This PR also keeps into account deleted custom fields and issue types.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17614
