### PR TITLE
[MM-20014] Show project metadata fetch error

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -199,7 +199,7 @@
     "max-nested-callbacks": [
       2,
       {
-        "max": 2
+        "max": 3
       }
     ],
     "max-statements-per-line": [

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -95,30 +95,6 @@ export const fetchJiraProjectMetadata = () => {
     };
 };
 
-// Fetch channel subscriptions and project metadata, then open modal
-export const fetchChannelSettingsDataAndOpenModal = (channelId) => {
-    return async (dispatch) => {
-        dispatch(sendEphemeralPost('Retrieving Subscriptions'));
-
-        const projectsPromise = dispatch(fetchJiraProjectMetadata());
-        const subscriptionsPromise = dispatch(fetchChannelSubscriptions(channelId));
-
-        const subscriptionsResponse = await subscriptionsPromise;
-        if (subscriptionsResponse.error) {
-            dispatch(sendEphemeralPost('You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'));
-            return {error: subscriptionsResponse.error};
-        }
-
-        const projectsResponse = await projectsPromise;
-        if (projectsResponse.error) {
-            dispatch(sendEphemeralPost('Failed to get Jira project information. Please contact your Mattermost administrator.'));
-            return {error: projectsResponse.error};
-        }
-
-        return dispatch(openChannelSettings(channelId));
-    };
-};
-
 export const fetchEpicsWithParams = (params) => {
     return async (dispatch, getState) => {
         const url = getPluginServerRoute(getState()) + '/api/v2/get-search-epics';
@@ -228,11 +204,6 @@ export const fetchChannelSubscriptions = (channelId) => {
                 method: 'get',
             });
         } catch (error) {
-            dispatch({
-                type: ActionTypes.RECEIVED_CHANNEL_SUBSCRIPTIONS,
-                channelId,
-                data: error,
-            });
             return {error};
         }
 

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -95,6 +95,30 @@ export const fetchJiraProjectMetadata = () => {
     };
 };
 
+// Fetch channel subscriptions and project metadata, then open modal
+export const fetchChannelSettingsDataAndOpenModal = (channelId) => {
+    return async (dispatch) => {
+        dispatch(sendEphemeralPost('Retrieving Subscriptions'));
+
+        const projectsPromise = dispatch(fetchJiraProjectMetadata());
+        const subscriptionsPromise = dispatch(fetchChannelSubscriptions(channelId));
+
+        const subscriptionsResponse = await subscriptionsPromise;
+        if (subscriptionsResponse.error) {
+            dispatch(sendEphemeralPost('You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'));
+            return {error: subscriptionsResponse.error};
+        }
+
+        const projectsResponse = await projectsPromise;
+        if (projectsResponse.error) {
+            dispatch(sendEphemeralPost('Failed to get Jira project information. Please contact your Mattermost administrator.'));
+            return {error: projectsResponse.error};
+        }
+
+        return dispatch(openChannelSettings(channelId));
+    };
+};
+
 export const fetchEpicsWithParams = (params) => {
     return async (dispatch, getState) => {
         const url = getPluginServerRoute(getState()) + '/api/v2/get-search-epics';

--- a/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
@@ -32,7 +32,7 @@ describe('components/ChannelSettingsModal', () => {
         close: () => jest.fn(),
     } as Props;
 
-    test('modal only shows when appropriate props are present', async () => {
+    test('modal only shows when channel, channelSubscriptions, and jiraProjectMetadata props are present', async () => {
         const props = {
             ...baseProps,
             channel: null,

--- a/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import testChannel from 'testdata/channel.json';
+
+import ChannelSettingsModal, {Props} from './channel_settings';
+
+describe('components/ChannelSettingsModal', () => {
+    const baseProps = {
+        sendEphemeralPost: jest.fn(),
+        close: jest.fn(),
+        fetchJiraProjectMetadata: jest.fn(),
+        fetchChannelSubscriptions: jest.fn(),
+    } as Props;
+
+    test('error fetching project metadata, should close modal and show ephemeral message', async () => {
+        const props = {
+            ...baseProps,
+            fetchJiraProjectMetadata: jest.fn().mockImplementation(() => Promise.resolve({error: 'Failed to fetch'})),
+            sendEphemeralPost: jest.fn(),
+            close: jest.fn(),
+        };
+
+        const wrapper = shallow<ChannelSettingsModal>(
+            <ChannelSettingsModal {...props}/>
+        );
+
+        wrapper.setProps({...props, channel: testChannel});
+
+        expect(props.fetchJiraProjectMetadata).toHaveBeenCalled();
+
+        await Promise.resolve();
+
+        expect(props.close).toHaveBeenCalled();
+        expect(props.sendEphemeralPost).toHaveBeenCalledWith('Failed to get Jira project information. Please contact your Mattermost administrator.');
+    });
+});

--- a/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.test.tsx
@@ -6,35 +6,44 @@ import {shallow} from 'enzyme';
 
 import testChannel from 'testdata/channel.json';
 
+import {IssueMetadata, ProjectMetadata} from 'types/model';
+
+import FullScreenModal from '../full_screen_modal/full_screen_modal';
+
 import ChannelSettingsModal, {Props} from './channel_settings';
+import ChannelSettingsModalInner from './channel_settings_internal';
 
 describe('components/ChannelSettingsModal', () => {
     const baseProps = {
-        sendEphemeralPost: jest.fn(),
-        close: jest.fn(),
-        fetchJiraProjectMetadata: jest.fn(),
-        fetchChannelSubscriptions: jest.fn(),
+        theme: {},
+        jiraIssueMetadata: {} as IssueMetadata,
+        fetchJiraIssueMetadataForProjects: jest.fn(),
+        jiraProjectMetadata: {} as ProjectMetadata,
+        channel: testChannel,
+        channelSubscriptions: [],
+        omitDisplayName: false,
+        createChannelSubscription: jest.fn(),
+        deleteChannelSubscription: jest.fn(),
+        editChannelSubscription: jest.fn(),
+        clearIssueMetadata: jest.fn(),
+        close: () => jest.fn(),
     } as Props;
 
-    test('error fetching project metadata, should close modal and show ephemeral message', async () => {
+    test('modal only shows when channel is passed in', async () => {
         const props = {
             ...baseProps,
-            fetchJiraProjectMetadata: jest.fn().mockImplementation(() => Promise.resolve({error: 'Failed to fetch'})),
-            sendEphemeralPost: jest.fn(),
-            close: jest.fn(),
+            channel: null,
         };
 
         const wrapper = shallow<ChannelSettingsModal>(
             <ChannelSettingsModal {...props}/>
         );
 
+        expect(wrapper.find(ChannelSettingsModalInner).length).toEqual(0);
+        expect(wrapper.find(FullScreenModal).props().show).toBe(false);
+
         wrapper.setProps({...props, channel: testChannel});
-
-        expect(props.fetchJiraProjectMetadata).toHaveBeenCalled();
-
-        await Promise.resolve();
-
-        expect(props.close).toHaveBeenCalled();
-        expect(props.sendEphemeralPost).toHaveBeenCalledWith('Failed to get Jira project information. Please contact your Mattermost administrator.');
+        expect(wrapper.find(ChannelSettingsModalInner).length).toEqual(1);
+        expect(wrapper.find(FullScreenModal).props().show).toBe(true);
     });
 });

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -2,10 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React, {PureComponent} from 'react';
-import {Modal} from 'react-bootstrap';
-
-import Loading from 'components/loading';
-import {ProjectMetadata, ChannelSubscription} from 'types/model';
 
 import FullScreenModal from '../full_screen_modal/full_screen_modal';
 
@@ -14,38 +10,9 @@ import {SharedProps} from './shared_props';
 
 import './channel_settings_modal.scss';
 
-export type Props = SharedProps & {
-    fetchJiraProjectMetadata: () => Promise<{data?: ProjectMetadata; error: Error}>;
-    fetchChannelSubscriptions: (channelId: string) => Promise<{data: ChannelSubscription[]}>;
-    close: () => void;
-    sendEphemeralPost: (message: string) => void;
-}
+export type Props = SharedProps;
 
-type State = {
-    error: string | null;
-};
-
-export default class ChannelSettingsModal extends PureComponent<Props, State> {
-    state = {
-        error: null,
-    };
-
-    componentDidUpdate(prevProps: Props): void {
-        if (this.props.channel && (!prevProps.channel || this.props.channel.id !== prevProps.channel.id)) {
-            this.fetchProjectMetadata();
-            this.props.fetchChannelSubscriptions(this.props.channel.id);
-        }
-    }
-
-    fetchProjectMetadata = (): void => {
-        this.props.fetchJiraProjectMetadata().then(({error}) => {
-            if (error) {
-                this.props.sendEphemeralPost('Failed to get Jira project information. Please contact your Mattermost administrator.');
-                this.props.close();
-            }
-        });
-    };
-
+export default class ChannelSettingsModal extends PureComponent<Props> {
     handleClose = (e: Event): void => {
         if (e && e.preventDefault) {
             e.preventDefault();
@@ -54,21 +21,13 @@ export default class ChannelSettingsModal extends PureComponent<Props, State> {
     };
 
     render(): JSX.Element {
-        let inner = <Loading/>;
-        if (this.props.channelSubscriptions && this.props.jiraProjectMetadata) {
-            if (this.props.channelSubscriptions instanceof Error) {
-                inner = (
-                    <Modal.Body>
-                        {'You do not have permission to edit the subscriptions for this channel. Configuring a Jira subscription will create notifications in this channel when certain events happen in Jira, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'}
-                    </Modal.Body>
-                );
-            } else {
-                inner = (
-                    <ChannelSettingsModalInner
-                        {...this.props}
-                    />
-                );
-            }
+        let inner;
+        if (this.props.channel) {
+            inner = (
+                <ChannelSettingsModalInner
+                    {...this.props}
+                />
+            );
         }
 
         return (

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -14,11 +14,11 @@ import {SharedProps} from './shared_props';
 
 import './channel_settings_modal.scss';
 
-type Props = SharedProps & {
+export type Props = SharedProps & {
     fetchJiraProjectMetadata: () => Promise<{data?: ProjectMetadata; error: Error}>;
     fetchChannelSubscriptions: (channelId: string) => Promise<{data: ChannelSubscription[]}>;
     close: () => void;
-    sendEphemeralPost: (msg: string) => void;
+    sendEphemeralPost: (message: string) => void;
 }
 
 type State = {

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -3,6 +3,8 @@
 
 import React, {PureComponent} from 'react';
 
+import {ProjectMetadata, ChannelSubscription} from 'types/model';
+
 import FullScreenModal from '../full_screen_modal/full_screen_modal';
 
 import ChannelSettingsModalInner from './channel_settings_internal';
@@ -10,19 +12,58 @@ import {SharedProps} from './shared_props';
 
 import './channel_settings_modal.scss';
 
-export type Props = SharedProps;
+export type Props = SharedProps & {
+    fetchJiraProjectMetadata: () => Promise<{data?: ProjectMetadata; error: Error}>;
+    fetchChannelSubscriptions: (channelId: string) => Promise<{data: ChannelSubscription[]; error: Error}>;
+    sendEphemeralPost: (message: string) => void;
+    channelSubscriptions: ChannelSubscription[] | null;
+    jiraProjectMetadata: ProjectMetadata | null;
+}
 
 export default class ChannelSettingsModal extends PureComponent<Props> {
-    handleClose = (e: Event): void => {
+    componentDidUpdate(prevProps: Props): void {
+        if (this.props.channel && (!prevProps.channel || this.props.channel.id !== prevProps.channel.id)) {
+            this.fetchData();
+        }
+    }
+
+    fetchData = async (): Promise<void> => {
+        if (!this.props.channel) {
+            return;
+        }
+
+        this.props.sendEphemeralPost('Retrieving Subscriptions');
+
+        const projectsPromise = this.props.fetchJiraProjectMetadata();
+        const subscriptionsPromise = this.props.fetchChannelSubscriptions(this.props.channel.id);
+
+        const subscriptionsResponse = await subscriptionsPromise;
+        if (subscriptionsResponse.error) {
+            this.props.sendEphemeralPost('You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.');
+            this.handleClose();
+            return;
+        }
+
+        const projectsResponse = await projectsPromise;
+        if (projectsResponse.error) {
+            this.props.sendEphemeralPost('Failed to get Jira project information. Please contact your Mattermost administrator.');
+            this.handleClose();
+        }
+    };
+
+    handleClose = (e?: Event): void => {
         if (e && e.preventDefault) {
             e.preventDefault();
         }
+
         this.props.close();
     };
 
     render(): JSX.Element {
+        const isModalOpen = Boolean(this.props.channel && this.props.jiraProjectMetadata && this.props.channelSubscriptions);
+
         let inner;
-        if (this.props.channel) {
+        if (isModalOpen) {
             inner = (
                 <ChannelSettingsModalInner
                     {...this.props}
@@ -32,7 +73,7 @@ export default class ChannelSettingsModal extends PureComponent<Props> {
 
         return (
             <FullScreenModal
-                show={Boolean(this.props.channel)}
+                show={isModalOpen}
                 onClose={this.handleClose}
             >
                 <div className='channel-subscriptions-modal'>

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -18,6 +18,7 @@ type Props = SharedProps & {
     fetchJiraProjectMetadata: () => Promise<{data?: ProjectMetadata; error: Error}>;
     fetchChannelSubscriptions: (channelId: string) => Promise<{data: ChannelSubscription[]}>;
     close: () => void;
+    sendEphemeralPost: (msg: string) => void;
 }
 
 type State = {
@@ -36,10 +37,11 @@ export default class ChannelSettingsModal extends PureComponent<Props, State> {
         }
     }
 
-    fetchProjectMetadata = () => {
+    fetchProjectMetadata = (): void => {
         this.props.fetchJiraProjectMetadata().then(({error}) => {
             if (error) {
-                this.setState({error: 'Failed to get Jira project information. Please contact your Mattermost administrator.'});
+                this.props.sendEphemeralPost('Failed to get Jira project information. Please contact your Mattermost administrator.');
+                this.props.close();
             }
         });
     };
@@ -53,13 +55,7 @@ export default class ChannelSettingsModal extends PureComponent<Props, State> {
 
     render(): JSX.Element {
         let inner = <Loading/>;
-        if (this.state.error) {
-            inner = (
-                <Modal.Body>
-                    {this.state.error}
-                </Modal.Body>
-            );
-        } else if (this.props.channelSubscriptions && this.props.jiraProjectMetadata) {
+        if (this.props.channelSubscriptions && this.props.jiraProjectMetadata) {
             if (this.props.channelSubscriptions instanceof Error) {
                 inner = (
                     <Modal.Body>

--- a/webapp/src/components/modals/channel_settings/index.ts
+++ b/webapp/src/components/modals/channel_settings/index.ts
@@ -16,6 +16,7 @@ import {
     fetchJiraProjectMetadata,
     fetchJiraIssueMetadataForProjects,
     clearIssueMetadata,
+    sendEphemeralPost,
 } from 'actions';
 
 import {getChannelSubscriptions, getChannelIdWithSettingsOpen, getJiraProjectMetadata, getJiraIssueMetadata} from 'selectors';
@@ -55,6 +56,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
     fetchChannelSubscriptions,
     deleteChannelSubscription,
     editChannelSubscription,
+    sendEphemeralPost,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChannelSettingsModal);

--- a/webapp/src/components/modals/channel_settings/index.ts
+++ b/webapp/src/components/modals/channel_settings/index.ts
@@ -9,14 +9,11 @@ import {isDirectChannel, isGroupChannel} from 'mattermost-redux/utils/channel_ut
 
 import {
     createChannelSubscription,
-    fetchChannelSubscriptions,
     deleteChannelSubscription,
     editChannelSubscription,
     closeChannelSettings,
-    fetchJiraProjectMetadata,
     fetchJiraIssueMetadataForProjects,
     clearIssueMetadata,
-    sendEphemeralPost,
 } from 'actions';
 
 import {getChannelSubscriptions, getChannelIdWithSettingsOpen, getJiraProjectMetadata, getJiraIssueMetadata} from 'selectors';
@@ -49,14 +46,11 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     close: closeChannelSettings,
-    fetchJiraProjectMetadata,
     fetchJiraIssueMetadataForProjects,
     clearIssueMetadata,
     createChannelSubscription,
-    fetchChannelSubscriptions,
     deleteChannelSubscription,
     editChannelSubscription,
-    sendEphemeralPost,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChannelSettingsModal);

--- a/webapp/src/components/modals/channel_settings/index.ts
+++ b/webapp/src/components/modals/channel_settings/index.ts
@@ -9,11 +9,14 @@ import {isDirectChannel, isGroupChannel} from 'mattermost-redux/utils/channel_ut
 
 import {
     createChannelSubscription,
+    fetchChannelSubscriptions,
     deleteChannelSubscription,
     editChannelSubscription,
     closeChannelSettings,
+    fetchJiraProjectMetadata,
     fetchJiraIssueMetadataForProjects,
     clearIssueMetadata,
+    sendEphemeralPost,
 } from 'actions';
 
 import {getChannelSubscriptions, getChannelIdWithSettingsOpen, getJiraProjectMetadata, getJiraIssueMetadata} from 'selectors';
@@ -46,11 +49,14 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     close: closeChannelSettings,
+    fetchJiraProjectMetadata,
     fetchJiraIssueMetadataForProjects,
     clearIssueMetadata,
     createChannelSubscription,
+    fetchChannelSubscriptions,
     deleteChannelSubscription,
     editChannelSubscription,
+    sendEphemeralPost,
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChannelSettingsModal);

--- a/webapp/src/components/modals/channel_settings/shared_props.ts
+++ b/webapp/src/components/modals/channel_settings/shared_props.ts
@@ -1,7 +1,7 @@
 import {ProjectMetadata, IssueMetadata, ChannelSubscription} from 'types/model';
 
 export type SharedProps = {
-    channel: {id: string; name: string; display_name: string};
+    channel: {id: string; name: string; display_name: string} | null;
     theme: any;
     jiraProjectMetadata: ProjectMetadata;
     jiraIssueMetadata: IssueMetadata | null;

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {isDesktopApp} from '../utils/user_agent';
-import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
+import {openCreateModalWithoutPost, fetchChannelSettingsDataAndOpenModal, sendEphemeralPost} from '../actions';
 import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
 import PluginId from 'plugin_id';
 
@@ -58,7 +58,7 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
                 return Promise.resolve({});
             }
-            this.store.dispatch(openChannelSettings(contextArgs.channel_id));
+            this.store.dispatch(fetchChannelSettingsDataAndOpenModal(contextArgs.channel_id));
             return Promise.resolve({});
         }
 

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {isDesktopApp} from '../utils/user_agent';
-import {openCreateModalWithoutPost, fetchChannelSettingsDataAndOpenModal, sendEphemeralPost} from '../actions';
+import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
 import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
 import PluginId from 'plugin_id';
 
@@ -58,7 +58,8 @@ export default class Hooks {
                 this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
                 return Promise.resolve({});
             }
-            this.store.dispatch(fetchChannelSettingsDataAndOpenModal(contextArgs.channel_id));
+
+            this.store.dispatch(openChannelSettings(contextArgs.channel_id));
             return Promise.resolve({});
         }
 

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -95,6 +95,8 @@ const jiraIssueMetadata = (state = null, action) => {
         return action.data;
     case ActionTypes.CLEAR_JIRA_ISSUE_METADATA:
         return null;
+    case ActionTypes.CLOSE_CHANNEL_SETTINGS:
+        return null;
     default:
         return state;
     }
@@ -104,6 +106,8 @@ const jiraProjectMetadata = (state = null, action) => {
     switch (action.type) {
     case ActionTypes.RECEIVED_JIRA_PROJECT_METADATA:
         return action.data;
+    case ActionTypes.CLOSE_CHANNEL_SETTINGS:
+        return null;
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary

When the `get-jira-project-metadata` call fails, we should show an error to the user.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20014
https://mattermost.atlassian.net/browse/MM-19928

#### Screenshots:

The modal does not open, and an ephemeral message is posted:

Permissions error
![image](https://user-images.githubusercontent.com/6913320/68883632-70503600-06df-11ea-94e5-ddc1f0021bb2.png)

Error fetching Jira project data
![image](https://user-images.githubusercontent.com/6913320/68883662-7c3bf800-06df-11ea-8768-e5e182d406f8.png)