### PR TITLE
[MM-18076] Add disable button to create subscriptions modal

### DIFF
--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -3878,6 +3878,16 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
       type="button"
     />
     <FormButton
+      btnClass="btn-danger pull-left"
+      defaultMessage="Delete"
+      disabled={true}
+      extraClasses=""
+      id="jira-delete-subscription"
+      onClick={[Function]}
+      savingMessage="Creating"
+      type="button"
+    />
+    <FormButton
       btnClass="btn-primary"
       defaultMessage="Set Subscription"
       disabled={true}

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
@@ -316,7 +316,8 @@ describe('components/EditChannelSettings', () => {
             <EditChannelSettings {...props}/>
         );
 
-        expect(wrapper.exists('#jira-delete-subscription')).toBe(false);
+        expect(wrapper.exists('#jira-delete-subscription')).toBe(true);
+        expect(wrapper.find('#jira-delete-subscription').prop('disabled')).toBe(true);
     });
 
     test('should delete subscription', async () => {

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -287,7 +287,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
         }
 
         const enableSubmitButton = Boolean(this.state.filters.projects[0]);
-        const showDeleteButton = Boolean(this.props.selectedSubscription);
+        const enableDeleteButton = Boolean(this.props.selectedSubscription);
 
         return (
             <form
@@ -308,15 +308,14 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                         defaultMessage='Cancel'
                         onClick={this.handleClose}
                     />
-                    {showDeleteButton && (
-                        <FormButton
-                            id='jira-delete-subscription'
-                            type='button'
-                            btnClass='btn-danger pull-left'
-                            defaultMessage='Delete'
-                            onClick={this.deleteChannelSubscription}
-                        />
-                    )}
+                    <FormButton
+                        id='jira-delete-subscription'
+                        type='button'
+                        btnClass='btn-danger pull-left'
+                        defaultMessage='Delete'
+                        disabled={!enableDeleteButton}
+                        onClick={this.deleteChannelSubscription}
+                    />
                     <FormButton
                         type='submit'
                         disabled={!enableSubmitButton}


### PR DESCRIPTION
This PR adds the `Delete` button to the Subscriptions modal, but disables the button unless the subscription has been previously saved.

Previously, the `Delete` button was hidden.

<img width="1015" alt="Screen Shot 2019-09-30 at 5 12 29 PM" src="https://user-images.githubusercontent.com/7575921/65920790-b8243380-e3a5-11e9-993f-8d84027094bc.png">

This image capture shows a previously saved subscription being edited.  You can observe that the `Delete` button is now active, allowing the user to delete the subscription

<img width="1019" alt="Screen Shot 2019-09-30 at 5 19 00 PM" src="https://user-images.githubusercontent.com/7575921/65921237-4cdb6100-e3a7-11e9-8c0f-ab108c2e288a.png">

### Ticket 
https://mattermost.atlassian.net/browse/MM-18076