### PR TITLE
[MM-19643] Limit Subscription name to 100 characters

### DIFF
--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -22,6 +22,8 @@ const (
 	FILTER_INCLUDE_ANY = "include_any"
 	FILTER_INCLUDE_ALL = "include_all"
 	FILTER_EXCLUDE_ANY = "exclude_any"
+
+	MAX_SUBSCRIPTION_NAME_LENGTH = 100
 )
 
 type FieldFilter struct {
@@ -258,7 +260,7 @@ func (p *Plugin) addChannelSubscription(newSubscription *ChannelSubscription) er
 			return nil, err
 		}
 
-		err = p.checkChannelSubscriptionNameUnique(newSubscription.ChannelId, newSubscription)
+		err = p.validateSubscription(newSubscription)
 		if err != nil {
 			return nil, err
 		}
@@ -275,7 +277,16 @@ func (p *Plugin) addChannelSubscription(newSubscription *ChannelSubscription) er
 	})
 }
 
-func (p *Plugin) checkChannelSubscriptionNameUnique(channelId string, subscription *ChannelSubscription) error {
+func (p *Plugin) validateSubscription(subscription *ChannelSubscription) error {
+	if len(subscription.Name) == 0 {
+		return errors.New("Please provide a name for the subscription.")
+	}
+
+	if len(subscription.Name) > MAX_SUBSCRIPTION_NAME_LENGTH {
+		return fmt.Errorf("Please provide a name less than %d characters.", MAX_SUBSCRIPTION_NAME_LENGTH)
+	}
+
+	channelId := subscription.ChannelId
 	subs, err := p.getSubscriptionsForChannel(channelId)
 	if err != nil {
 		return err
@@ -307,7 +318,7 @@ func (p *Plugin) editChannelSubscription(modifiedSubscription *ChannelSubscripti
 			return nil, errors.New("Existing subscription does not exist.")
 		}
 
-		err = p.checkChannelSubscriptionNameUnique(oldSub.ChannelId, modifiedSubscription)
+		err = p.validateSubscription(modifiedSubscription)
 		if err != nil {
 			return nil, err
 		}

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}
@@ -203,7 +203,7 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}
@@ -3616,7 +3616,7 @@ exports[`components/EditChannelSettings should match snapshot with no filters 1`
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}
@@ -3781,7 +3781,7 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}
@@ -3957,7 +3957,7 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -288,6 +288,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                             label={'Subscription Name'}
                             placeholder={'Name'}
                             type={'input'}
+                            maxLength={100}
                             required={true}
                             onChange={this.handleNameChange}
                             value={this.state.subscriptionName}


### PR DESCRIPTION
#### Summary

This PR makes it so the user can only have 100 characters in their subscription name.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19643

#### Additional Info

This is adding validation server-side and client-side. I don't expect users to be using our API without the UI, but the server should be performing its own validation for data integrity.