### PR TITLE
[MM-17809] Include version and hash in `/jira info`

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -15,17 +15,24 @@ const pluginIdGoFileTemplate = `package main
 var manifest = struct {
 	Id      string
 	Version string
+	Hash    string
 }{
 	Id:      "%s",
 	Version: "%s",
+	Hash:    "%s",
 }
 `
 
 const pluginIdJsFileTemplate = `export const id = '%s';
 export const version = '%s';
+export const hash = '%s';
 `
 
+var buildHash string
+
 func main() {
+	buildHash = buildHash[:7]
+
 	if len(os.Args) <= 1 {
 		panic("no cmd specified")
 	}
@@ -42,6 +49,9 @@ func main() {
 
 	case "version":
 		dumpPluginVersion(manifest)
+
+	case "hash":
+		fmt.Printf("%s", buildHash)
 
 	case "has_server":
 		if manifest.HasServer() {
@@ -101,7 +111,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasServer() {
 		if err := ioutil.WriteFile(
 			"server/manifest.go",
-			[]byte(fmt.Sprintf(pluginIdGoFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIdGoFileTemplate, manifest.Id, manifest.Version, buildHash)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to write server/manifest.go")
@@ -111,7 +121,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasWebapp() {
 		if err := ioutil.WriteFile(
 			"webapp/src/manifest.js",
-			[]byte(fmt.Sprintf(pluginIdJsFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIdJsFileTemplate, manifest.Id, manifest.Version, buildHash)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to open webapp/src/manifest.js")

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -4,8 +4,10 @@ ifeq ($(GO),)
     $(error "go is not available: see https://golang.org/doc/install")
 endif
 
+BUILD_HASH = $(shell git rev-parse HEAD)
+
 # Ensure that the build tools are compiled. Go's caching makes this quick.
-$(shell cd build/manifest && $(GO) build -o ../bin/manifest)
+$(shell cd build/manifest && $(GO) build -ldflags "-X main.buildHash=$(BUILD_HASH)" -o ../bin/manifest)
 
 # Extract the plugin id from the manifest.
 PLUGIN_ID ?= $(shell build/bin/manifest id)

--- a/server/command.go
+++ b/server/command.go
@@ -483,12 +483,12 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 
 	uinfo := getUserInfo(p, header.UserId)
 
-	resp := ""
+	resp := fmt.Sprintf("Jira plugin version: %s\nJira plugin hash: %s\n\n", manifest.Version, manifest.Hash)
 	switch {
 	case uinfo.IsConnected:
-		resp = fmt.Sprintf("Connected to Jira %s as %s.\n", uinfo.JIRAURL, uinfo.JIRAUser.DisplayName)
+		resp += fmt.Sprintf("Connected to Jira %s as %s.\n", uinfo.JIRAURL, uinfo.JIRAUser.DisplayName)
 	case uinfo.InstanceInstalled:
-		resp = fmt.Sprintf("Jira %s is installed, but you are not connected. Please use `/jira connect`.\n", uinfo.JIRAURL)
+		resp += fmt.Sprintf("Jira %s is installed, but you are not connected. Please use `/jira connect`.\n", uinfo.JIRAURL)
 	default:
 		return p.responsef(header, "No Jira instance installed, please contact your system administrator.")
 	}

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -3,7 +3,9 @@ package main
 var manifest = struct {
 	Id      string
 	Version string
+	Hash    string
 }{
 	Id:      "jira",
 	Version: "2.1.0",
+	Hash:    "5ebe3c8",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,3 @@
 export const id = 'jira';
 export const version = '2.1.0';
+export const hash = '5ebe3c8';


### PR DESCRIPTION
#### Summary
- It's tough to debug during development (or on customer installs) when we're not exactly sure what version and commit is running

#### Links
- [MM-17809](https://mattermost.atlassian.net/browse/MM-17809)
- Would have been useful for: [MM-17794](https://mattermost.atlassian.net/browse/MM-17794)