### PR TITLE
[MM-19144] Prompt user to use browser to connect to Jira Cloud

### DIFF
--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -3,7 +3,7 @@
 
 import {isDesktopApp} from '../utils/user_agent';
 import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
-import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
+import {isUserConnected, isInstanceInstalled} from '../selectors';
 import PluginId from 'plugin_id';
 
 export default class Hooks {

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -35,7 +35,7 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.'));
                 return Promise.resolve({});
             }
-            if (getInstalledInstanceType(this.store.getState()) === 'server' && isDesktopApp()) {
+            if (isDesktopApp()) {
                 this.store.dispatch(sendEphemeralPost('Please use your browser to connect to Jira.'));
                 return Promise.resolve({});
             }


### PR DESCRIPTION
#### Summary

Normally the Jira Cloud connect popup works with the Desktop App, but after changes in the v4.3 of the Desktop App, it longer works. Nothing happens when you run `/jira connect`. Until we have a more sound solution, we will mimic the behavior we have for Jira Server in order to avoid connect issues.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19144