### PR TITLE
[MM-17849] Make sure post headline says 'mentioned you' when you are the assignee

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 }{
 	Id:      "jira",
 	Version: "2.1.0",
-	Hash:    "ba80f9f",
+	Hash:    "8e17cf0",
 }

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -239,6 +239,8 @@ func appendCommentNotifications(wh *webhook) {
 	message := fmt.Sprintf("%s mentioned you on %s:\n>%s",
 		commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body)
 
+	assigneeMentioned := false
+
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {
 		isAccountId := false
 		if strings.HasPrefix(u, "accountid:") {
@@ -251,9 +253,9 @@ func appendCommentNotifications(wh *webhook) {
 			continue
 		}
 
-		// don't mention the Issue assignee, will get a special notice
+		// Avoid duplicated mention for assignee. Boolean value is checked after the loop.
 		if jwh.Issue.Fields.Assignee != nil && (u == jwh.Issue.Fields.Assignee.Name || u == jwh.Issue.Fields.Assignee.AccountID) {
-			continue
+			assigneeMentioned = true
 		}
 
 		notification := webhookNotification{
@@ -272,8 +274,9 @@ func appendCommentNotifications(wh *webhook) {
 	}
 
 	// Don't send a notification to the assignee if they don't exist, or if are also the author.
+	// Also, if the assignee was mentioned above, avoid sending a duplicate notification here.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
-	if jwh.Issue.Fields.Assignee == nil || jwh.Issue.Fields.Assignee.Name == jwh.User.Name ||
+	if assigneeMentioned || jwh.Issue.Fields.Assignee == nil || jwh.Issue.Fields.Assignee.Name == jwh.User.Name ||
 		(jwh.Issue.Fields.Assignee.AccountID != "" && jwh.Issue.Fields.Assignee.AccountID == jwh.Comment.UpdateAuthor.AccountID) {
 		return
 	}

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,3 +1,3 @@
 export const id = 'jira';
 export const version = '2.1.0';
-export const hash = 'ba80f9f';
+export const hash = '8e17cf0';


### PR DESCRIPTION
#### Summary

This PR fixes the issue where if the assignee gets mentioned in a comment, the headline would display `(user) commented on (issue)`. Now it correctly shows `(user) mentioned you on (issue)`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17849