### PR TITLE
[MM-18736] Add Confirm Modal for Subscription Delete Button Click

### DIFF
--- a/webapp/src/components/confirm_modal.tsx
+++ b/webapp/src/components/confirm_modal.tsx
@@ -92,8 +92,7 @@ export default class ConfirmModal extends PureComponent<Props, State> {
         return nextProps.show !== this.props.show;
     }
 
-    // UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-    componentDidUpdate(prevProps) { // eslint-disable-line camelcase
+    componentDidUpdate(prevProps) { 
         if (prevProps.show && !this.props.show) {
             document.removeEventListener('keydown', this.handleKeypress);
         } else if (!prevProps.show && this.props.show) {

--- a/webapp/src/components/confirm_modal.tsx
+++ b/webapp/src/components/confirm_modal.tsx
@@ -92,7 +92,7 @@ export default class ConfirmModal extends PureComponent<Props, State> {
         return nextProps.show !== this.props.show;
     }
 
-    componentDidUpdate(prevProps) { 
+    componentDidUpdate(prevProps) {
         if (prevProps.show && !this.props.show) {
             document.removeEventListener('keydown', this.handleKeypress);
         } else if (!prevProps.show && this.props.show) {

--- a/webapp/src/components/confirm_modal.tsx
+++ b/webapp/src/components/confirm_modal.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {PureComponent} from 'react';
+import {Modal} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
+
+export type Props = {
+
+    /*
+     * Set to show modal
+     */
+    show: boolean;
+
+    /*
+     * Title to use for the modal
+     */
+    title: React.ReactNode;
+
+    /*
+     * Message to display in the body of the modal
+     */
+    message: React.ReactNode;
+
+    /*
+     * The CSS class to apply to the confirm button
+     */
+    confirmButtonClass: string;
+
+    /*
+     * The CSS class to apply to the modal
+     */
+    modalClass?: string;
+
+    /*
+     * Text/jsx element on the confirm button
+     */
+    confirmButtonText: React.ReactNode;
+
+    /*
+     * Text/jsx element on the cancel button
+     */
+    cancelButtonText: React.ReactNode;
+
+    /*
+     * Set to show checkbox
+     */
+    showCheckbox?: boolean;
+
+    /*
+     * Text/jsx element to display with the checkbox
+     */
+    checkboxText?: string;
+
+    /*
+     * Function called when the confirm button or ENTER is pressed. Passes `true` if the checkbox is checked
+     */
+    onConfirm?: (arg0: boolean) => void;
+
+    /*
+     * Function called when the cancel button is pressed or the modal is hidden. Passes `true` if the checkbox is checked
+     */
+    onCancel?: (arg0: boolean) => void;
+
+    /**
+     * Function called when modal is dismissed
+     */
+    onExited?: () => void;
+
+    /*
+     * Set to hide the cancel button
+     */
+    hideCancel: boolean;
+
+}
+
+export type State = {
+}
+
+export default class ConfirmModal extends PureComponent<Props, State> {
+    componentDidMount() {
+        if (this.props.show) {
+            document.addEventListener('keydown', this.handleKeypress);
+        }
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeypress);
+    }
+
+    shouldComponentUpdate(nextProps) {
+        return nextProps.show !== this.props.show;
+    }
+
+    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
+        if (this.props.show && !nextProps.show) {
+            document.removeEventListener('keydown', this.handleKeypress);
+        } else if (!this.props.show && nextProps.show) {
+            document.addEventListener('keydown', this.handleKeypress);
+        }
+    }
+
+    handleKeypress = (e) => {
+        if (e.key === 'Enter' && this.props.show) {
+            this.handleConfirm();
+        }
+    }
+
+    handleConfirm = () => {
+        // const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
+        const checked = false;
+        this.props.onConfirm(checked);
+    }
+
+    handleCancel = () => {
+        // const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
+        const checked = false;
+        this.props.onCancel(checked);
+    }
+
+    render() {
+        let checkbox;
+        if (this.props.showCheckbox) {
+            checkbox = (
+                <div className='checkbox text-right margin-bottom--none'>
+                    <label>
+                        <input
+                            ref='checkbox'
+                            type='checkbox'
+                        />
+                        {this.props.checkboxText}
+                    </label>
+                </div>
+            );
+        }
+
+        let cancelText;
+        if (this.props.cancelButtonText) {
+            cancelText = this.props.cancelButtonText;
+        } else {
+            cancelText = (
+                <FormattedMessage
+                    id='confirm_modal.cancel'
+                    defaultMessage='Cancel'
+                />
+            );
+        }
+
+        let cancelButton;
+        if (!this.props.hideCancel) {
+            cancelButton = (
+                <button
+                    type='button'
+                    className='btn btn-link btn-cancel'
+                    onClick={this.handleCancel}
+                    id='cancelModalButton'
+                >
+                    {cancelText}
+                </button>
+            );
+        }
+
+        return (
+            <Modal
+                className={'modal-confirm ' + this.props.modalClass}
+                dialogClassName='a11y__modal'
+                show={this.props.show}
+                onHide={this.props.onCancel}
+                onExited={this.props.onExited}
+                id='confirmModal'
+                role='dialog'
+                style={{zIndex: 2001}}
+                aria-labelledby='confirmModalLabel'
+            >
+                <Modal.Header closeButton={false}>
+                    <Modal.Title
+                        componentClass='h1'
+                        id='confirmModalLabel'
+                    >
+                        {this.props.title}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {this.props.message}
+                    {checkbox}
+                </Modal.Body>
+                <Modal.Footer>
+                    {cancelButton}
+                    <button
+                        autoFocus={true}
+                        type='button'
+                        className={this.props.confirmButtonClass}
+                        onClick={this.handleConfirm}
+                        id='confirmModalButton'
+                    >
+                        {this.props.confirmButtonText}
+                    </button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}

--- a/webapp/src/components/confirm_modal.tsx
+++ b/webapp/src/components/confirm_modal.tsx
@@ -74,10 +74,7 @@ export type Props = {
 
 }
 
-export type State = {
-}
-
-export default class ConfirmModal extends PureComponent<Props, State> {
+export default class ConfirmModal extends PureComponent<Props> {
     componentDidMount() {
         if (this.props.show) {
             document.addEventListener('keydown', this.handleKeypress);

--- a/webapp/src/components/confirm_modal.tsx
+++ b/webapp/src/components/confirm_modal.tsx
@@ -92,10 +92,11 @@ export default class ConfirmModal extends PureComponent<Props, State> {
         return nextProps.show !== this.props.show;
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (this.props.show && !nextProps.show) {
+    // UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
+    componentDidUpdate(prevProps) { // eslint-disable-line camelcase
+        if (prevProps.show && !this.props.show) {
             document.removeEventListener('keydown', this.handleKeypress);
-        } else if (!this.props.show && nextProps.show) {
+        } else if (!prevProps.show && this.props.show) {
             document.addEventListener('keydown', this.handleKeypress);
         }
     }
@@ -107,14 +108,12 @@ export default class ConfirmModal extends PureComponent<Props, State> {
     }
 
     handleConfirm = () => {
-        // const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
-        const checked = false;
+        const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
         this.props.onConfirm(checked);
     }
 
     handleCancel = () => {
-        // const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
-        const checked = false;
+        const checked = this.refs.checkbox ? this.refs.checkbox.checked : false;
         this.props.onCancel(checked);
     }
 

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
     <ConfirmModal
       cancelButtonText="Cancel"
       confirmButtonClass="btn btn-danger"
-      confirmButtonText="Confirm"
+      confirmButtonText="Delete"
       hideCancel={false}
       message="Delete Subscription ?"
       onCancel={[Function]}
@@ -3488,7 +3488,7 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
     <ConfirmModal
       cancelButtonText="Cancel"
       confirmButtonClass="btn btn-danger"
-      confirmButtonText="Confirm"
+      confirmButtonText="Delete"
       hideCancel={false}
       message="Delete Subscription ?"
       onCancel={[Function]}
@@ -3625,7 +3625,7 @@ exports[`components/EditChannelSettings should match snapshot with no filters 1`
     <ConfirmModal
       cancelButtonText="Cancel"
       confirmButtonClass="btn btn-danger"
-      confirmButtonText="Confirm"
+      confirmButtonText="Delete"
       hideCancel={false}
       message="Delete Subscription ?"
       onCancel={[Function]}
@@ -3773,7 +3773,7 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
     <ConfirmModal
       cancelButtonText="Cancel"
       confirmButtonClass="btn btn-danger"
-      confirmButtonText="Confirm"
+      confirmButtonText="Delete"
       hideCancel={false}
       message="Delete Subscription ?"
       onCancel={[Function]}
@@ -3910,7 +3910,7 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
     <ConfirmModal
       cancelButtonText="Cancel"
       confirmButtonClass="btn btn-danger"
-      confirmButtonText="Confirm"
+      confirmButtonText="Delete"
       hideCancel={false}
       message="Delete Subscription ?"
       onCancel={[Function]}

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3490,7 +3490,7 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3627,7 +3627,7 @@ exports[`components/EditChannelSettings should match snapshot with no filters 1`
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3775,7 +3775,7 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -100,6 +100,17 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
         style={Object {}}
       />
     </div>
+    <ConfirmModal
+      cancelButtonText="Cancel"
+      confirmButtonClass="btn btn-danger"
+      confirmButtonText="Confirm"
+      hideCancel={false}
+      message="Delete Subscription ?"
+      onCancel={[Function]}
+      onConfirm={[Function]}
+      show={false}
+      title="Subscription"
+    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"
@@ -3474,6 +3485,17 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
         values={Array []}
       />
     </div>
+    <ConfirmModal
+      cancelButtonText="Cancel"
+      confirmButtonClass="btn btn-danger"
+      confirmButtonText="Confirm"
+      hideCancel={false}
+      message="Delete Subscription ?"
+      onCancel={[Function]}
+      onConfirm={[Function]}
+      show={false}
+      title="Subscription"
+    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"
@@ -3600,6 +3622,17 @@ exports[`components/EditChannelSettings should match snapshot with no filters 1`
         value={Array []}
       />
     </div>
+    <ConfirmModal
+      cancelButtonText="Cancel"
+      confirmButtonClass="btn btn-danger"
+      confirmButtonText="Confirm"
+      hideCancel={false}
+      message="Delete Subscription ?"
+      onCancel={[Function]}
+      onConfirm={[Function]}
+      show={false}
+      title="Subscription"
+    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"
@@ -3737,6 +3770,17 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
         style={Object {}}
       />
     </div>
+    <ConfirmModal
+      cancelButtonText="Cancel"
+      confirmButtonClass="btn btn-danger"
+      confirmButtonText="Confirm"
+      hideCancel={false}
+      message="Delete Subscription ?"
+      onCancel={[Function]}
+      onConfirm={[Function]}
+      show={false}
+      title="Subscription"
+    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"
@@ -3863,6 +3907,17 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
         value={Array []}
       />
     </div>
+    <ConfirmModal
+      cancelButtonText="Cancel"
+      confirmButtonClass="btn btn-danger"
+      confirmButtonText="Confirm"
+      hideCancel={false}
+      message="Delete Subscription ?"
+      onCancel={[Function]}
+      onConfirm={[Function]}
+      show={false}
+      title="Subscription"
+    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription ?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3490,7 +3490,7 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription ?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3627,7 +3627,7 @@ exports[`components/EditChannelSettings should match snapshot with no filters 1`
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription ?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3775,7 +3775,7 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
       confirmButtonClass="btn btn-danger"
       confirmButtonText="Delete"
       hideCancel={false}
-      message="Delete Subscription ?"
+      message="Delete Subscription asxtifxe8jyi9y81htww6ixkiy}?"
       onCancel={[Function]}
       onConfirm={[Function]}
       show={false}
@@ -3907,17 +3907,6 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
         value={Array []}
       />
     </div>
-    <ConfirmModal
-      cancelButtonText="Cancel"
-      confirmButtonClass="btn btn-danger"
-      confirmButtonText="Delete"
-      hideCancel={false}
-      message="Delete Subscription ?"
-      onCancel={[Function]}
-      onConfirm={[Function]}
-      show={false}
-      title="Subscription"
-    />
   </ModalBody>
   <ModalFooter
     bsClass="modal-footer"

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
@@ -324,7 +324,6 @@ describe('components/EditChannelSettings', () => {
         let close = jest.fn();
         const props = {
             ...baseProps,
-            deleteChannelSubscription,
             close,
         };
         const wrapper = shallow<EditChannelSettings>(
@@ -332,9 +331,10 @@ describe('components/EditChannelSettings', () => {
         );
 
         expect(wrapper.exists('#jira-delete-subscription')).toBe(true);
-
         wrapper.find('#jira-delete-subscription').simulate('click');
-        expect(deleteChannelSubscription).toHaveBeenCalled();
+
+        expect(wrapper.state().showConfirmModal).toBe(true);
+        wrapper.instance().handleConfirmDelete();
 
         await Promise.resolve();
         expect(wrapper.state().error).toBe(null);
@@ -344,8 +344,7 @@ describe('components/EditChannelSettings', () => {
         close = jest.fn();
         wrapper.setProps({deleteChannelSubscription, close});
 
-        wrapper.find('#jira-delete-subscription').simulate('click');
-        expect(deleteChannelSubscription).toHaveBeenCalled();
+        wrapper.instance().handleConfirmDelete();
 
         await Promise.resolve();
         expect(wrapper.state().error).toEqual('Failure');
@@ -366,6 +365,9 @@ describe('components/EditChannelSettings', () => {
 
         expect(wrapper.exists('#jira-delete-subscription')).toBe(true);
         wrapper.find('#jira-delete-subscription').simulate('click');
+
+        expect(wrapper.state().showConfirmModal).toBe(true);
+        wrapper.instance().handleConfirmDelete();
 
         expect(deleteChannelSubscription).toHaveBeenCalled();
 

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.test.tsx
@@ -320,10 +320,11 @@ describe('components/EditChannelSettings', () => {
     });
 
     test('should delete subscription', async () => {
-        let deleteChannelSubscription = jest.fn().mockResolvedValue({});
-        let close = jest.fn();
+        const deleteChannelSubscription = jest.fn().mockResolvedValue({});
+        const close = jest.fn();
         const props = {
             ...baseProps,
+            deleteChannelSubscription,
             close,
         };
         const wrapper = shallow<EditChannelSettings>(
@@ -336,19 +337,11 @@ describe('components/EditChannelSettings', () => {
         expect(wrapper.state().showConfirmModal).toBe(true);
         wrapper.instance().handleConfirmDelete();
 
+        expect(deleteChannelSubscription).toHaveBeenCalled();
+
         await Promise.resolve();
         expect(wrapper.state().error).toBe(null);
         expect(close).toHaveBeenCalled();
-
-        deleteChannelSubscription = jest.fn().mockResolvedValue({error: {message: 'Failure'}});
-        close = jest.fn();
-        wrapper.setProps({deleteChannelSubscription, close});
-
-        wrapper.instance().handleConfirmDelete();
-
-        await Promise.resolve();
-        expect(wrapper.state().error).toEqual('Failure');
-        expect(close).not.toHaveBeenCalled();
     });
 
     test('should show error if delete fails', async () => {

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -349,7 +349,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                         btnClass='btn-danger pull-left'
                         defaultMessage='Delete'
                         disabled={!enableDeleteButton}
-                        onClick={this.deleteChannelSubscription}
+                        onClick={this.handleDeleteChannelSubscription}
                     />
                     <FormButton
                         type='submit'

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -109,7 +109,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
         }
     };
 
-    handleDeactivateCancel = () => {
+    handleCancelDelete = () => {
         this.setState({showConfirmModal: false});
     }
 
@@ -303,7 +303,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                     confirmButtonClass={'btn btn-danger'}
                     hideCancel={false}
                     message={`Delete Subscription ${this.props.selectedSubscription.id}?`}
-                    onCancel={this.handleDeactivateCancel}
+                    onCancel={this.handleCancelDelete}
                     onConfirm={this.handleConfirmDelete}
                     show={showConfirmModal}
                     title={'Subscription'}

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -302,7 +302,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                     confirmButtonText={'Delete'}
                     confirmButtonClass={'btn btn-danger'}
                     hideCancel={false}
-                    message={`Delete Subscription ${this.props.selectedSubscription.id}}?`}
+                    message={`Delete Subscription ${this.props.selectedSubscription.id}?`}
                     onCancel={this.handleDeactivateCancel}
                     onConfirm={this.handleConfirmDelete}
                     show={showConfirmModal}

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -297,7 +297,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
         const confirmComponent = (
             <ConfirmModal
                 cancelButtonText={'Cancel'}
-                confirmButtonText={'Confirm'}
+                confirmButtonText={'Delete'}
                 confirmButtonClass={'btn btn-danger'}
                 hideCancel={false}
                 message={'Delete Subscription ?'}

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -50,7 +50,7 @@ export type State = {
     error: string | null;
     getMetaDataErr: string | null;
     submitting: boolean;
-    showConfirmModal: boolean | false;
+    showConfirmModal: boolean;
 };
 
 export default class EditChannelSettings extends PureComponent<Props, State> {
@@ -294,19 +294,22 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
         }
 
         const {showConfirmModal} = this.state;
-        const confirmComponent = (
-            <ConfirmModal
-                cancelButtonText={'Cancel'}
-                confirmButtonText={'Delete'}
-                confirmButtonClass={'btn btn-danger'}
-                hideCancel={false}
-                message={'Delete Subscription ?'}
-                onCancel={this.handleDeactivateCancel}
-                onConfirm={this.handleConfirmDelete}
-                show={showConfirmModal}
-                title={'Subscription'}
-            />
-        );
+        let confirmComponent;
+        if (this.props.selectedSubscription) {
+            confirmComponent = (
+                <ConfirmModal
+                    cancelButtonText={'Cancel'}
+                    confirmButtonText={'Delete'}
+                    confirmButtonClass={'btn btn-danger'}
+                    hideCancel={false}
+                    message={`Delete Subscription ${this.props.selectedSubscription.id}}?`}
+                    onCancel={this.handleDeactivateCancel}
+                    onConfirm={this.handleConfirmDelete}
+                    show={showConfirmModal}
+                    title={'Subscription'}
+                />
+            );
+        }
 
         let error = null;
         if (this.state.error || this.state.getMetaDataErr) {

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import {ChannelSubscription} from 'types/model';
 
+import ConfirmModal from 'components/confirm_modal';
+
 import {SharedProps} from './shared_props';
 
 type Props = SharedProps & {
@@ -11,11 +13,26 @@ type Props = SharedProps & {
 
 type State = {
     error: string | null;
+    showConfirmModal: boolean | false;
 }
 
 export default class SelectChannelSubscriptionInternal extends React.PureComponent<Props, State> {
     state = {
         error: null,
+        showConfirmModal: false,
+    };
+
+    handleDeactivateCancel = () => {
+        this.setState({showConfirmModal: false});
+    }
+
+    handleConfirmDelete = (sub: ChannelSubscription) => {
+        this.setState({showConfirmModal: false});
+        this.deleteChannelSubscription(sub);
+    }
+
+    handleDeleteChannelSubscription = (): void => {
+        this.setState({showConfirmModal: true});
     };
 
     deleteChannelSubscription = (sub: ChannelSubscription): void => {
@@ -28,7 +45,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
 
     render(): React.ReactElement {
         const {channel} = this.props;
-        const {error} = this.state;
+        const {error, showConfirmModal} = this.state;
 
         const headerText = `Jira Subscriptions in "${channel.name}"`;
 
@@ -38,6 +55,40 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
                 <span className='error'>{error}</span>
             );
         }
+
+        const subscriptionRows = this.props.channelSubscriptions.map((sub) => (
+            <div
+                key={sub.id}
+                className='select-channel-subscriptions-row'
+            >
+                <ConfirmModal
+                    cancelButtonText={'Cancel'}
+                    confirmButtonText={'Confirm'}
+                    confirmButtonClass={'btn btn-danger'}
+                    hideCancel={false}
+                    message={'Delete Subscription "' + sub.id + '"?'}
+                    onCancel={this.handleDeactivateCancel}
+                    onConfirm={(): void => this.handleConfirmDelete(sub)}
+                    show={showConfirmModal}
+                    title={'Subscription'}
+                />
+                <div className='channel-subscription-id-container'>
+                    <span>{sub.id}</span>
+                </div>
+                <button
+                    className='btn btn-info'
+                    onClick={(): void => this.props.showEditChannelSubscription(sub)}
+                >
+                    {'Edit'}
+                </button>
+                <button
+                    className='btn btn-danger'
+                    onClick={this.handleDeleteChannelSubscription}
+                >
+                    {'Delete'}
+                </button>
+            </div>
+        ));
 
         return (
             <div>
@@ -49,28 +100,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
                     {'Create Subscription'}
                 </button>
                 {errorDisplay}
-                {this.props.channelSubscriptions.map((sub) => (
-                    <div
-                        key={sub.id}
-                        className='select-channel-subscriptions-row'
-                    >
-                        <div className='channel-subscription-id-container'>
-                            <span>{sub.id}</span>
-                        </div>
-                        <button
-                            className='btn btn-info'
-                            onClick={(): void => this.props.showEditChannelSubscription(sub)}
-                        >
-                            {'Edit'}
-                        </button>
-                        <button
-                            className='btn btn-danger'
-                            onClick={(): void => this.deleteChannelSubscription(sub)}
-                        >
-                            {'Delete'}
-                        </button>
-                    </div>
-                ))}
+                {subscriptionRows}
             </div>
         );
     }

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -63,7 +63,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
             >
                 <ConfirmModal
                     cancelButtonText={'Cancel'}
-                    confirmButtonText={'Confirm'}
+                    confirmButtonText={'Delete'}
                     confirmButtonClass={'btn btn-danger'}
                     hideCancel={false}
                     message={'Delete Subscription "' + sub.id + '"?'}

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -38,7 +38,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
     deleteChannelSubscription = (sub: ChannelSubscription): void => {
         this.props.deleteChannelSubscription(sub).then((res: { error?: { message: string } }) => {
             if (res.error) {
-                this.setState({ error: res.error.message });
+                this.setState({error: res.error.message});
             }
         });
     };
@@ -54,17 +54,16 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
             );
         }
 
-
         const subscriptionRows = (
             <table className='table'>
                 <thead>
                     <tr>
-                        <th scope='col'>ID</th>
-                        <th scope='col'>Actions</th>
+                        <th scope='col'>{'Name'}</th>
+                        <th scope='col'>{'Actions'}</th>
                     </tr>
                 </thead>
-                {this.props.channelSubscriptions.map((sub) => (
-                    <tbody>
+                {this.props.channelSubscriptions.map((sub, i) => (
+                    <tbody key={i}>
                         <td
                             key={sub.id}
                             className='select-channel-subscriptions-row'
@@ -100,7 +99,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
                     </tbody>
                 ))}
             </table>
-        )
+        );
 
         return (
             <div>

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -13,7 +13,7 @@ type Props = SharedProps & {
 
 type State = {
     error: string | null;
-    showConfirmModal: boolean | false;
+    showConfirmModal: boolean;
 }
 
 export default class SelectChannelSubscriptionInternal extends React.PureComponent<Props, State> {


### PR DESCRIPTION
## Summary

This PR adds a confirm modal that gets called when the user clicks the 'Delete` button on a subscription.  This is an added step to reduce the chance of an accidental subscription deletion.

There are two area where a user can delete a subscription.

1) From the Subscriptions List Modal.  This view shows saved subscriptions with an inline delete button for each subscription

![image](https://user-images.githubusercontent.com/7575921/66433718-900c8400-e9e6-11e9-8ae4-57f8a9a130b1.png)

Corresponding Confirm Modal for this case:

![image](https://user-images.githubusercontent.com/7575921/66444198-e5a55880-ea07-11e9-8af7-34448c803023.png)

2) After a subscription is saved and a user clicks the `Edit` button on a subscription.

![image](https://user-images.githubusercontent.com/7575921/66433829-cd711180-e9e6-11e9-9348-9f71fd8964ab.png)

Corresponding Confirm Modal for this case: 
![image](https://user-images.githubusercontent.com/7575921/66444187-cf979800-ea07-11e9-8105-9f56fdb2e48f.png)

Other Notables for this ticket:
* the confirm modal was copied from the webapp repo, and converted to Typescript
* `zIndex` is set to 2001. This brings the modal in front of the full-screen modal.  https://github.com/mattermost/mattermost-plugin-jira/blob/3ea62625e2b269046b5fd3ef8e20dfed52e63dbc/webapp/src/components/confirm_modal.tsx#L172
* Tests were adjusted to understand the additional step of clicking the Confirm Button on the confirm modal to trigger a subscription delete.

## Ticket
https://mattermost.atlassian.net/browse/MM-18736