### PR TITLE
Include missing event type name fix (#287) for patch release

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 }{
 	Id:      "jira",
 	Version: "2.1.0",
-	Hash:    "5ebe3c8",
+	Hash:    "06a79da",
 }

--- a/server/testdata/webhook-server-comment-deleted.json
+++ b/server/testdata/webhook-server-comment-deleted.json
@@ -1,0 +1,56 @@
+{
+    "timestamp": 1559610488109,
+    "webhookEvent": "comment_deleted",
+    "user": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+        "name": "levbrouk",
+        "key": "levbrouk",
+        "emailAddress": "lev@mattermost.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+        },
+        "displayName": "Lev Brouk",
+        "active": true,
+        "timeZone": "Etc/UTC"
+    },
+    "comment": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10084",
+        "id": "10084",
+        "author": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "body": "and higher eeven higher",
+        "updateAuthor": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "created": "2019-06-04T00:50:04.873+0000",
+        "updated": "2019-06-04T00:53:33.665+0000"
+    }
+}

--- a/server/testdata/webhook-server-comment-updated.json
+++ b/server/testdata/webhook-server-comment-updated.json
@@ -1,0 +1,56 @@
+{
+    "timestamp": 1559609613673,
+    "webhookEvent": "comment_updated",
+    "user": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+        "name": "levbrouk",
+        "key": "levbrouk",
+        "emailAddress": "lev@mattermost.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+        },
+        "displayName": "Lev Brouk",
+        "active": true,
+        "timeZone": "Etc/UTC"
+    },
+    "comment": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10084",
+        "id": "10084",
+        "author": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "body": "and higher eeven higher",
+        "updateAuthor": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "created": "2019-06-04T00:50:04.873+0000",
+        "updated": "2019-06-04T00:53:33.665+0000"
+    }
+}

--- a/server/testdata/webhook-server-old-issue-updated-no-event-type-assigned.json
+++ b/server/testdata/webhook-server-old-issue-updated-no-event-type-assigned.json
@@ -1,0 +1,216 @@
+{
+  "timestamp": 1550287081752,
+  "webhookEvent": "jira:issue_updated",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "lastViewed": "2019-02-15T19:07:41.418-0800",
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i0000r:r",
+      "customfield_10023": null,
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "customfield_10026": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "updated": "2019-02-15T19:18:01.707-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long, a little longer now",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "customfield_10007": null,
+      "security": null,
+      "customfield_10008": null,
+      "aggregatetimeestimate": null,
+      "customfield_10009": null,
+      "attachment": [],
+      "summary": "Unit test summary 1",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "customfield_10000": "{}",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10230",
+    "items": [
+      {
+        "field": "assignee",
+        "fieldtype": "jira",
+        "fieldId": "assignee",
+        "from": null,
+        "fromString": null,
+        "to": "admin",
+        "toString": "Test User"
+      }
+    ]
+  }
+}

--- a/server/testdata/webhook-server-old-issue-updated-no-event-type-comment-deleted.json
+++ b/server/testdata/webhook-server-old-issue-updated-no-event-type-comment-deleted.json
@@ -1,0 +1,568 @@
+{
+    "timestamp": 1559610488109,
+    "webhookEvent": "jira:issue_updated",
+    "user": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+        "name": "levbrouk",
+        "key": "levbrouk",
+        "emailAddress": "lev@mattermost.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+        },
+        "displayName": "Lev Brouk",
+        "active": true,
+        "timeZone": "Etc/UTC"
+    },
+    "issue": {
+        "id": "10013",
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013",
+        "key": "PRJX-14",
+        "fields": {
+            "issuetype": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10001",
+                "id": "10001",
+                "description": "Created by JIRA Software - do not edit or delete. Issue type for a user story.",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/issuetypes/story.svg",
+                "name": "Story",
+                "subtask": false
+            },
+            "timespent": null,
+            "project": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/project/10000",
+                "id": "10000",
+                "key": "PRJX",
+                "name": "ProjectX",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?pid=10000&avatarId=10210",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10210",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&pid=10000&avatarId=10210",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&pid=10000&avatarId=10210"
+                }
+            },
+            "fixVersions": [],
+            "customfield_10110": null,
+            "customfield_10111": null,
+            "aggregatetimespent": null,
+            "resolution": null,
+            "customfield_10112": null,
+            "customfield_10113": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@283ea221[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d6f11a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@1486f769[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f0a937b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2f81d11[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34907275[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@170ee631[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1c943ee0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5ec6b8f6[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69f26a81[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@9ad36e0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34736a0b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5f19757b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10114": "0|i000bj:",
+            "customfield_10104": [
+                "com.atlassian.greenhopper.service.sprint.Sprint@a88a698[id=1,rapidViewId=1,state=ACTIVE,name=Sample Sprint 2,startDate=2018-05-09T06:39:30.147Z,endDate=2018-05-23T06:59:30.147Z,completeDate=<null>,sequence=1,goal=<null>]"
+            ],
+            "customfield_10105": "0|i0002v:",
+            "customfield_10106": 3.0,
+            "customfield_10107": null,
+            "customfield_10108": null,
+            "customfield_10109": null,
+            "resolutiondate": null,
+            "workratio": -1,
+            "lastViewed": "2019-06-04T01:08:08.103+0000",
+            "watches": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/watchers",
+                "watchCount": 2,
+                "isWatching": true
+            },
+            "created": "2018-05-15T11:39:29.303+0000",
+            "priority": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "labels": [],
+            "timeestimate": null,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "issuelinks": [],
+            "assignee": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                "name": "levbrouk",
+                "key": "levbrouk",
+                "emailAddress": "lev@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                },
+                "displayName": "Lev Brouk",
+                "active": true,
+                "timeZone": "Etc/UTC"
+            },
+            "updated": "2019-06-04T01:08:08.107+0000",
+            "status": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/status/10000",
+                "description": "",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/",
+                "name": "To Do",
+                "id": "10000",
+                "statusCategory": {
+                    "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "To Do"
+                }
+            },
+            "components": [],
+            "timeoriginalestimate": null,
+            "description": "*Creating Quick Filters*\n\nYou can add your own Quick Filters in the board configuration (select *Board > Configure*)",
+            "customfield_10130": null,
+            "customfield_10131": null,
+            "timetracking": {},
+            "customfield_10126": null,
+            "customfield_10127": null,
+            "customfield_10128": null,
+            "customfield_10129": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "summary": "As a user, I can find important items on the board by using the customisable \"Quick Filters\" above >> Try clicking the \"Only My Issues\" Quick Filter above",
+            "creator": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "subtasks": [],
+            "reporter": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "customfield_10120": null,
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2341de9[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@167f1bef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@687ec019[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1270a585[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@30093977[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e47fcfa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@40a79123[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57ec483f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2e570134[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f168828[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@33443660[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6dc3d87[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1014d2c9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10121": null,
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "customfield_10122": null,
+            "customfield_10123": null,
+            "customfield_10124": null,
+            "customfield_10125": null,
+            "customfield_10115": null,
+            "customfield_10116": null,
+            "environment": null,
+            "customfield_10117": "false",
+            "customfield_10118": null,
+            "customfield_10119": "false",
+            "duedate": null,
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "comment": {
+                "comments": [
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+                        "id": "10005",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2018-05-15T11:39:29.299+0000",
+                        "updated": "2018-05-15T11:39:29.299+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10043",
+                        "id": "10043",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Update test comments....",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T16:18:52.995+0000",
+                        "updated": "2019-02-27T16:18:52.995+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10044",
+                        "id": "10044",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Another comment...",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T20:11:05.906+0000",
+                        "updated": "2019-02-27T20:11:05.906+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10076",
+                        "id": "10076",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "and more comments",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:32:03.233+0000",
+                        "updated": "2019-06-03T23:32:03.233+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10077",
+                        "id": "10077",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sdfsdfs",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:38:52.611+0000",
+                        "updated": "2019-06-03T23:38:52.611+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10078",
+                        "id": "10078",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:05:47.936+0000",
+                        "updated": "2019-06-04T00:05:47.936+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10079",
+                        "id": "10079",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "slsdkjf lksdj f",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:06:53.965+0000",
+                        "updated": "2019-06-04T00:06:53.965+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10080",
+                        "id": "10080",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:08:45.402+0000",
+                        "updated": "2019-06-04T00:08:45.402+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10081",
+                        "id": "10081",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:10:21.326+0000",
+                        "updated": "2019-06-04T00:10:21.326+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10083",
+                        "id": "10083",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "very low",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:29:43.704+0000",
+                        "updated": "2019-06-04T00:29:43.704+0000"
+                    }
+                ],
+                "maxResults": 10,
+                "total": 10,
+                "startAt": 0
+            },
+            "votes": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 0,
+                "worklogs": []
+            }
+        }
+    }
+}

--- a/server/testdata/webhook-server-old-issue-updated-no-event-type-comment-edited.json
+++ b/server/testdata/webhook-server-old-issue-updated-no-event-type-comment-edited.json
@@ -1,0 +1,679 @@
+{
+    "timestamp": 1559609613673,
+    "webhookEvent": "jira:issue_updated",
+    "user": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+        "name": "levbrouk",
+        "key": "levbrouk",
+        "emailAddress": "lev@mattermost.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+        },
+        "displayName": "Lev Brouk",
+        "active": true,
+        "timeZone": "Etc/UTC"
+    },
+    "issue": {
+        "id": "10013",
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013",
+        "key": "PRJX-14",
+        "fields": {
+            "issuetype": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10001",
+                "id": "10001",
+                "description": "Created by JIRA Software - do not edit or delete. Issue type for a user story.",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/issuetypes/story.svg",
+                "name": "Story",
+                "subtask": false
+            },
+            "timespent": null,
+            "project": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/project/10000",
+                "id": "10000",
+                "key": "PRJX",
+                "name": "ProjectX",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?pid=10000&avatarId=10210",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10210",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&pid=10000&avatarId=10210",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&pid=10000&avatarId=10210"
+                }
+            },
+            "fixVersions": [],
+            "customfield_10110": null,
+            "customfield_10111": null,
+            "aggregatetimespent": null,
+            "resolution": null,
+            "customfield_10112": null,
+            "customfield_10113": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@681be77a[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6974c5f2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@644889d3[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bc75c36[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4c504403[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3c4532e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@23e24494[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@62858a32[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2cbbaa3d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@dc7d1a7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3c30f26f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@72aa3bc1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3b19deb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10114": "0|i000bj:",
+            "customfield_10104": [
+                "com.atlassian.greenhopper.service.sprint.Sprint@a88a698[id=1,rapidViewId=1,state=ACTIVE,name=Sample Sprint 2,startDate=2018-05-09T06:39:30.147Z,endDate=2018-05-23T06:59:30.147Z,completeDate=<null>,sequence=1,goal=<null>]"
+            ],
+            "customfield_10105": "0|i0002v:",
+            "customfield_10106": 3.0,
+            "customfield_10107": null,
+            "customfield_10108": null,
+            "customfield_10109": null,
+            "resolutiondate": null,
+            "workratio": -1,
+            "lastViewed": "2019-06-04T00:53:33.664+0000",
+            "watches": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/watchers",
+                "watchCount": 2,
+                "isWatching": true
+            },
+            "created": "2018-05-15T11:39:29.303+0000",
+            "priority": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "labels": [],
+            "timeestimate": null,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "issuelinks": [],
+            "assignee": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                "name": "levbrouk",
+                "key": "levbrouk",
+                "emailAddress": "lev@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                },
+                "displayName": "Lev Brouk",
+                "active": true,
+                "timeZone": "Etc/UTC"
+            },
+            "updated": "2019-06-04T00:50:04.873+0000",
+            "status": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/status/10000",
+                "description": "",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/",
+                "name": "To Do",
+                "id": "10000",
+                "statusCategory": {
+                    "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "To Do"
+                }
+            },
+            "components": [],
+            "timeoriginalestimate": null,
+            "description": "*Creating Quick Filters*\n\nYou can add your own Quick Filters in the board configuration (select *Board > Configure*)",
+            "customfield_10130": null,
+            "customfield_10131": null,
+            "timetracking": {},
+            "customfield_10126": null,
+            "customfield_10127": null,
+            "customfield_10128": null,
+            "customfield_10129": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "summary": "As a user, I can find important items on the board by using the customisable \"Quick Filters\" above >> Try clicking the \"Only My Issues\" Quick Filter above",
+            "creator": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "subtasks": [],
+            "reporter": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "customfield_10120": null,
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3e96da3c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2808d52[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@cee975f[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@162b7903[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1e6416c0[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1808f243[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@60a4ca72[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d8a5404[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@13e69563[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c23f7b6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@a12431a[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75471c28[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@52add26e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10121": null,
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "customfield_10122": null,
+            "customfield_10123": null,
+            "customfield_10124": null,
+            "customfield_10125": null,
+            "customfield_10115": null,
+            "customfield_10116": null,
+            "environment": null,
+            "customfield_10117": "false",
+            "customfield_10118": null,
+            "customfield_10119": "false",
+            "duedate": null,
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "comment": {
+                "comments": [
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+                        "id": "10005",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2018-05-15T11:39:29.299+0000",
+                        "updated": "2018-05-15T11:39:29.299+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10043",
+                        "id": "10043",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Update test comments....",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T16:18:52.995+0000",
+                        "updated": "2019-02-27T16:18:52.995+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10044",
+                        "id": "10044",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Another comment...",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T20:11:05.906+0000",
+                        "updated": "2019-02-27T20:11:05.906+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10076",
+                        "id": "10076",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "and more comments",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:32:03.233+0000",
+                        "updated": "2019-06-03T23:32:03.233+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10077",
+                        "id": "10077",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sdfsdfs",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:38:52.611+0000",
+                        "updated": "2019-06-03T23:38:52.611+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10078",
+                        "id": "10078",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:05:47.936+0000",
+                        "updated": "2019-06-04T00:05:47.936+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10079",
+                        "id": "10079",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "slsdkjf lksdj f",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:06:53.965+0000",
+                        "updated": "2019-06-04T00:06:53.965+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10080",
+                        "id": "10080",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:08:45.402+0000",
+                        "updated": "2019-06-04T00:08:45.402+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10081",
+                        "id": "10081",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:10:21.326+0000",
+                        "updated": "2019-06-04T00:10:21.326+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10082",
+                        "id": "10082",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "unik",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:15:17.234+0000",
+                        "updated": "2019-06-04T00:15:17.234+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10083",
+                        "id": "10083",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "very low",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:29:43.704+0000",
+                        "updated": "2019-06-04T00:29:43.704+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10084",
+                        "id": "10084",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "and higher eeven higher",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:50:04.873+0000",
+                        "updated": "2019-06-04T00:53:33.665+0000"
+                    }
+                ],
+                "maxResults": 12,
+                "total": 12,
+                "startAt": 0
+            },
+            "votes": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 0,
+                "worklogs": []
+            }
+        }
+    },
+    "comment": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10084",
+        "id": "10084",
+        "author": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "body": "and higher eeven higher",
+        "updateAuthor": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "created": "2019-06-04T00:50:04.873+0000",
+        "updated": "2019-06-04T00:53:33.665+0000"
+    }
+}

--- a/server/testdata/webhook-server-old-issue-updated-no-event-type-commented.json
+++ b/server/testdata/webhook-server-old-issue-updated-no-event-type-commented.json
@@ -1,0 +1,605 @@
+{
+    "timestamp": 1559607317244,
+    "webhookEvent": "jira:issue_updated",
+    "user": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+        "name": "levbrouk",
+        "key": "levbrouk",
+        "emailAddress": "lev@mattermost.com",
+        "avatarUrls": {
+            "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+            "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+            "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+            "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+        },
+        "displayName": "Lev Brouk",
+        "active": true,
+        "timeZone": "Etc/UTC"
+    },
+    "issue": {
+        "id": "10013",
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013",
+        "key": "PRJX-14",
+        "fields": {
+            "issuetype": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issuetype/10001",
+                "id": "10001",
+                "description": "Created by JIRA Software - do not edit or delete. Issue type for a user story.",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/issuetypes/story.svg",
+                "name": "Story",
+                "subtask": false
+            },
+            "timespent": null,
+            "project": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/project/10000",
+                "id": "10000",
+                "key": "PRJX",
+                "name": "ProjectX",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?pid=10000&avatarId=10210",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10210",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=xsmall&pid=10000&avatarId=10210",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/projectavatar?size=medium&pid=10000&avatarId=10210"
+                }
+            },
+            "fixVersions": [],
+            "customfield_10110": null,
+            "customfield_10111": null,
+            "aggregatetimespent": null,
+            "resolution": null,
+            "customfield_10112": null,
+            "customfield_10113": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@464372f5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7da41753[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@7961596e[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a08c1ce[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5701cea0[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ac2459c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@791bc783[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35517fdf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6cfcc31b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@740a95bd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@538a7360[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d9b5149[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6775b3fa[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10114": "0|i000bj:",
+            "customfield_10104": [
+                "com.atlassian.greenhopper.service.sprint.Sprint@a88a698[id=1,rapidViewId=1,state=ACTIVE,name=Sample Sprint 2,startDate=2018-05-09T06:39:30.147Z,endDate=2018-05-23T06:59:30.147Z,completeDate=<null>,sequence=1,goal=<null>]"
+            ],
+            "customfield_10105": "0|i0002v:",
+            "customfield_10106": 3.0,
+            "customfield_10107": null,
+            "customfield_10108": null,
+            "customfield_10109": null,
+            "resolutiondate": null,
+            "workratio": -1,
+            "lastViewed": "2019-06-04T00:10:22.819+0000",
+            "watches": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/watchers",
+                "watchCount": 2,
+                "isWatching": true
+            },
+            "created": "2018-05-15T11:39:29.303+0000",
+            "priority": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": null,
+            "labels": [],
+            "timeestimate": null,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "issuelinks": [],
+            "assignee": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                "name": "levbrouk",
+                "key": "levbrouk",
+                "emailAddress": "lev@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                    "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                    "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                    "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                },
+                "displayName": "Lev Brouk",
+                "active": true,
+                "timeZone": "Etc/UTC"
+            },
+            "updated": "2019-06-04T00:10:21.326+0000",
+            "status": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/status/10000",
+                "description": "",
+                "iconUrl": "http://sales-jira.centralus.cloudapp.azure.com:8080/",
+                "name": "To Do",
+                "id": "10000",
+                "statusCategory": {
+                    "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "To Do"
+                }
+            },
+            "components": [],
+            "timeoriginalestimate": null,
+            "description": "*Creating Quick Filters*\n\nYou can add your own Quick Filters in the board configuration (select *Board > Configure*)",
+            "customfield_10130": null,
+            "customfield_10131": null,
+            "timetracking": {},
+            "customfield_10126": null,
+            "customfield_10127": null,
+            "customfield_10128": null,
+            "customfield_10129": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "summary": "As a user, I can find important items on the board by using the customisable \"Quick Filters\" above >> Try clicking the \"Only My Issues\" Quick Filter above",
+            "creator": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "subtasks": [],
+            "reporter": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                "name": "craig",
+                "key": "craig",
+                "emailAddress": "craig@mattermost.com",
+                "avatarUrls": {
+                    "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                    "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                    "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                    "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                },
+                "displayName": "Craig Vitter",
+                "active": true,
+                "timeZone": "America/New_York"
+            },
+            "customfield_10120": null,
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@e33aca6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@746f19b1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.PullRequestOverallBean@543be32[stateCount=0,state=OPEN,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69423903[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7a07fe11[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7629c271[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6e0340a8[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@16f1e64a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@534365f3[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6bc11fa0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1fb30470[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6e9627a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@4ecdf3a9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10121": null,
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "customfield_10122": null,
+            "customfield_10123": null,
+            "customfield_10124": null,
+            "customfield_10125": null,
+            "customfield_10115": null,
+            "customfield_10116": null,
+            "environment": null,
+            "customfield_10117": "false",
+            "customfield_10118": null,
+            "customfield_10119": "false",
+            "duedate": null,
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "comment": {
+                "comments": [
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+                        "id": "10005",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2018-05-15T11:39:29.299+0000",
+                        "updated": "2018-05-15T11:39:29.299+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10043",
+                        "id": "10043",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Update test comments....",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T16:18:52.995+0000",
+                        "updated": "2019-02-27T16:18:52.995+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10044",
+                        "id": "10044",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "body": "Another comment...",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+                            "name": "craig",
+                            "key": "craig",
+                            "emailAddress": "craig@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+                            },
+                            "displayName": "Craig Vitter",
+                            "active": true,
+                            "timeZone": "America/New_York"
+                        },
+                        "created": "2019-02-27T20:11:05.906+0000",
+                        "updated": "2019-02-27T20:11:05.906+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10076",
+                        "id": "10076",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "and more comments",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:32:03.233+0000",
+                        "updated": "2019-06-03T23:32:03.233+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10077",
+                        "id": "10077",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sdfsdfs",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-03T23:38:52.611+0000",
+                        "updated": "2019-06-03T23:38:52.611+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10078",
+                        "id": "10078",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:05:47.936+0000",
+                        "updated": "2019-06-04T00:05:47.936+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10079",
+                        "id": "10079",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "slsdkjf lksdj f",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:06:53.965+0000",
+                        "updated": "2019-06-04T00:06:53.965+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10080",
+                        "id": "10080",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:08:45.402+0000",
+                        "updated": "2019-06-04T00:08:45.402+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10081",
+                        "id": "10081",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "sd",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:10:21.326+0000",
+                        "updated": "2019-06-04T00:10:21.326+0000"
+                    },
+                    {
+                        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10082",
+                        "id": "10082",
+                        "author": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "body": "unik",
+                        "updateAuthor": {
+                            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+                            "name": "levbrouk",
+                            "key": "levbrouk",
+                            "emailAddress": "lev@mattermost.com",
+                            "avatarUrls": {
+                                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+                            },
+                            "displayName": "Lev Brouk",
+                            "active": true,
+                            "timeZone": "Etc/UTC"
+                        },
+                        "created": "2019-06-04T00:15:17.234+0000",
+                        "updated": "2019-06-04T00:15:17.234+0000"
+                    }
+                ],
+                "maxResults": 10,
+                "total": 10,
+                "startAt": 0
+            },
+            "votes": {
+                "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/PRJX-14/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 0,
+                "worklogs": []
+            }
+        }
+    },
+    "comment": {
+        "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10082",
+        "id": "10082",
+        "author": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "body": "unik",
+        "updateAuthor": {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=levbrouk",
+            "name": "levbrouk",
+            "key": "levbrouk",
+            "emailAddress": "lev@mattermost.com",
+            "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/8c504b6c8f13cf9dc9ffb8af57323320?d=mm&s=32"
+            },
+            "displayName": "Lev Brouk",
+            "active": true,
+            "timeZone": "Etc/UTC"
+        },
+        "created": "2019-06-04T00:15:17.234+0000",
+        "updated": "2019-06-04T00:15:17.234+0000"
+    }
+}

--- a/server/testdata/webhook-server-old-issue-updated-no-event-type-edited.json
+++ b/server/testdata/webhook-server-old-issue-updated-no-event-type-edited.json
@@ -1,0 +1,201 @@
+{
+  "timestamp": 1550286601840,
+  "webhookEvent": "jira:issue_updated",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "lastViewed": "2019-02-15T19:07:41.418-0800",
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i0000r:r",
+      "customfield_10023": null,
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10026": null,
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "aggregatetimeoriginalestimate": null,
+      "timeestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:10:01.805-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long, a little longer now",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "security": null,
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "aggregatetimeestimate": null,
+      "customfield_10009": null,
+      "attachment": [],
+      "summary": "Unit test summary 1",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10000": "{}",
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10225",
+    "items": [
+      {
+        "field": "description",
+        "fieldtype": "jira",
+        "fieldId": "description",
+        "from": null,
+        "fromString": "Unit test description, not that long",
+        "to": null,
+        "toString": "Unit test description, not that long, a little longer now"
+      }
+    ]
+  }
+}

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -66,7 +66,7 @@ func TestWebhookHTTP(t *testing.T) {
 		ExpectedText            string
 		ExpectedFields          []*model.SlackAttachmentField
 		ExpectedStatus          int
-		ExpectedIgnored         bool
+		ExpectedIgnored         bool // Indicates that no post was made as a result of the webhook request
 		CurrentInstance         bool
 	}{
 		"issue created": {
@@ -121,6 +121,13 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedText:            "Unit test description, not that long, a little longer now",
 			CurrentInstance:         true,
 		},
+		"SERVER (old version) issue edited (no issue_event_type_name)": {
+			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-edited.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline:        "Test User edited the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedText:            "Unit test description, not that long, a little longer now",
+			CurrentInstance:         true,
+		},
 		"issue renamed": {
 			Request:          testWebhookRequest("webhook-issue-updated-renamed.json"),
 			ExpectedHeadline: "Test User updated summary from \"Unit test summary\" to \"Unit test summary 1\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
@@ -134,6 +141,11 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue assigned": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned.json"),
+			ExpectedHeadline: "Test User assigned Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			CurrentInstance:  true,
+		},
+		"SERVER (old version) issue assigned (no issue_event_type_name)": {
+			Request:          testWebhookRequest("webhook-server-old-issue-updated-no-event-type-assigned.json"),
 			ExpectedHeadline: "Test User assigned Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
@@ -318,14 +330,34 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedText:            "unik",
 			CurrentInstance:         true,
 		},
+		"SERVER (old version) issue commented (no issue_event_type_name)": {
+			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-commented.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline:        "Lev Brouk commented on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedText:            "unik",
+			CurrentInstance:         true,
+		},
 		"SERVER issue comment deleted": {
 			Request:          testWebhookRequest("webhook-server-issue-updated-comment-deleted.json"),
 			ExpectedHeadline: "Lev Brouk deleted comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:     "",
 			CurrentInstance:  true,
 		},
+		"SERVER (old version) issue comment deleted (no issue_event_type_name)": {
+			Request:         testWebhookRequest("webhook-server-old-issue-updated-no-event-type-comment-deleted.json"),
+			ExpectedIgnored: true,
+			ExpectedStatus:  http.StatusBadRequest,
+			CurrentInstance: true,
+		},
 		"SERVER issue comment edited": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-comment-edited.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline:        "Lev Brouk edited comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedText:            "and higher eeven higher",
+			CurrentInstance:         true,
+		},
+		"SERVER (old version) issue comment edited (no issue_event_type_name)": {
+			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-comment-edited.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk edited comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "and higher eeven higher",
@@ -340,6 +372,16 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"SERVER: ignored comment created": {
 			Request:         testWebhookRequest("webhook-server-comment-created.json"),
+			ExpectedIgnored: true,
+			CurrentInstance: true,
+		},
+		"SERVER: ignored comment updated": {
+			Request:         testWebhookRequest("webhook-server-comment-updated.json"),
+			ExpectedIgnored: true,
+			CurrentInstance: true,
+		},
+		"SERVER: ignored comment deleted": {
+			Request:         testWebhookRequest("webhook-server-comment-deleted.json"),
 			ExpectedIgnored: true,
 			CurrentInstance: true,
 		},

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,3 +1,3 @@
 export const id = 'jira';
 export const version = '2.1.0';
-export const hash = '5ebe3c8';
+export const hash = '06a79da';


### PR DESCRIPTION
#### Summary

This PR fixes the issue of webhook payloads that do not include a `issue_event_type_name` for a `jira:issue_updated` event.

0/5 on keeping this release small and including just this commit here. I'd like to get this out quick as it's causing Jira servers with older versions to not work with the plugin (legacy webhooks and channel subscriptions).

Here's all of the new commits on master since 2.1 release: https://github.com/mattermost/mattermost-plugin-jira/compare/fdba0d10e3da8e1171d26d2f7dbc1021e41b31f2...master in case the team thinks we should include another fix in the patch.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17682
https://mattermost.atlassian.net/browse/MM-17750
https://github.com/mattermost/mattermost-plugin-jira/issues/277
https://github.com/mattermost/mattermost-plugin-jira/issues/272