### PR TITLE
[MM-20013] Improve epic link search

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -317,7 +317,7 @@ func httpAPIGetSearchEpics(ji Instance, w http.ResponseWriter, r *http.Request) 
 
 	wg.Wait()
 
-	var result []ReactSelectOption
+	result := []ReactSelectOption{}
 	if exact != nil {
 		name, _ := exact.Fields.Unknowns.String(epicNameTypeID)
 		if name != "" {

--- a/webapp/src/components/jira_epic_selector/jira_epic_selector.test.tsx
+++ b/webapp/src/components/jira_epic_selector/jira_epic_selector.test.tsx
@@ -72,7 +72,7 @@ describe('components/JiraEpicSelector', () => {
         args = props.fetchEpicsWithParams.mock.calls[2][0];
         expect(args).toEqual({
             epic_name_type_id: 'customfield_10011',
-            jql: 'project=KT and issuetype=10000  and "Epic Name"~"some input"  ORDER BY updated DESC',
+            jql: 'project=KT and issuetype=10000  and ("Epic Name"~"some input" or "Epic Name"~"some input*") ORDER BY updated DESC',
             q: 'some input',
         });
     });

--- a/webapp/src/components/jira_epic_selector/jira_epic_selector.tsx
+++ b/webapp/src/components/jira_epic_selector/jira_epic_selector.tsx
@@ -104,7 +104,7 @@ export default class JiraEpicSelector extends React.PureComponent<Props, State> 
         let searchStr = '';
         if (userInput) {
             const cleanedInput = userInput.trim().replace(/"/g, '\\"');
-            searchStr = ` and "${epicNameTypeName}"~"${cleanedInput}" `;
+            searchStr = ` and ("${epicNameTypeName}"~"${cleanedInput}" or "${epicNameTypeName}"~"${cleanedInput}*")`;
         }
 
         return this.fetchEpicsFromJql(searchStr, userInput);


### PR DESCRIPTION
#### Summary

This PR improves the search for Epics by using `*` in an additional clause.

`... and "Epic Name"~"{searchTerm}"`

becomes

`... and ("Epic Name” ~ “{searchTerm}” or “Epic Name” ~ “{searchTerm}*”)`

When not using the clause with `*`, searches with just a few characters do not find many results. Using two clauses together:
- `~` makes it so the fuzzy search for several words works
- `~...*` makes it so exact prefix matching works

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20013