### PR TITLE
[MM-18674] Add post in channel when subscription is created or updated

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -313,6 +313,7 @@ func TestSubscribe(t *testing.T) {
 				mock.AnythingOfTypeArgument("string")).Return(nil)
 
 			api.On("GetChannelMember", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.ChannelMember{}, (*model.AppError)(nil))
+			api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 
 			if tc.apiCalls != nil {
 				tc.apiCalls(api)
@@ -323,6 +324,7 @@ func TestSubscribe(t *testing.T) {
 			})
 			p.SetAPI(api)
 			p.currentInstanceStore = mockCurrentInstanceStore{&p}
+			p.userStore = mockUserStore{}
 
 			w := httptest.NewRecorder()
 			request := httptest.NewRequest("POST", "/api/v2/subscriptions/channel", ioutil.NopCloser(bytes.NewBufferString(tc.subscription)))
@@ -583,6 +585,7 @@ func TestEditSubscription(t *testing.T) {
 				mock.AnythingOfTypeArgument("string")).Return(nil)
 
 			api.On("GetChannelMember", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.ChannelMember{}, (*model.AppError)(nil))
+			api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 
 			if tc.apiCalls != nil {
 				tc.apiCalls(api)
@@ -593,6 +596,7 @@ func TestEditSubscription(t *testing.T) {
 			})
 			p.SetAPI(api)
 			p.currentInstanceStore = mockCurrentInstanceStore{&p}
+			p.userStore = mockUserStore{}
 
 			w := httptest.NewRecorder()
 			request := httptest.NewRequest("PUT", "/api/v2/subscriptions/channel", ioutil.NopCloser(bytes.NewBufferString(tc.subscription)))

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -455,6 +455,7 @@ func TestDeleteSubscription(t *testing.T) {
 				mock.AnythingOfTypeArgument("string")).Return(nil)
 
 			api.On("GetChannelMember", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.ChannelMember{}, (*model.AppError)(nil))
+			api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 
 			if tc.apiCalls != nil {
 				tc.apiCalls(api)
@@ -465,6 +466,7 @@ func TestDeleteSubscription(t *testing.T) {
 			})
 			p.SetAPI(api)
 			p.currentInstanceStore = mockCurrentInstanceStore{&p}
+			p.userStore = mockUserStore{}
 
 			w := httptest.NewRecorder()
 			request := httptest.NewRequest("DELETE", "/api/v2/subscriptions/channel/"+tc.subscriptionId, nil)

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -589,6 +589,24 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte("{\"status\": \"OK\"}"))
 
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	post := &model.Post{
+		UserId:    p.getConfig().botUserID,
+		ChannelId: subscription.ChannelId,
+		Message:   fmt.Sprintf("Jira subscription, \"%v\", was removed from this channel by %v", subscription.Name, jiraUser.DisplayName),
+	}
+
+	p.API.CreatePost(post)
+
 	return http.StatusOK, nil
 }
 

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -492,6 +492,24 @@ func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
 
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	post := &model.Post{
+		UserId:    p.getConfig().botUserID,
+		ChannelId: subscription.ChannelId,
+		Message:   fmt.Sprintf("Jira subscription, \"%v\", was added to this channel by %v", subscription.Name, jiraUser.DisplayName),
+	}
+
+	p.API.CreatePost(post)
+
 	return http.StatusOK, nil
 }
 
@@ -523,6 +541,24 @@ func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Reque
 	if _, err := w.Write(b); err != nil {
 		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
+
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mattermostUserId)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	post := &model.Post{
+		UserId:    p.getConfig().botUserID,
+		ChannelId: subscription.ChannelId,
+		Message:   fmt.Sprintf("Jira subscription, \"%v\", was updated by %v", subscription.Name, jiraUser.DisplayName),
+	}
+
+	p.API.CreatePost(post)
 
 	return http.StatusOK, nil
 }

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -465,7 +465,8 @@ func httpSubscribeWebhook(p *Plugin, w http.ResponseWriter, r *http.Request) (in
 
 func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	subscription := ChannelSubscription{}
-	if err := json.NewDecoder(r.Body).Decode(&subscription); err != nil {
+	err := json.NewDecoder(r.Body).Decode(&subscription)
+	if err != nil {
 		return http.StatusBadRequest, errors.WithMessage(err, "failed to decode incoming request")
 	}
 
@@ -474,21 +475,25 @@ func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusBadRequest, fmt.Errorf("Channel subscription invalid")
 	}
 
-	if _, err := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId); err != nil {
+	_, appErr := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId)
+	if appErr != nil {
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
 	}
 
-	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+	err = p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId)
+	if err != nil {
 		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
-	if err := p.addChannelSubscription(&subscription); err != nil {
+	err = p.addChannelSubscription(&subscription)
+	if err != nil {
 		return http.StatusInternalServerError, err
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	b, _ := json.Marshal(&subscription)
-	if _, err := w.Write(b); err != nil {
+	_, err = w.Write(b)
+	if err != nil {
 		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
 
@@ -515,7 +520,8 @@ func httpChannelCreateSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 
 func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Request, mattermostUserId string) (int, error) {
 	subscription := ChannelSubscription{}
-	if err := json.NewDecoder(r.Body).Decode(&subscription); err != nil {
+	err := json.NewDecoder(r.Body).Decode(&subscription)
+	if err != nil {
 		return http.StatusBadRequest, errors.WithMessage(err, "failed to decode incoming request")
 	}
 
@@ -524,21 +530,25 @@ func httpChannelEditSubscription(p *Plugin, w http.ResponseWriter, r *http.Reque
 		return http.StatusBadRequest, fmt.Errorf("Channel subscription invalid")
 	}
 
-	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+	err = p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId)
+	if err != nil {
 		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
-	if _, err := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId); err != nil {
+	_, appErr := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId)
+	if appErr != nil {
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
 	}
 
-	if err := p.editChannelSubscription(&subscription); err != nil {
+	err = p.editChannelSubscription(&subscription)
+	if err != nil {
 		return http.StatusInternalServerError, err
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	b, _ := json.Marshal(&subscription)
-	if _, err := w.Write(b); err != nil {
+	_, err = w.Write(b)
+	if err != nil {
 		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
 
@@ -574,15 +584,18 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusBadRequest, errors.Wrap(err, "bad subscription id")
 	}
 
-	if err = p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+	err = p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId)
+	if err != nil {
 		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
-	if _, err := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId); err != nil {
+	_, appErr := p.API.GetChannelMember(subscription.ChannelId, mattermostUserId)
+	if appErr != nil {
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
 	}
 
-	if err = p.removeChannelSubscription(subscriptionId); err != nil {
+	err = p.removeChannelSubscription(subscriptionId)
+	if err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "unable to remove channel subscription")
 	}
 

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -574,7 +574,7 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusBadRequest, errors.Wrap(err, "bad subscription id")
 	}
 
-	if err := p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
+	if err = p.hasPermissionToManageSubscription(mattermostUserId, subscription.ChannelId); err != nil {
 		return http.StatusForbidden, errors.Wrap(err, "you don't have permission to manage subscriptions")
 	}
 
@@ -582,7 +582,7 @@ func httpChannelDeleteSubscription(p *Plugin, w http.ResponseWriter, r *http.Req
 		return http.StatusForbidden, errors.New("Not a member of the channel specified")
 	}
 
-	if err := p.removeChannelSubscription(subscriptionId); err != nil {
+	if err = p.removeChannelSubscription(subscriptionId); err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "unable to remove channel subscription")
 	}
 


### PR DESCRIPTION
## Summary
This PR adds a post, from the Jira Bot, informing users when a subscription was created, edited or deleted.

![image](https://user-images.githubusercontent.com/7575921/67824430-5504ea00-fa94-11e9-8144-26a033e07c3e.png)
![image](https://user-images.githubusercontent.com/7575921/67905663-162c6e00-fb40-11e9-81f9-49d95bedd53e.png)

## Ticket
https://mattermost.atlassian.net/browse/MM-18674