### PR TITLE
[MM-19810] Handle default vs custom fields in events

### DIFF
--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -182,40 +182,12 @@ exports[`components/EditChannelSettings SERVER - should match snapshot after fet
               "value": "event_updated_summary",
             },
             Object {
-              "label": "Issue Updated: Custom - Affects Version/s",
-              "value": "event_updated_Affects Version/s",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Component/s",
-              "value": "event_updated_Component/s",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Environment",
-              "value": "event_updated_Environment",
-            },
-            Object {
               "label": "Issue Updated: Custom - Epic Link",
               "value": "event_updated_Epic Link",
             },
             Object {
               "label": "Issue Updated: Custom - Epic Name",
               "value": "event_updated_Epic Name",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Issue Type",
-              "value": "event_updated_Issue Type",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Linked Issues",
-              "value": "event_updated_Linked Issues",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Project",
-              "value": "event_updated_Project",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Reporter",
-              "value": "event_updated_Reporter",
             },
           ]
         }
@@ -2198,18 +2170,6 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
               "value": "event_updated_summary",
             },
             Object {
-              "label": "Issue Updated: Custom - Affects versions",
-              "value": "event_updated_versions",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Components",
-              "value": "event_updated_components",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Environment",
-              "value": "event_updated_environment",
-            },
-            Object {
               "label": "Issue Updated: Custom - Epic Link",
               "value": "event_updated_customfield_10014",
             },
@@ -2220,14 +2180,6 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
             Object {
               "label": "Issue Updated: Custom - Favorite Food",
               "value": "event_updated_customfield_10067",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Issue Type",
-              "value": "event_updated_issuetype",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Linked Issues",
-              "value": "event_updated_issuelinks",
             },
             Object {
               "label": "Issue Updated: Custom - MJK - Checkbox",
@@ -2272,14 +2224,6 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
             Object {
               "label": "Issue Updated: Custom - MJK - User Picker",
               "value": "event_updated_customfield_10080",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Project",
-              "value": "event_updated_project",
-            },
-            Object {
-              "label": "Issue Updated: Custom - Sprint",
-              "value": "event_updated_customfield_10021",
             },
             Object {
               "label": "Issue Updated: Custom - Text Field 1",

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -13,7 +13,7 @@ import Validator from 'components/validator';
 import {
     getProjectValues,
     getIssueValuesForMultipleProjects,
-    getCustomFieldValuesForProjects,
+    getCustomFieldValuesForEvents,
     getCustomFieldFiltersForProjects,
     getConflictingFields,
 } from 'utils/jira_issue_metadata';
@@ -60,20 +60,6 @@ export type State = {
     subscriptionName: string | null;
     showConfirmModal: boolean;
     conflictingError: string | null;
-};
-
-const removeDuplicateEvents = (array: ReactSelectOption[]): ReactSelectOption[] => {
-    const result = {} as any;
-    for (const event of array) {
-        let value = event.value;
-        if (value === 'event_updated_Fix Version/s' || value === 'event_updated_fixVersions') {
-            value = 'event_updated_fix_version';
-        }
-        if (!result[value.toLowerCase()]) {
-            result[value] = event;
-        }
-    }
-    return Object.values(result);
 };
 
 export default class EditChannelSettings extends PureComponent<Props, State> {
@@ -294,11 +280,10 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
 
         const projectOptions = getProjectValues(this.props.jiraProjectMetadata);
         const issueOptions = getIssueValuesForMultipleProjects(this.props.jiraProjectMetadata, this.state.filters.projects);
-        const customFields = getCustomFieldValuesForProjects(this.props.jiraIssueMetadata, this.state.filters.projects);
+        const customFields = getCustomFieldValuesForEvents(this.props.jiraIssueMetadata, this.state.filters.projects);
         const filterFields = getCustomFieldFiltersForProjects(this.props.jiraIssueMetadata, this.state.filters.projects);
 
-        let eventOptions = JiraEventOptions.concat(customFields);
-        eventOptions = removeDuplicateEvents(eventOptions);
+        const eventOptions = JiraEventOptions.concat(customFields);
 
         let conflictingErrorComponent = null;
         if (this.state.conflictingError) {

--- a/webapp/src/testdata/cloud-get-create-issue-metadata-for-project-many-fields.json
+++ b/webapp/src/testdata/cloud-get-create-issue-metadata-for-project-many-fields.json
@@ -359,11 +359,6 @@
           }
         },
         "labels": {
-          "COMMENT": "allowedValues would not normally be here",
-          "allowedValues": [
-            "Pickles",
-            "Some Label"
-          ],
           "autoCompleteUrl": "https://mmtest.atlassian.net/rest/api/1.0/labels/suggest?query=",
           "hasDefaultValue": false,
           "key": "labels",

--- a/webapp/src/utils/jira_issue_metadata.tsx
+++ b/webapp/src/utils/jira_issue_metadata.tsx
@@ -208,6 +208,7 @@ export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null,
 
 const avoidedCustomTypesForEvents = [
     'com.pyxis.greenhopper.jira:gh-sprint',
+    'com.pyxis.greenhopper.jira:gh-lexo-rank',
 ];
 
 function isValidFieldForEvents(field: JiraField): boolean {

--- a/webapp/src/utils/jira_issue_metadata.tsx
+++ b/webapp/src/utils/jira_issue_metadata.tsx
@@ -140,27 +140,28 @@ export function getCustomFieldsForProjects(metadata: IssueMetadata | null, proje
 const allowedTypes = [
     'priority',
     'securitylevel',
+    'security',
 ];
 
-const avoidedCustomTypes = [
+const avoidedCustomTypesForFilters = [
     'com.pyxis.greenhopper.jira:gh-sprint',
 ];
 
-const acceptedCustomTypes = [
+const acceptedCustomTypesForFilters = [
     'com.pyxis.greenhopper.jira:gh-epic-link',
 ];
 
 function isValidFieldForFilter(field: JiraField): boolean {
     const {custom, type, items} = field.schema;
-    if (custom && avoidedCustomTypes.includes(custom)) {
+    if (custom && avoidedCustomTypesForFilters.includes(custom)) {
         return false;
     }
 
-    return allowedTypes.includes(type) || (custom && acceptedCustomTypes.includes(custom)) ||
-    type === 'option' ||
-    (type === 'array' && items === 'option') ||
-    (type === 'array' && items === 'version') ||
-    (type === 'array' && items === 'string');
+    return allowedTypes.includes(type) || (custom && acceptedCustomTypesForFilters.includes(custom)) ||
+    type === 'option' || // single select
+    (type === 'array' && items === 'option') || // multiselect
+    (type === 'array' && items === 'version') || // fix and affects versions
+    (type === 'array' && items === 'string'); // labels
 }
 
 export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null, projectKeys: string[]): FilterField[] {
@@ -205,8 +206,21 @@ export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null,
     return sortByName(result);
 }
 
-export function getCustomFieldValuesForProjects(metadata: IssueMetadata | null, projectKeys: string[]): ReactSelectOption[] {
-    return getCustomFieldsForProjects(metadata, projectKeys).map((field) => ({
+const avoidedCustomTypesForEvents = [
+    'com.pyxis.greenhopper.jira:gh-sprint',
+];
+
+function isValidFieldForEvents(field: JiraField): boolean {
+    const {custom} = field.schema;
+    if (!custom) {
+        return false;
+    }
+
+    return !avoidedCustomTypesForEvents.includes(custom);
+}
+
+export function getCustomFieldValuesForEvents(metadata: IssueMetadata | null, projectKeys: string[]): ReactSelectOption[] {
+    return getCustomFieldsForProjects(metadata, projectKeys).filter(isValidFieldForEvents).map((field) => ({
         label: `Issue Updated: Custom - ${field.name}`,
         value: `event_updated_${field.changeLogID}`,
     }));


### PR DESCRIPTION
#### Summary

When parsing fields for filters, the dataset includes default fields. Some code was reused for events, and the default fields are already included inside of the component for events. This PR makes it so, for events, only custom fields are retrieved from the issue metadata.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19810