### PR TITLE
[MM-19689] Improve `/jira subscribe list` UX

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -269,7 +269,7 @@ func executeSubscribeList(p *Plugin, c *plugin.Context, header *model.CommandArg
 		return p.responsef(header, "`/jira subscribe list` can only be run by a system administrator.")
 	}
 
-	msg, err := p.listChannelSubscriptions()
+	msg, err := p.listChannelSubscriptions(header.TeamId)
 	if err != nil {
 		return p.responsef(header, "%v", err)
 	}

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -53,6 +53,11 @@ type ChannelSubscriptions struct {
 	IdByEvent     map[string]StringSet           `json:"id_by_event"`
 }
 
+type TeamSubscriptions struct {
+	TeamId string
+	SubIds []string
+}
+
 func NewChannelSubscriptions() *ChannelSubscriptions {
 	return &ChannelSubscriptions{
 		ById:          map[string]ChannelSubscription{},
@@ -360,22 +365,95 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 		return "", err
 	}
 
+	teamDMGMSubs, err := p.getSubscriptionsOrderedByTeamDMandGM()
+	if err != nil {
+		return "", err
+	}
+
 	rows := []string{}
-	for channelID, subIDs := range subs.Channel.IdByChannelId {
-		channel, appErr := p.API.GetChannel(channelID)
-		if appErr != nil {
-			return "", errors.New("Failed to get channel")
+	printDMGMHeader := true
+
+	for _, teamSubs := range teamDMGMSubs {
+
+		// create team header for channels.  Only print header for DMs and GMs channels once.
+		if teamSubs.TeamId != "" {
+			channelTeam, appErr := p.API.GetTeam(teamSubs.TeamId)
+			if appErr != nil {
+				return "", appErr
+			}
+			rows = append(rows, fmt.Sprintf("\n### %s", channelTeam.DisplayName))
+		} else {
+			if printDMGMHeader {
+				rows = append(rows, fmt.Sprintf("\n### %s", "Group and Direct Messages"))
+				printDMGMHeader = false
+			}
 		}
 
-		rows = append(rows, fmt.Sprintf("~%s (%d):", channel.Name, len(subIDs)))
+		var printChannelName = true
+		for _, subId := range teamSubs.SubIds {
+			sub := subs.Channel.ById[subId]
 
-		for subID := range subIDs {
-			sub := subs.Channel.ById[subID]
-			rows = append(rows, fmt.Sprintf("* %s - %s", sub.Filters.Projects.Elems()[0], sub.Name))
+			channel, appErr := p.API.GetChannel(sub.ChannelId)
+			if appErr != nil {
+				return "", errors.New("Failed to get channel")
+			}
+
+			// only print channel name once for all subscriptions
+			if printChannelName {
+				rows = append(rows, fmt.Sprintf("* **~%s** (%d):", channel.Name, len(teamSubs.SubIds)))
+				printChannelName = false
+			}
+
+			subName := "(No Name)"
+			if sub.Name != "" {
+				subName = sub.Name
+			}
+			rows = append(rows, fmt.Sprintf("  * %s - %s", sub.Filters.Projects.Elems()[0], subName))
 		}
 	}
 
 	return strings.Join(rows, "\n"), nil
+}
+
+func (p *Plugin) getSubscriptionsOrderedByTeamDMandGM() ([]TeamSubscriptions, error) {
+	subs, err := p.getSubscriptions()
+	if err != nil {
+		return nil, err
+	}
+
+	var teamSubs []TeamSubscriptions
+	var dmgmSubs []TeamSubscriptions
+
+	// get teams from subscriptions
+	for channelID, subIDs := range subs.Channel.IdByChannelId {
+
+		// channel does not have any subIDs.
+		if len(subIDs) == 0 {
+			continue
+		}
+
+		channel, appErr := p.API.GetChannel(channelID)
+		if appErr != nil {
+			return nil, errors.New("Failed to get channel")
+		}
+
+		var teamData TeamSubscriptions
+
+		for subID := range subIDs {
+			teamData.SubIds = append(teamData.SubIds, subID)
+		}
+		teamData.TeamId = channel.TeamId
+
+		if !channel.IsGroupOrDirect() {
+			teamSubs = append(teamSubs, teamData)
+		} else {
+			dmgmSubs = append(dmgmSubs, teamData)
+		}
+	}
+
+	var teamDMGMSubs []TeamSubscriptions
+	teamDMGMSubs = append(teamSubs, dmgmSubs...)
+	return teamDMGMSubs, nil
 }
 
 func inAllowedGroup(inGroups []*jira.UserGroup, allowedGroups []string) bool {

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -377,11 +377,11 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 
 		// create team header for channels.  Only print header for DMs and GMs channels once.
 		if teamSubs.TeamId != "" {
-			channelTeam, appErr := p.API.GetTeam(teamSubs.TeamId)
+			team, appErr := p.API.GetTeam(teamSubs.TeamId)
 			if appErr != nil {
 				return "", appErr
 			}
-			rows = append(rows, fmt.Sprintf("\n### %s", channelTeam.DisplayName))
+			rows = append(rows, fmt.Sprintf("\n### %s", team.DisplayName))
 		} else {
 			if printDMGMHeader {
 				rows = append(rows, fmt.Sprintf("\n### %s", "Group and Direct Messages"))

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -378,7 +378,7 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 		rows = append(rows, fmt.Sprintf("There are currently no channels subcriptions to Jira notifications. To add a subscription, navigate to a channel and type `/jira subscribe`\n"))
 		return strings.Join(rows, "\n"), nil
 	}
-	rows = append(rows, fmt.Sprintf("The following channels have subcribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`"))
+	rows = append(rows, fmt.Sprintf("The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`"))
 
 	for _, teamSubs := range sortedSubs {
 

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -366,7 +366,7 @@ type SubsGroupedByChannel struct {
 	SubIds    []string
 }
 
-func (p *Plugin) listChannelSubscriptions() (string, error) {
+func (p *Plugin) listChannelSubscriptions(teamId string) (string, error) {
 	subs, err := p.getSubscriptions()
 	if err != nil {
 		return "", err
@@ -398,7 +398,12 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 			}
 
 			// only print channel name once for all subscriptions
-			rows = append(rows, fmt.Sprintf("* **~%s** (%d):", channel.Name, len(grouped.SubIds)))
+			channelPrint := fmt.Sprintf("* **%s** (%d):", channel.Name, len(grouped.SubIds))
+			if teamId == teamSubs.TeamId {
+				// only link the channels on the current team
+				channelPrint = fmt.Sprintf("* **~%s** (%d):", channel.Name, len(grouped.SubIds))
+			}
+			rows = append(rows, channelPrint)
 
 			for _, subId := range grouped.SubIds {
 				sub := subs.Channel.ById[subId]

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -367,7 +367,7 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 		return "", err
 	}
 
-	sortedSubs, err := p.getSubscriptionsSorted()
+	sortedSubs, err := p.getSortedSubscriptions()
 	if err != nil {
 		return "", err
 	}
@@ -415,7 +415,7 @@ func (p *Plugin) listChannelSubscriptions() (string, error) {
 	return strings.Join(rows, "\n"), nil
 }
 
-func (p *Plugin) getSubscriptionsSorted() ([]TeamSubscriptions, error) {
+func (p *Plugin) getSortedSubscriptions() ([]TeamSubscriptions, error) {
 	subs, err := p.getSubscriptions()
 	if err != nil {
 		return nil, err

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -398,12 +398,12 @@ func (p *Plugin) listChannelSubscriptions(teamId string) (string, error) {
 			}
 
 			// only print channel name once for all subscriptions
-			channelPrint := fmt.Sprintf("* **%s** (%d):", channel.Name, len(grouped.SubIds))
+			channelRow := fmt.Sprintf("* **%s** (%d):", channel.Name, len(grouped.SubIds))
 			if teamId == teamSubs.TeamId {
 				// only link the channels on the current team
-				channelPrint = fmt.Sprintf("* **~%s** (%d):", channel.Name, len(grouped.SubIds))
+				channelRow = fmt.Sprintf("* **~%s** (%d):", channel.Name, len(grouped.SubIds))
 			}
-			rows = append(rows, channelPrint)
+			rows = append(rows, channelRow)
 
 			for _, subId := range grouped.SubIds {
 				sub := subs.Channel.ById[subId]

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -149,17 +149,9 @@ func TestListChannelSubscriptions(t *testing.T) {
 				ChannelSubscription{
 					Id:        "SubID1a",
 					ChannelId: "channel1",
-					Name:      "Sub Name 1a",
+					Name:      "Sub Name 1",
 					Filters: SubscriptionFilters{
 						Projects: NewStringSet("PROJ"),
-					},
-				},
-				ChannelSubscription{
-					Id:        "SubID1b",
-					ChannelId: "channel1",
-					Name:      "Sub Name 1b",
-					Filters: SubscriptionFilters{
-						Projects: NewStringSet("EXT"),
 					},
 				},
 				ChannelSubscription{
@@ -190,7 +182,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 			RunAssertions: func(t *testing.T, actual string) {
 				expected := "The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n"
 				expected += "#### Team 1 Display Name\n"
-				expected += "* **~channel-1-name** (2):\n  * PROJ - Sub Name 1a\n  * EXT - Sub Name 1b\n\n"
+				expected += "* **~channel-1-name** (1):\n  * PROJ - Sub Name 1\n\n"
 				expected += "#### Team 2 Display Name\n"
 				expected += "* **~channel-3-name** (1):\n  * EXT - Sub Name 3\n"
 				expected += "* **~channel-4** (1):\n  * EXT - Sub Name 4\n\n"

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -40,7 +40,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				},
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
-				expected := "The following channels have subcribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Team 1 Display Name\n* **~channel-1-name** (1):\n  * PROJ - Sub Name X"
+				expected := "The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Team 1 Display Name\n* **~channel-1-name** (1):\n  * PROJ - Sub Name X"
 				assert.Equal(t, expected, actual)
 			},
 		},
@@ -63,7 +63,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				},
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
-				expected := "The following channels have subcribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Group and Direct Messages\n* **~channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
+				expected := "The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Group and Direct Messages\n* **~channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
 				assert.Equal(t, expected, actual)
 			},
 		},

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -40,7 +40,14 @@ func TestListChannelSubscriptions(t *testing.T) {
 				},
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
-				expected := "\n### Team 1 Display Name\n* **~channel-1-name** (1):\n  * PROJ - Sub Name X"
+				expected := "The following channels have subcribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Team 1 Display Name\n* **~channel-1-name** (1):\n  * PROJ - Sub Name X"
+				assert.Equal(t, expected, actual)
+			},
+		},
+		"zero subscriptions": {
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{}),
+			RunAssertions: func(t *testing.T, actual string) {
+				expected := "There are currently no channels subcriptions to Jira notifications. To add a subscription, navigate to a channel and type `/jira subscribe`\n"
 				assert.Equal(t, expected, actual)
 			},
 		},
@@ -56,7 +63,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				},
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
-				expected := "\n### Group and Direct Messages\n* **~channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
+				expected := "The following channels have subcribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Group and Direct Messages\n* **~channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
 				assert.Equal(t, expected, actual)
 			},
 		},
@@ -88,9 +95,9 @@ func TestListChannelSubscriptions(t *testing.T) {
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
 				numlines := strings.Count(actual, "\n") + 1
-				assert.Equal(t, 6, numlines)
-				assert.NotContains(t, actual, "\n### Group and Direct Messages")
-				assert.Contains(t, actual, "\n### Team 1 Display Name")
+				assert.Equal(t, 7, numlines)
+				assert.NotContains(t, actual, "\n#### Group and Direct Messages")
+				assert.Contains(t, actual, "\n#### Team 1 Display Name")
 				assert.Contains(t, actual, `**~channel-1-name** (3):`)
 				assert.Contains(t, actual, `* PROJ - Sub Name X`)
 				assert.Contains(t, actual, `* EXT - Sub Name Y`)
@@ -126,9 +133,9 @@ func TestListChannelSubscriptions(t *testing.T) {
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
 				numlines := strings.Count(actual, "\n") + 1
-				assert.Equal(t, 9, numlines)
-				assert.Contains(t, actual, "\n### Group and Direct Messages")
-				assert.Contains(t, actual, "\n### Team 1 Display Name")
+				assert.Equal(t, 10, numlines)
+				assert.Contains(t, actual, "\n#### Group and Direct Messages")
+				assert.Contains(t, actual, "\n#### Team 1 Display Name")
 				assert.Contains(t, actual, `Group and Direct Messages`)
 				assert.Contains(t, actual, `**~channel-1-name** (2):`)
 				assert.Contains(t, actual, `* PROJ - Sub Name X`)
@@ -165,6 +172,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				Id:          "channel2",
 				Name:        "channel-2-name-DM",
 				DisplayName: "Channel 2 Display Name",
+				Type:        "D",
 			}
 
 			api.On("GetChannel", "channel2").Return(channel2, nil)

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -63,7 +63,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				},
 			}),
 			RunAssertions: func(t *testing.T, actual string) {
-				expected := "The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Group and Direct Messages\n* **~channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
+				expected := "The following channels have subscribed to Jira notifications. To modify a subscription, navigate to the channel and type `/jira subscribe`\n\n#### Group and Direct Messages\n* **channel-2-name-DM** (1):\n  * PROJ - Sub Name X"
 				assert.Equal(t, expected, actual)
 			},
 		},
@@ -140,7 +140,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				assert.Contains(t, actual, `**~channel-1-name** (2):`)
 				assert.Contains(t, actual, `* PROJ - Sub Name X`)
 				assert.Contains(t, actual, `* EXT - Sub Name Y`)
-				assert.Contains(t, actual, `**~channel-2-name-DM** (1):`)
+				assert.Contains(t, actual, `**channel-2-name-DM** (1):`)
 				assert.Contains(t, actual, `* EXT - Sub Name Z`)
 			},
 		},
@@ -184,10 +184,10 @@ func TestListChannelSubscriptions(t *testing.T) {
 				expected += "#### Team 1 Display Name\n"
 				expected += "* **~channel-1-name** (1):\n  * PROJ - Sub Name 1\n\n"
 				expected += "#### Team 2 Display Name\n"
-				expected += "* **~channel-3-name** (1):\n  * EXT - Sub Name 3\n"
-				expected += "* **~channel-4** (1):\n  * EXT - Sub Name 4\n\n"
+				expected += "* **channel-3-name** (1):\n  * EXT - Sub Name 3\n"
+				expected += "* **channel-4** (1):\n  * EXT - Sub Name 4\n\n"
 				expected += "#### Group and Direct Messages\n"
-				expected += "* **~channel-2-name-DM** (1):\n  * EXT - Sub Name 2"
+				expected += "* **channel-2-name-DM** (1):\n  * EXT - Sub Name 2"
 				assert.Equal(t, expected, actual)
 			},
 		},
@@ -259,7 +259,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 				return true
 			})).Return(nil)
 
-			actual, err := p.listChannelSubscriptions()
+			actual, err := p.listChannelSubscriptions(team1.Id)
 			assert.Nil(t, err)
 			assert.NotNil(t, actual)
 

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -147,7 +147,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 		"two teams with two channels with multiple subscriptions": {
 			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
 				ChannelSubscription{
-					Id:        model.NewId(),
+					Id:        "SubID1a",
 					ChannelId: "channel1",
 					Name:      "Sub Name 1a",
 					Filters: SubscriptionFilters{
@@ -155,7 +155,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 					},
 				},
 				ChannelSubscription{
-					Id:        model.NewId(),
+					Id:        "SubID1b",
 					ChannelId: "channel1",
 					Name:      "Sub Name 1b",
 					Filters: SubscriptionFilters{
@@ -163,7 +163,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 					},
 				},
 				ChannelSubscription{
-					Id:        model.NewId(),
+					Id:        "SubID2",
 					ChannelId: "channel2",
 					Name:      "Sub Name 2",
 					Filters: SubscriptionFilters{
@@ -171,7 +171,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 					},
 				},
 				ChannelSubscription{
-					Id:        model.NewId(),
+					Id:        "SubID3",
 					ChannelId: "channel3",
 					Name:      "Sub Name 3",
 					Filters: SubscriptionFilters{
@@ -179,7 +179,7 @@ func TestListChannelSubscriptions(t *testing.T) {
 					},
 				},
 				ChannelSubscription{
-					Id:        model.NewId(),
+					Id:        "SubID4",
 					ChannelId: "channel4",
 					Name:      "Sub Name 4",
 					Filters: SubscriptionFilters{


### PR DESCRIPTION
## Summary

This PR improves the output of the `/jira subscribe list` command output by grouping channel subscriptions by team.  For DM and GM channels, post the hashes under the Generic Headline "Group and Direct Messages".

The following is directly from the commit logs, but is a comprehensive list of the changes made and testing needed for QA.

Group channels by Team Name
Include Group and Direct Message channels exposing hashes for channel names

Add tests for the following:
- team and DM/GM channels subscriptions
- team only channel subscriptions
- DM/GM only channel subscriptions
- Team Heading level and bold of channel names
- Subscription that was not previously saved with a name
- Zero subscriptions on any channels
- Team names are sorted alphabetically

## Ticket 
https://mattermost.atlassian.net/browse/MM-19689

## Screenshots
![image](https://user-images.githubusercontent.com/7575921/69033867-8a229f00-09a5-11ea-8833-21dba93385b4.png)
