### PR TITLE
[MM-19793] Change wording of channel subscriptions permissions error

### DIFF
--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`components/EditChannelSettings SERVER - should match snapshot after fet
       <Input
         addValidate={[Function]}
         label="Subscription Name"
-        maxLength={null}
+        maxLength={100}
         onChange={[Function]}
         placeholder="Name"
         readOnly={false}

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -43,7 +43,7 @@ export default class ChannelSettingsModal extends PureComponent {
             if (this.props.channelSubscriptions instanceof Error) {
                 inner = (
                     <Modal.Body>
-                        {'You do not have permission to access Jira subscriptions in this channel.'}
+                        {'You do not have permission to edit the subscriptions for this channel. Configuring a Jira subscription will create notifications in this channel when certain events happen in Jira, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'}
                     </Modal.Body>
                 );
             } else {


### PR DESCRIPTION
#### Summary

When a user that does not have permissions to create channel subscriptions opens the modal, they are now shown the text:

> You do not have permission to edit the subscriptions for this channel. Configuring a Jira subscription will create notifications in this channel when certain events happen in Jira, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19793

#### Screenshots

![image](https://user-images.githubusercontent.com/6913320/68007082-e91bb080-fc50-11e9-8c24-336ca9ec0c88.png)
