### PR TITLE
Fixed MM-19213: Issue.Self is no longer good

### DIFF
--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -20,6 +20,7 @@ func parseJiraLinksToMarkdown(text string) string {
 }
 
 func mdKeySummaryLink(issue *jira.Issue) string {
+	// Use Self URL only to extract the full hostname from it
 	pos := strings.LastIndex(issue.Self, "/rest/api")
 	if pos < 0 {
 		return ""

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -132,11 +132,11 @@ func (wh *webhook) PostNotifications(p *Plugin) ([]*model.Post, int, error) {
 		// Otherwise, check if they can view the issue.
 
 		isCommentEvent := wh.Events().Intersection(commentEvents).Len() > 0
-		selfURL := wh.Issue.Self
 		if isCommentEvent {
-			selfURL = notification.commentSelf
+			err = client.RESTGet(notification.commentSelf, nil, &struct{}{})
+		} else {
+			_, err = client.GetIssue(wh.Issue.ID, nil)
 		}
-		err = client.RESTGet(selfURL, nil, &struct{}{})
 		if err != nil {
 			p.errorf("PostNotifications: failed to get self: %v", err)
 			continue

--- a/server/webhook_jira.go
+++ b/server/webhook_jira.go
@@ -31,6 +31,7 @@ type JiraWebhook struct {
 }
 
 func (jwh *JiraWebhook) mdJiraLink(title, suffix string) string {
+	// Use Self URL only to extract the full hostname from it
 	pos := strings.LastIndex(jwh.Issue.Self, "/rest/api")
 	if pos < 0 {
 		return ""


### PR DESCRIPTION
The Issue.Self URLs in Jira Cloud webhooks appear to have become invalid.

This PR stops relying on them.