### PR TITLE
Revert "Prompt user to use browser to connect to Jira Cloud"

### DIFF
--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -3,7 +3,7 @@
 
 import {isDesktopApp} from '../utils/user_agent';
 import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
-import {isUserConnected, isInstanceInstalled} from '../selectors';
+import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
 import PluginId from 'plugin_id';
 
 export default class Hooks {
@@ -35,7 +35,7 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('You already have a Jira account linked to your Mattermost account. Please use `/jira disconnect` to disconnect.'));
                 return Promise.resolve({});
             }
-            if (isDesktopApp()) {
+            if (getInstalledInstanceType(this.store.getState()) === 'server' && isDesktopApp()) {
                 this.store.dispatch(sendEphemeralPost('Please use your browser to connect to Jira.'));
                 return Promise.resolve({});
             }


### PR DESCRIPTION
#### Summary

This reverts PR https://github.com/mattermost/mattermost-plugin-jira/pull/332 "Prompt user to use browser to connect to Jira Cloud"

There was an issue with opening popups in the desktop app for v4.3, which seems to be solved by https://github.com/mattermost/desktop/pull/1062 .

~Though, running the desktop app on master locally shows that the issue here is not fixed for me. @deanwhillier Can you weigh in on this?~
Edit: Nevermind I wasn't running the latest desktop build. The issue is fixed.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19144