### PR TITLE
[MM-17666] Handle desktop app connect auth issue for Jira Server Instance

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -384,7 +384,7 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": false,
+			"instance_installed": "",
 		},
 		&model.WebsocketBroadcast{},
 	)
@@ -434,7 +434,7 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": false,
+			"instance_installed": "",
 		},
 		&model.WebsocketBroadcast{},
 	)
@@ -487,7 +487,7 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 	switch {
 	case uinfo.IsConnected:
 		resp = fmt.Sprintf("Connected to Jira %s as %s.\n", uinfo.JIRAURL, uinfo.JIRAUser.DisplayName)
-	case uinfo.InstanceInstalled:
+	case uinfo.InstanceInstalled != "":
 		resp = fmt.Sprintf("Jira %s is installed, but you are not connected. Please use `/jira connect`.\n", uinfo.JIRAURL)
 	default:
 		return p.responsef(header, "No Jira instance installed, please contact your system administrator.")

--- a/server/command.go
+++ b/server/command.go
@@ -404,7 +404,8 @@ func executeUninstallCloud(p *Plugin, c *plugin.Context, header *model.CommandAr
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": "",
+			"instance_installed": false,
+			"instance_type":      "",
 		},
 		&model.WebsocketBroadcast{},
 	)
@@ -454,7 +455,8 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": "",
+			"instance_installed": false,
+			"instance_type":      "",
 		},
 		&model.WebsocketBroadcast{},
 	)
@@ -507,7 +509,7 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 	switch {
 	case uinfo.IsConnected:
 		resp = fmt.Sprintf("Connected to Jira %s as %s.\n", uinfo.JIRAURL, uinfo.JIRAUser.DisplayName)
-	case uinfo.InstanceInstalled != "":
+	case uinfo.InstanceInstalled:
 		resp = fmt.Sprintf("Jira %s is installed, but you are not connected. Please use `/jira connect`.\n", uinfo.JIRAURL)
 	default:
 		return p.responsef(header, "No Jira instance installed, please contact your system administrator.")

--- a/server/instance.go
+++ b/server/instance.go
@@ -42,7 +42,7 @@ type JIRAInstance struct {
 }
 
 type InstanceStatus struct {
-	InstanceInstalled bool `json:"instance_installed"`
+	InstanceInstalled string `json:"instance_installed"`
 }
 
 var regexpNonAlnum = regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/server/instance.go
+++ b/server/instance.go
@@ -42,7 +42,8 @@ type JIRAInstance struct {
 }
 
 type InstanceStatus struct {
-	InstanceInstalled string `json:"instance_installed"`
+	InstanceInstalled bool   `json:"instance_installed"`
+	InstanceType      string `json:"instance_type"`
 }
 
 var regexpNonAlnum = regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/server/kv.go
+++ b/server/kv.go
@@ -213,7 +213,7 @@ func (store store) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
 	store.plugin.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": true,
+			"instance_installed": ji.GetType(),
 		},
 		&model.WebsocketBroadcast{},
 	)

--- a/server/kv.go
+++ b/server/kv.go
@@ -213,7 +213,8 @@ func (store store) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
 	store.plugin.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": ji.GetType(),
+			"instance_installed": true,
+			"instance_type":      ji.GetType(),
 		},
 		&model.WebsocketBroadcast{},
 	)

--- a/server/user.go
+++ b/server/user.go
@@ -41,7 +41,8 @@ type UserSettings struct {
 type UserInfo struct {
 	JIRAUser
 	IsConnected       bool              `json:"is_connected"`
-	InstanceInstalled string            `json:"instance_installed"`
+	InstanceInstalled bool              `json:"instance_installed"`
+	InstanceType      string            `json:"instance_type"`
 	JIRAURL           string            `json:"jira_url,omitempty"`
 	InstanceDetails   map[string]string `json:"instance_details,omitempty"`
 }
@@ -96,7 +97,8 @@ func httpAPIGetUserInfo(p *Plugin, w http.ResponseWriter, r *http.Request) (int,
 func getUserInfo(p *Plugin, mattermostUserId string) UserInfo {
 	resp := UserInfo{}
 	if ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance(); err == nil {
-		resp.InstanceInstalled = ji.GetType()
+		resp.InstanceInstalled = true
+		resp.InstanceType = ji.GetType()
 		resp.InstanceDetails = ji.GetDisplayDetails()
 		resp.JIRAURL = ji.GetURL()
 		if jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId); err == nil {

--- a/server/user.go
+++ b/server/user.go
@@ -41,7 +41,7 @@ type UserSettings struct {
 type UserInfo struct {
 	JIRAUser
 	IsConnected       bool              `json:"is_connected"`
-	InstanceInstalled bool              `json:"instance_installed"`
+	InstanceInstalled string            `json:"instance_installed"`
 	JIRAURL           string            `json:"jira_url,omitempty"`
 	InstanceDetails   map[string]string `json:"instance_details,omitempty"`
 }
@@ -96,7 +96,7 @@ func httpAPIGetUserInfo(p *Plugin, w http.ResponseWriter, r *http.Request) (int,
 func getUserInfo(p *Plugin, mattermostUserId string) UserInfo {
 	resp := UserInfo{}
 	if ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance(); err == nil {
-		resp.InstanceInstalled = true
+		resp.InstanceInstalled = ji.GetType()
 		resp.InstanceDetails = ji.GetDisplayDetails()
 		resp.JIRAURL = ji.GetURL()
 		if jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId); err == nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -198,7 +198,8 @@ func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) error {
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": ji.GetType(),
+			"instance_installed": true,
+			"instance_type":      ji.GetType(),
 		},
 		&model.WebsocketBroadcast{},
 	)

--- a/server/utils.go
+++ b/server/utils.go
@@ -198,7 +198,7 @@ func (p *Plugin) StoreCurrentJIRAInstanceAndNotify(ji Instance) error {
 	p.API.PublishWebSocketEvent(
 		wSEventInstanceStatus,
 		map[string]interface{}{
-			"instance_installed": true,
+			"instance_installed": ji.GetType(),
 		},
 		&model.WebsocketBroadcast{},
 	)

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -289,24 +289,26 @@ export function handleInstanceStatusChange(store) {
     };
 }
 
-export function sendEphemeralPost(store, message, channelId) {
-    const timestamp = Date.now();
-    const post = {
-        id: 'jiraPlugin' + Date.now(),
-        user_id: store.getState().entities.users.currentUserId,
-        channel_id: channelId || getCurrentChannelId(store.getState()),
-        message,
-        type: 'system_ephemeral',
-        create_at: timestamp,
-        update_at: timestamp,
-        root_id: '',
-        parent_id: '',
-        props: {},
-    };
+export function sendEphemeralPost(message, channelId) {
+    return (dispatch, getState) => {
+        const timestamp = Date.now();
+        const post = {
+            id: 'jiraPlugin' + Date.now(),
+            user_id: getState().entities.users.currentUserId,
+            channel_id: channelId || getCurrentChannelId(getState()),
+            message,
+            type: 'system_ephemeral',
+            create_at: timestamp,
+            update_at: timestamp,
+            root_id: '',
+            parent_id: '',
+            props: {},
+        };
 
-    store.dispatch({
-        type: PostTypes.RECEIVED_NEW_POST,
-        data: post,
-        channelId,
-    });
+        dispatch({
+            type: PostTypes.RECEIVED_NEW_POST,
+            data: post,
+            channelId,
+        });
+    };
 }

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import PluginId from 'plugin_id';
 
+import {isDesktopApp} from 'utils/user_agent';
 import JiraIcon from 'components/icon';
 
 export default class AttachCommentToIssuePostMenuAction extends PureComponent {
@@ -16,6 +17,7 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
         postId: PropTypes.string,
         userConnected: PropTypes.bool.isRequired,
         instanceInstalled: PropTypes.bool.isRequired,
+        sendEphemeralPost: PropTypes.func.isRequired,
     };
 
     static defaultTypes = {
@@ -39,6 +41,10 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
     };
 
     connectClick = () => {
+        if (this.props.instanceInstalled === 'server' && isDesktopApp()) {
+            this.props.sendEphemeralPost('Please use your browser to connect to Jira.');
+            return;
+        }
         window.open('/plugins/' + PluginId + '/user/connect', '_blank');
     };
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/attach_comment_to_issue.jsx
@@ -16,7 +16,8 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
         userConnected: PropTypes.bool.isRequired,
-        instanceInstalled: PropTypes.bool.isRequired,
+        isInstanceInstalled: PropTypes.bool.isRequired,
+        installedInstanceType: PropTypes.bool.isRequired,
         sendEphemeralPost: PropTypes.func.isRequired,
     };
 
@@ -41,7 +42,7 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
     };
 
     connectClick = () => {
-        if (this.props.instanceInstalled === 'server' && isDesktopApp()) {
+        if (this.props.isInstanceInstalled && this.props.installedInstanceType === 'server' && isDesktopApp()) {
             this.props.sendEphemeralPost('Please use your browser to connect to Jira.');
             return;
         }
@@ -49,7 +50,7 @@ export default class AttachCommentToIssuePostMenuAction extends PureComponent {
     };
 
     render() {
-        if (this.props.isSystemMessage || !this.props.instanceInstalled || !this.props.userConnected) {
+        if (this.props.isSystemMessage || !this.props.isInstanceInstalled || !this.props.userConnected) {
             return null;
         }
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openAttachCommentToIssueModal, sendEphemeralPost} from 'actions';
 
-import {getCurrentUserLocale, isUserConnected, getInstanceInstalled} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, getInstalledInstanceType, isInstanceInstalled} from 'selectors';
 import {isCombinedUserActivityPost} from 'utils/posts';
 
 import AttachCommentToIssuePostMenuAction from './attach_comment_to_issue';
@@ -23,7 +23,8 @@ const mapStateToProps = (state, ownProps) => {
         locale: getCurrentUserLocale(state),
         isSystemMessage: systemMessage,
         userConnected: isUserConnected(state),
-        instanceInstalled: getInstanceInstalled(state),
+        isInstanceInstalled: isInstanceInstalled(state),
+        installedInstanceType: getInstalledInstanceType(state),
     };
 };
 

--- a/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
+++ b/webapp/src/components/post_menu_actions/attach_comment_to_issue/index.js
@@ -7,9 +7,9 @@ import {bindActionCreators} from 'redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
-import {openAttachCommentToIssueModal} from 'actions';
+import {openAttachCommentToIssueModal, sendEphemeralPost} from 'actions';
 
-import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, getInstanceInstalled} from 'selectors';
 import {isCombinedUserActivityPost} from 'utils/posts';
 
 import AttachCommentToIssuePostMenuAction from './attach_comment_to_issue';
@@ -23,12 +23,13 @@ const mapStateToProps = (state, ownProps) => {
         locale: getCurrentUserLocale(state),
         isSystemMessage: systemMessage,
         userConnected: isUserConnected(state),
-        instanceInstalled: isInstanceInstalled(state),
+        instanceInstalled: getInstanceInstalled(state),
     };
 };
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     open: openAttachCommentToIssueModal,
+    sendEphemeralPost,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(AttachCommentToIssuePostMenuAction);

--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -5,6 +5,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
 import PluginId from 'plugin_id';
+import {isDesktopApp} from 'utils/user_agent';
 import JiraIcon from 'components/icon';
 
 export default class CreateIssuePostMenuAction extends PureComponent {
@@ -15,6 +16,7 @@ export default class CreateIssuePostMenuAction extends PureComponent {
         postId: PropTypes.string,
         userConnected: PropTypes.bool.isRequired,
         instanceInstalled: PropTypes.bool.isRequired,
+        sendEphemeralPost: PropTypes.func.isRequired,
     };
 
     static defaultTypes = {
@@ -38,6 +40,10 @@ export default class CreateIssuePostMenuAction extends PureComponent {
     };
 
     connectClick = () => {
+        if (this.props.instanceInstalled === 'server' && isDesktopApp()) {
+            this.props.sendEphemeralPost('Please use your browser to connect to Jira.');
+            return;
+        }
         window.open('/plugins/' + PluginId + '/user/connect', '_blank');
     };
 

--- a/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_actions/create_issue/create_issue.jsx
@@ -15,7 +15,8 @@ export default class CreateIssuePostMenuAction extends PureComponent {
         open: PropTypes.func.isRequired,
         postId: PropTypes.string,
         userConnected: PropTypes.bool.isRequired,
-        instanceInstalled: PropTypes.bool.isRequired,
+        installedInstanceType: PropTypes.string.isRequired,
+        isInstanceInstalled: PropTypes.bool.isRequired,
         sendEphemeralPost: PropTypes.func.isRequired,
     };
 
@@ -40,7 +41,7 @@ export default class CreateIssuePostMenuAction extends PureComponent {
     };
 
     connectClick = () => {
-        if (this.props.instanceInstalled === 'server' && isDesktopApp()) {
+        if (this.props.isInstanceInstalled && this.props.installedInstanceType === 'server' && isDesktopApp()) {
             this.props.sendEphemeralPost('Please use your browser to connect to Jira.');
             return;
         }
@@ -48,7 +49,7 @@ export default class CreateIssuePostMenuAction extends PureComponent {
     };
 
     render() {
-        if (this.props.isSystemMessage || !this.props.instanceInstalled) {
+        if (this.props.isSystemMessage || !this.props.isInstanceInstalled) {
             return null;
         }
 

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -7,9 +7,9 @@ import {bindActionCreators} from 'redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
-import {openCreateModal} from 'actions';
+import {openCreateModal, sendEphemeralPost} from 'actions';
 
-import {getCurrentUserLocale, isUserConnected, isInstanceInstalled} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, getInstanceInstalled} from 'selectors';
 import {isCombinedUserActivityPost} from 'utils/posts';
 
 import CreateIssuePostMenuAction from './create_issue';
@@ -23,12 +23,13 @@ const mapStateToProps = (state, ownProps) => {
         locale: getCurrentUserLocale(state),
         isSystemMessage: systemMessage,
         userConnected: isUserConnected(state),
-        instanceInstalled: isInstanceInstalled(state),
+        instanceInstalled: getInstanceInstalled(state),
     };
 };
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     open: openCreateModal,
+    sendEphemeralPost,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateIssuePostMenuAction);

--- a/webapp/src/components/post_menu_actions/create_issue/index.js
+++ b/webapp/src/components/post_menu_actions/create_issue/index.js
@@ -9,7 +9,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {openCreateModal, sendEphemeralPost} from 'actions';
 
-import {getCurrentUserLocale, isUserConnected, getInstanceInstalled} from 'selectors';
+import {getCurrentUserLocale, isUserConnected, getInstalledInstanceType, isInstanceInstalled} from 'selectors';
 import {isCombinedUserActivityPost} from 'utils/posts';
 
 import CreateIssuePostMenuAction from './create_issue';
@@ -23,7 +23,8 @@ const mapStateToProps = (state, ownProps) => {
         locale: getCurrentUserLocale(state),
         isSystemMessage: systemMessage,
         userConnected: isUserConnected(state),
-        instanceInstalled: getInstanceInstalled(state),
+        isInstanceInstalled: isInstanceInstalled(state),
+        installedInstanceType: getInstalledInstanceType(state),
     };
 };
 

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -3,7 +3,7 @@
 
 import {isDesktopApp} from '../utils/user_agent';
 import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
-import {isUserConnected, getInstanceInstalled, isInstanceInstalled} from '../selectors';
+import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
 import PluginId from 'plugin_id';
 
 export default class Hooks {
@@ -27,8 +27,7 @@ export default class Hooks {
         }
 
         if (message && (message.startsWith('/jira connect') || message === '/jira connect')) {
-            const instance = getInstanceInstalled(this.store.getState());
-            if (!instance) {
+            if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
             }
@@ -36,7 +35,7 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.'));
                 return Promise.resolve({});
             }
-            if (instance === 'server' && isDesktopApp()) {
+            if (getInstalledInstanceType(this.store.getState()) === 'server' && isDesktopApp()) {
                 this.store.dispatch(sendEphemeralPost('Please use your browser to connect to Jira.'));
                 return Promise.resolve({});
             }

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -14,11 +14,11 @@ export default class Hooks {
     slashCommandWillBePostedHook = (message, contextArgs) => {
         if (message && (message.startsWith('/jira create ') || message === '/jira create')) {
             if (!isInstanceInstalled(this.store.getState())) {
-                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
+                this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
             }
             if (!isUserConnected(this.store.getState())) {
-                sendEphemeralPost(this.store, 'Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.');
+                this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
                 return Promise.resolve({});
             }
             const description = message.slice(12).trim();
@@ -29,15 +29,15 @@ export default class Hooks {
         if (message && (message.startsWith('/jira connect') || message === '/jira connect')) {
             const instance = getInstanceInstalled(this.store.getState());
             if (!instance) {
-                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
+                this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
             }
             if (isUserConnected(this.store.getState())) {
-                sendEphemeralPost(this.store, 'You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.');
+                this.store.dispatch(sendEphemeralPost('You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.'));
                 return Promise.resolve({});
             }
             if (instance === 'server' && isDesktopApp()) {
-                sendEphemeralPost(this.store, 'Please use your browser to connect to Jira.');
+                this.store.dispatch(sendEphemeralPost('Please use your browser to connect to Jira.'));
                 return Promise.resolve({});
             }
 
@@ -47,11 +47,11 @@ export default class Hooks {
 
         if (message && (message.startsWith('/jira subscribe ') || message === '/jira subscribe')) {
             if (!isInstanceInstalled(this.store.getState())) {
-                sendEphemeralPost(this.store, 'There is no Jira instance installed. Please contact your system administrator.');
+                this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
             }
             if (!isUserConnected(this.store.getState())) {
-                sendEphemeralPost(this.store, 'Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.');
+                this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
                 return Promise.resolve({});
             }
             this.store.dispatch(openChannelSettings(contextArgs.channel_id));

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -14,7 +14,7 @@ function userConnected(state = false, action) {
     }
 }
 
-function instanceInstalled(state = '', action) {
+function instanceInstalled(state = false, action) {
     // We're notified of the instance status at startup (through getConnected)
     // and when we get a websocket instance_status event
     switch (action.type) {
@@ -22,6 +22,17 @@ function instanceInstalled(state = '', action) {
         return action.data.instance_installed ? action.data.instance_installed : state;
     case ActionTypes.RECEIVED_INSTANCE_STATUS:
         return action.data.instance_installed;
+    default:
+        return state;
+    }
+}
+
+function instanceType(state = '', action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_CONNECTED:
+        return action.data.instance_type ? action.data.instance_type : state;
+    case ActionTypes.RECEIVED_INSTANCE_STATUS:
+        return action.data.instance_type;
     default:
         return state;
     }
@@ -134,6 +145,7 @@ const channelSubscripitons = (state = {}, action) => {
 export default combineReducers({
     userConnected,
     instanceInstalled,
+    instanceType,
     createModalVisible,
     createModal,
     attachCommentToIssueModalVisible,

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -14,7 +14,7 @@ function userConnected(state = false, action) {
     }
 }
 
-function instanceInstalled(state = false, action) {
+function instanceInstalled(state = '', action) {
     // We're notified of the instance status at startup (through getConnected)
     // and when we get a websocket instance_status event
     switch (action.type) {

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -55,4 +55,6 @@ export const getChannelSubscriptions = (state) => getPluginState(state).channelS
 
 export const isUserConnected = (state) => getPluginState(state).userConnected;
 
-export const isInstanceInstalled = (state) => getPluginState(state).instanceInstalled;
+export const getInstanceInstalled = (state) => getPluginState(state).instanceInstalled;
+
+export const isInstanceInstalled = (state) => Boolean(getPluginState(state).instanceInstalled);

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -55,6 +55,6 @@ export const getChannelSubscriptions = (state) => getPluginState(state).channelS
 
 export const isUserConnected = (state) => getPluginState(state).userConnected;
 
-export const getInstanceInstalled = (state) => getPluginState(state).instanceInstalled;
+export const isInstanceInstalled = (state) => getPluginState(state).instanceInstalled;
 
-export const isInstanceInstalled = (state) => Boolean(getPluginState(state).instanceInstalled);
+export const getInstalledInstanceType = (state) => getPluginState(state).instanceType;

--- a/webapp/src/utils/user_agent.jsx
+++ b/webapp/src/utils/user_agent.jsx
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const userAgent = window.navigator.userAgent;
+
+export function isDesktopApp() {
+    return userAgent.indexOf('Mattermost') !== -1 && userAgent.indexOf('Electron') !== -1;
+}


### PR DESCRIPTION
#### Summary

This PR solves the issue of the Jira Server authentication window hanging when using the desktop app. We first determine if they are `using desktop && installed Jira Server`, then prompt the user to use the browser instead of opening the popup.

The login `redirect_to` solution does not work because the url needs to be within the supported webapp UI routes. Also, the connect url does not load in an external browser if your domain is the server's SiteURL, so that is not an option.

There is also the server-side backup connect command in case the hooks do not load properly.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17666
https://mattermost.atlassian.net/browse/MM-17699

The message is currently set to be `Please use your browser to connect to Jira.` This message only shows when they are using the desktop app with a Jira Server instance.

![image](https://user-images.githubusercontent.com/6913320/63002389-d6f55780-be43-11e9-91c6-db804935501f.png)
