### PR TITLE
[MM-19179] Avoid react-select caching when num options is negligible

### DIFF
--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -98,7 +98,7 @@ export default class ReactSelectSetting extends React.PureComponent {
         }
 
         let selectComponent = null;
-        if (this.props.limitOptions) {
+        if (this.props.limitOptions && this.props.options.length > MAX_NUM_OPTIONS) {
             selectComponent = (
                 <AsyncSelect
                     {...this.props}


### PR DESCRIPTION
#### Summary

This PR fixes an issue where adding or deleting a Jira project from your Jira instance may not be reflected in the subscribe modal, until you open it twice.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19179

#### Additional Info

I believe this is caused by React reusing the same component that was used the last time the modal was open. We fetch new metadata, and feed a new array of options to the AsyncSelect component. But it assumes that it should reuse the same AsyncSelect component, causing the updated options prop to be ignored (as expected).

In a previous PR https://github.com/mattermost/mattermost-plugin-jira/pull/318 we made it so the only condition that would cause the AsyncSelect component to be used, is if we pass a `limitOptions` prop. Since there can apparently be some component references carried over from the previous modal opening, we need to another check to see if the client-side paging is appropriate for the given dataset. Making it so we only explicitly do client-side paging on a large dataset makes it so we can ensure that there is no caching on smaller datasets.

@DHaussermann To add to the regression test steps, (on a branch where the issue exists) when you see a deleted project in the dropdown, searching for it by typing the name should result in the project not showing. This confirms that this PR fixes the correct issue.