### PR TITLE
[MM-19865] Fix modal close button to not overlap when screen is narrow

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings_modal.scss
+++ b/webapp/src/components/modals/channel_settings/channel_settings_modal.scss
@@ -14,8 +14,10 @@
 
     .channel-subscriptions-modal-body {
         max-width: 960px;
-        width: 90%;
+        width: 100%;
         margin-bottom: 28px;
+        padding-right: 20px;
+        padding-left: 20px;
 
         table {
             margin: 2rem 0;

--- a/webapp/src/components/modals/channel_settings/channel_settings_modal.scss
+++ b/webapp/src/components/modals/channel_settings/channel_settings_modal.scss
@@ -14,7 +14,7 @@
 
     .channel-subscriptions-modal-body {
         max-width: 960px;
-        width: 100%;
+        width: 90%;
         margin-bottom: 28px;
 
         table {

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
@@ -48,12 +48,10 @@ export default class FullScreenModal extends React.Component {
                 appear={true}
             >
                 <div className='FullScreenModal'>
-                    <div className='full-screen-modal-header'>
-                        <CloseIcon
-                            className='close-x'
-                            onClick={this.close}
-                        />
-                    </div>
+                    <CloseIcon
+                        className='close-x'
+                        onClick={this.close}
+                    />
                     {this.props.children}
                 </div>
             </CSSTransition>

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
@@ -48,10 +48,12 @@ export default class FullScreenModal extends React.Component {
                 appear={true}
             >
                 <div className='FullScreenModal'>
-                    <CloseIcon
-                        className='close-x'
-                        onClick={this.close}
-                    />
+                    <div className='full-screen-modal-header'>
+                        <CloseIcon
+                            className='close-x'
+                            onClick={this.close}
+                        />
+                    </div>
                     {this.props.children}
                 </div>
             </CSSTransition>

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
@@ -10,14 +10,10 @@ $full-screen-modal-transition: 100ms;
     z-index: 2000;
     overflow: auto;
 
-    .full-screen-modal-header {
-        height: 50px;
-    }
-
     .close-x {
         position: fixed;
-        top: 48px;
-        right: 48px;
+        top: 8px;
+        right: 16px;
         cursor: pointer;
         svg {
             fill: var(--center-channel-color-90);

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
@@ -10,6 +10,10 @@ $full-screen-modal-transition: 100ms;
     z-index: 2000;
     overflow: auto;
 
+    .full-screen-modal-header {
+        height: 50px;
+    }
+
     .close-x {
         position: fixed;
         top: 48px;


### PR DESCRIPTION
#### Summary

This PR makes the header of the full screen modal (part containing the close button) have a height of 50px to make it so the "Create Subscription" button is below the x when the screen is narrow.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19685

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/6913320/67606013-20b8c300-f74e-11e9-9436-346d7e657e68.png)

![image](https://user-images.githubusercontent.com/6913320/67606000-139bd400-f74e-11e9-9884-384c6d8ca329.png)


After

![image](https://user-images.githubusercontent.com/6913320/67605945-f1a25180-f74d-11e9-8e22-e1d88da698d1.png)
![image](https://user-images.githubusercontent.com/6913320/67605973-01219a80-f74e-11e9-97b1-232b7339fb1d.png)
