### PR TITLE
[MM-19784] Fetch jira cloud issue for webhook comment events

### DIFF
--- a/server/kv.go
+++ b/server/kv.go
@@ -207,6 +207,10 @@ func (store store) StoreCurrentJIRAInstance(ji Instance) (returnErr error) {
 	store.plugin.updateConfig(func(conf *config) {
 		conf.currentInstance = ji
 		conf.currentInstanceExpires = time.Now().Add(currentInstanceTTL)
+
+		// Removing from cache since we are switching instances
+		conf.currentCloudBotClient = nil
+		conf.currentCloudBotClientExpires = time.Time{}
 	})
 	store.plugin.debugf("Stored: current Jira instance: %s", ji.GetURL())
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 	"time"
 
+	jira "github.com/andygrunwald/go-jira"
 	"github.com/mattermost/mattermost-server/model"
 
 	"github.com/pkg/errors"
@@ -54,6 +55,7 @@ type externalConfig struct {
 }
 
 const currentInstanceTTL = 1 * time.Second
+const currentCloudBotClientTTL = 15 * time.Minute
 
 const defaultMaxAttachmentSize = ByteSize(10 * 1024 * 1024) // 10Mb
 
@@ -68,6 +70,11 @@ type config struct {
 	// of a value. A nil value means there is no instance available.
 	currentInstance        Instance
 	currentInstanceExpires time.Time
+
+	// Cached non-user Jira cloud client. A non-0 expires indicates the presence
+	// of a value. A nil value means there is no client available.
+	currentCloudBotClient        *jira.Client
+	currentCloudBotClientExpires time.Time
 
 	// Maximum attachment size allowed to be uploaded to Jira
 	maxAttachmentSize ByteSize

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -114,8 +114,25 @@ func (p *Plugin) getChannelsSubscribed(wh *webhook) (StringSet, error) {
 		return nil, err
 	}
 
-	webhookEvents := wh.Events()
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return nil, err
+	}
+
 	subIds := subs.Channel.ById
+	instType := ji.GetType()
+
+	issue := &jwh.Issue
+	webhookEvents := wh.Events()
+	isCommentEvent := jwh.WebhookEvent == "comment_created" || jwh.WebhookEvent == "comment_updated" || jwh.WebhookEvent == "comment_deleted"
+
+	if isCommentEvent && instType == "cloud" {
+		// Jira Cloud comment event. We need to fetch issue data because it is not expanded in webhook payload.
+		issue, err = p.getIssueDataForCloudWebhook(issue.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	channelIds := NewStringSet()
 	for _, sub := range subIds {
@@ -135,11 +152,11 @@ func (p *Plugin) getChannelsSubscribed(wh *webhook) (StringSet, error) {
 			continue
 		}
 
-		if !sub.Filters.IssueTypes.ContainsAny(jwh.Issue.Fields.Type.ID) {
+		if !sub.Filters.IssueTypes.ContainsAny(issue.Fields.Type.ID) {
 			continue
 		}
 
-		if !sub.Filters.Projects.ContainsAny(jwh.Issue.Fields.Project.Key) {
+		if !sub.Filters.Projects.ContainsAny(issue.Fields.Project.Key) {
 			continue
 		}
 
@@ -152,7 +169,7 @@ func (p *Plugin) getChannelsSubscribed(wh *webhook) (StringSet, error) {
 				break
 			}
 
-			value := getIssueFieldValue(&jwh.Issue, field.Key)
+			value := getIssueFieldValue(issue, field.Key)
 			containsAny := value.ContainsAny(field.Values.Elems()...)
 			containsAll := value.ContainsAll(field.Values.Elems()...)
 


### PR DESCRIPTION
#### Summary

For `comment_*` events from Jira Cloud, the issue is missing. This PR fetches the issue during the webhook call.

@levb @DHaussermann This problem does not exist for Jira Server. I had forgotten that Jira Server sends two payloads, and one has the whole issue attached.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19784

#### Additional Info

This PR contains some code pertaining to caching the Jira Cloud bot client. The code was reviewed and approved in [this PR](https://github.com/mattermost/mattermost-plugin-jira/pull/252).

This PR is currently the only code using the bot client. 