### PR TITLE
[MM-18536] `/jira subscribe list` command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -58,6 +58,7 @@ var jiraCommandHandler = CommandHandler{
 		"webhook":          executeWebhookURL,
 		"info":             executeInfo,
 		"help":             commandHelp,
+		"subscribe/list":   executeSubscribeList,
 		// "list":             executeList,
 		// "instance/select":  executeInstanceSelect,
 		// "instance/delete":  executeInstanceDelete,
@@ -257,6 +258,23 @@ func executeList(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 		text += fmt.Sprintf(format, i+1, key, details)
 	}
 	return p.responsef(header, text)
+}
+
+func executeSubscribeList(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	authorized, err := authorizedSysAdmin(p, header.UserId)
+	if err != nil {
+		return p.responsef(header, "%v", err)
+	}
+	if !authorized {
+		return p.responsef(header, "`/jira subscribe list` can only be run by a system administrator.")
+	}
+
+	msg, err := p.listChannelSubscriptions()
+	if err != nil {
+		return p.responsef(header, "%v", err)
+	}
+
+	return p.responsef(header, msg)
 }
 
 func authorizedSysAdmin(p *Plugin, userId string) (bool, error) {

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -324,6 +324,34 @@ func (p *Plugin) editChannelSubscription(modifiedSubscription *ChannelSubscripti
 	})
 }
 
+func (p *Plugin) listChannelSubscriptions() (string, error) {
+	subs, err := p.getSubscriptions()
+	if err != nil {
+		return "", err
+	}
+
+	rows := make([]string, len(subs.Channel.ById)+len(subs.Channel.IdByChannelId))
+	index := 0
+
+	for channelID, subIDs := range subs.Channel.IdByChannelId {
+		channel, appErr := p.API.GetChannel(channelID)
+		if appErr != nil {
+			return "", errors.New("Failed to get channel")
+		}
+
+		rows[index] = fmt.Sprintf("~%s (%d):", channel.Name, len(subIDs))
+		index++
+
+		for subID := range subIDs {
+			sub := subs.Channel.ById[subID]
+			rows[index] = fmt.Sprintf("* %s - %s", sub.Filters.Projects.Elems()[0], sub.Name)
+			index++
+		}
+	}
+
+	return strings.Join(rows, "\n"), nil
+}
+
 func inAllowedGroup(inGroups []*jira.UserGroup, allowedGroups []string) bool {
 	for _, inGroup := range inGroups {
 		for _, allowedGroup := range allowedGroups {

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -330,22 +330,18 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 		return "", err
 	}
 
-	rows := make([]string, len(subs.Channel.ById)+len(subs.Channel.IdByChannelId))
-	index := 0
-
+	rows := []string{}
 	for channelID, subIDs := range subs.Channel.IdByChannelId {
 		channel, appErr := p.API.GetChannel(channelID)
 		if appErr != nil {
 			return "", errors.New("Failed to get channel")
 		}
 
-		rows[index] = fmt.Sprintf("~%s (%d):", channel.Name, len(subIDs))
-		index++
+		rows = append(rows, fmt.Sprintf("~%s (%d):", channel.Name, len(subIDs)))
 
 		for subID := range subIDs {
 			sub := subs.Channel.ById[subID]
-			rows[index] = fmt.Sprintf("* %s - %s", sub.Filters.Projects.Elems()[0], sub.Name)
-			index++
+			rows = append(rows, fmt.Sprintf("* %s - %s", sub.Filters.Projects.Elems()[0], sub.Name))
 		}
 	}
 

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,22 +25,89 @@ func TestListChannelSubscriptions(t *testing.T) {
 	})
 
 	for name, tc := range map[string]struct {
-		Subs            *Subscriptions
-		Expected string
+		Subs          *Subscriptions
+		RunAssertions func(t *testing.T, actual string)
 	}{
-		"test 1": {
+		"one subscription": {
 			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
 				ChannelSubscription{
 					Id:        model.NewId(),
 					ChannelId: "channel1",
-					Name: "Sub Name X",
+					Name:      "Sub Name X",
 					Filters: SubscriptionFilters{
 						Projects: NewStringSet("PROJ"),
 					},
 				},
 			}),
-			Expected: `~channel-1-name (1):
-* PROJ - Sub Name X`,
+			RunAssertions: func(t *testing.T, actual string) {
+				expected := `~channel-1-name (1):
+* PROJ - Sub Name X`
+				assert.Equal(t, expected, actual)
+			},
+		},
+		"one channel with two subscriptions": {
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "channel1",
+					Name:      "Sub Name X",
+					Filters: SubscriptionFilters{
+						Projects: NewStringSet("PROJ"),
+					},
+				},
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "channel1",
+					Name:      "Sub Name Y",
+					Filters: SubscriptionFilters{
+						Projects: NewStringSet("EXT"),
+					},
+				},
+			}),
+			RunAssertions: func(t *testing.T, actual string) {
+				numlines := strings.Count(actual, "\n") + 1
+				assert.Equal(t, 3, numlines)
+				assert.Contains(t, actual, `~channel-1-name (2):`)
+				assert.Contains(t, actual, `* PROJ - Sub Name X`)
+				assert.Contains(t, actual, `* EXT - Sub Name Y`)
+			},
+		},
+		"two channels with multiple subscriptions": {
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "channel1",
+					Name:      "Sub Name X",
+					Filters: SubscriptionFilters{
+						Projects: NewStringSet("PROJ"),
+					},
+				},
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "channel1",
+					Name:      "Sub Name Y",
+					Filters: SubscriptionFilters{
+						Projects: NewStringSet("EXT"),
+					},
+				},
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "channel2",
+					Name:      "Sub Name Z",
+					Filters: SubscriptionFilters{
+						Projects: NewStringSet("EXT"),
+					},
+				},
+			}),
+			RunAssertions: func(t *testing.T, actual string) {
+				numlines := strings.Count(actual, "\n") + 1
+				assert.Equal(t, 5, numlines)
+				assert.Contains(t, actual, `~channel-1-name (2):`)
+				assert.Contains(t, actual, `* PROJ - Sub Name X`)
+				assert.Contains(t, actual, `* EXT - Sub Name Y`)
+				assert.Contains(t, actual, `~channel-2-name (1):`)
+				assert.Contains(t, actual, `* EXT - Sub Name Z`)
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -58,15 +126,15 @@ func TestListChannelSubscriptions(t *testing.T) {
 			api.On("KVGet", subKey).Return(subscriptionBytes, nil)
 
 			channel1 := &model.Channel{
-				Id: "channel1",
-				Name: "channel-1-name",
+				Id:          "channel1",
+				Name:        "channel-1-name",
 				DisplayName: "Channel 1 Display Name",
 			}
 			api.On("GetChannel", "channel1").Return(channel1, nil)
 
 			channel2 := &model.Channel{
-				Id: "channel2",
-				Name: "channel-2-name",
+				Id:          "channel2",
+				Name:        "channel-2-name",
 				DisplayName: "Channel 2 Display Name",
 			}
 			api.On("GetChannel", "channel2").Return(channel2, nil)
@@ -79,11 +147,10 @@ func TestListChannelSubscriptions(t *testing.T) {
 			assert.Nil(t, err)
 			assert.NotNil(t, actual)
 
-			assert.Equal(t, tc.Expected, actual)
+			tc.RunAssertions(t, actual)
 		})
 	}
 }
-
 
 func TestGetChannelsSubscribed(t *testing.T) {
 	p := &Plugin{}

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -12,7 +12,12 @@ export default class Hooks {
     }
 
     slashCommandWillBePostedHook = (message, contextArgs) => {
-        if (message && message.startsWith('/jira create')) {
+        let messageTrimmed;
+        if (message) {
+            messageTrimmed = message.trim();
+        }
+
+        if (messageTrimmed && messageTrimmed.startsWith('/jira create')) {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
@@ -21,12 +26,12 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
                 return Promise.resolve({});
             }
-            const description = message.slice(12).trim();
+            const description = messageTrimmed.slice(12).trim();
             this.store.dispatch(openCreateModalWithoutPost(description, contextArgs.channel_id));
             return Promise.resolve({});
         }
 
-        if (message && message.startsWith('/jira connect')) {
+        if (messageTrimmed && messageTrimmed === '/jira connect') {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
@@ -44,7 +49,7 @@ export default class Hooks {
             return Promise.resolve({});
         }
 
-        if (message && message.startsWith('/jira subscribe') && !message.startsWith('/jira subscribe list')) {
+        if (messageTrimmed && messageTrimmed === '/jira subscribe') {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -12,7 +12,7 @@ export default class Hooks {
     }
 
     slashCommandWillBePostedHook = (message, contextArgs) => {
-        if (message && (message.startsWith('/jira create ') || message === '/jira create')) {
+        if (message && message.startsWith('/jira create')) {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
@@ -26,7 +26,7 @@ export default class Hooks {
             return Promise.resolve({});
         }
 
-        if (message && (message.startsWith('/jira connect') || message === '/jira connect')) {
+        if (message && message.startsWith('/jira connect')) {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});
@@ -44,7 +44,7 @@ export default class Hooks {
             return Promise.resolve({});
         }
 
-        if (message && (message.startsWith('/jira subscribe ') || message === '/jira subscribe')) {
+        if (message && message.startsWith('/jira subscribe') && !message.startsWith('/jira subscribe list')) {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});


### PR DESCRIPTION
#### Summary

This PR adds functionality to list out subscriptions of all channels. It is only accessible to sys admins.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18536

Example Output:

```
~some-channel-name (2):
* PROJ1 - Subscription X
* PROJ1 - Subscription Y

~some-other-channel-name (1):
* PROJ2 - Subscription Z
```

The channels name are converted to markdown, and so they are clickable links to the channel.