### PR TITLE
[MM-19928] Change permissions error wording

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -41,7 +41,7 @@ export default class ChannelSettingsModal extends PureComponent<Props> {
             if (this.props.channelSubscriptions instanceof Error) {
                 inner = (
                     <Modal.Body>
-                        {'You do not have permission to edit the subscriptions for this channel. Configuring a Jira subscription will create notifications in this channel when certain events happen in Jira, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'}
+                        {'You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.'}
                     </Modal.Body>
                 );
             } else {


### PR DESCRIPTION
#### Summary

This PR changes the channel subscription permissions error to:
> You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.

This change was requested here https://github.com/mattermost/mattermost-plugin-jira/pull/372#pullrequestreview-310639140

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19928

#### Screenshots

![image](https://user-images.githubusercontent.com/6913320/68715999-395c1200-0571-11ea-88d5-77ac7958afbd.png)
