### PR TITLE
MM-20185 - Make subscription filter values not clearable

### DIFF
--- a/webapp/src/components/jira_epic_selector/__snapshots__/jira_epic_selector.test.tsx.snap
+++ b/webapp/src/components/jira_epic_selector/__snapshots__/jira_epic_selector.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`components/JiraEpicSelector should match snapshot 1`] = `
       }
     }
     filterOption={null}
-    isClearable={true}
     isMulti={true}
     loadOptions={[Function]}
     menuPlacement="auto"

--- a/webapp/src/components/jira_epic_selector/jira_epic_selector.tsx
+++ b/webapp/src/components/jira_epic_selector/jira_epic_selector.tsx
@@ -216,7 +216,6 @@ export default class JiraEpicSelector extends React.PureComponent<Props, State> 
                 onChange={this.onChange}
                 required={this.props.required}
                 isMulti={this.props.isMulti}
-                isClearable={true}
                 defaultOptions={true}
                 loadOptions={this.handleIssueSearchTermChange}
                 menuPortalTarget={document.body}

--- a/webapp/src/components/modals/channel_settings/channel_settings_filter.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_filter.tsx
@@ -230,6 +230,7 @@ export default class ChannelSettingsFilter extends React.PureComponent<Props, St
                 <JiraEpicSelector
                     required={!disableLastSelect}
                     isDisabled={disableLastSelect}
+                    isClearable={false}
                     placeholder={lastSelectPlaceholder}
                     issueMetadata={this.props.issueMetadata}
                     theme={theme}
@@ -248,6 +249,7 @@ export default class ChannelSettingsFilter extends React.PureComponent<Props, St
                     name={'values'}
                     required={!disableLastSelect}
                     isDisabled={disableLastSelect}
+                    isClearable={false}
                     placeholder={lastSelectPlaceholder}
                     hideRequiredStar={true}
                     options={fieldValueOptions}


### PR DESCRIPTION
#### Summary

This PR removes the X that is used to clear all of the values in a given filter's select dropdown. Now you cannot accidentally remove the values all at once.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20185

#### Screenshots

Before
![image](https://user-images.githubusercontent.com/6913320/69083664-909a3080-0a10-11ea-912b-4ce24d35d027.png)

After
![image](https://user-images.githubusercontent.com/6913320/69083132-7b70d200-0a0f-11ea-9ced-10cd770bbc17.png)

