### PR TITLE
[GH-168] Bold action verb in webhook notification pretext

### DIFF
--- a/server/testdata/webhook-issue-updated-reopened-one-changelog.json
+++ b/server/testdata/webhook-issue-updated-reopened-one-changelog.json
@@ -1,0 +1,202 @@
+{
+  "timestamp": 1550287026531,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_generic",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10027": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": "2019-02-15T19:07:41.418-0800",
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": null,
+      "customfield_10021": null,
+      "customfield_10022": "0|i0000r:r",
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10023": null,
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10026": null,
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "aggregatetimeoriginalestimate": null,
+      "timeestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:17:06.501-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "To Do",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "New"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long, a little longer now",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "customfield_10015": null,
+      "timetracking": {},
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "security": null,
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "aggregatetimeestimate": null,
+      "customfield_10009": null,
+      "attachment": [],
+      "summary": "Unit test summary 1",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "customfield_10000": "{}",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10229",
+    "items": [
+      {
+        "field": "resolution",
+        "fieldtype": "jira",
+        "fieldId": "resolution",
+        "from": "10000",
+        "fromString": "Done",
+        "to": null,
+        "toString": null
+      }
+    ]
+  }
+}

--- a/server/testdata/webhook-issue-updated-resolved-one-changelog.json
+++ b/server/testdata/webhook-issue-updated-resolved-one-changelog.json
@@ -1,0 +1,207 @@
+{
+  "timestamp": 1550286940507,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_generic",
+  "user": {
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+    "name": "admin",
+    "key": "admin",
+    "accountId": "5c5f880629be9642ba529340",
+    "emailAddress": "some-instance-test@gmail.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+      "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+      "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+      "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Los_Angeles"
+  },
+  "issue": {
+    "id": "10040",
+    "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10040",
+    "key": "TES-41",
+    "fields": {
+      "issuetype": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Stories track functionality or features expressed as user goals.",
+        "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "customfield_10030": null,
+      "project": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TES",
+        "name": "test1",
+        "projectTypeKey": "software",
+        "avatarUrls": {
+          "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/resolution/10000",
+        "id": "10000",
+        "description": "Work has been completed on this issue.",
+        "name": "Done"
+      },
+      "customfield_10027": null,
+      "resolutiondate": "2019-02-15T19:15:40.470-0800",
+      "workratio": -1,
+      "watches": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "lastViewed": "2019-02-15T19:07:41.418-0800",
+      "created": "2019-02-15T19:01:52.971-0800",
+      "customfield_10020": "3_*:*_1_*:*_78475_*|*_10002_*:*_1_*:*_0_*|*_10001_*:*_1_*:*_749036",
+      "customfield_10021": null,
+      "customfield_10022": "0|i0000r:r",
+      "priority": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+        "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+        "name": "High",
+        "id": "2"
+      },
+      "customfield_10023": null,
+      "customfield_10024": [],
+      "customfield_10025": null,
+      "customfield_10026": null,
+      "labels": [
+        "test-label"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": {
+        "hasEpicLinkFieldDependency": false,
+        "showField": false,
+        "nonEditableReason": {
+          "reason": "PLUGIN_LICENSE_ERROR",
+          "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+        }
+      },
+      "customfield_10019": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": null,
+      "updated": "2019-02-15T19:15:40.477-0800",
+      "status": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10002",
+        "description": "",
+        "iconUrl": "https://some-instance-test.atlassian.net/",
+        "name": "Done",
+        "id": "10002",
+        "statusCategory": {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/3",
+          "id": 3,
+          "key": "done",
+          "colorName": "green",
+          "name": "Complete"
+        }
+      },
+      "components": [
+        {
+          "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+          "id": "10000",
+          "name": "COMP-1",
+          "description": "Component-1"
+        }
+      ],
+      "timeoriginalestimate": null,
+      "description": "Unit test description, not that long, a little longer now",
+      "customfield_10010": null,
+      "customfield_10014": null,
+      "timetracking": {},
+      "customfield_10015": null,
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "security": null,
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "aggregatetimeestimate": null,
+      "attachment": [],
+      "customfield_10009": null,
+      "summary": "Unit test summary 1",
+      "creator": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5c5f880629be9642ba529340",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c5f880629be9642ba529340",
+        "emailAddress": "some-instance-test@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+          "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+          "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+          "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Los_Angeles"
+      },
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10000": "{}",
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "votes": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-41/votes",
+        "votes": 0,
+        "hasVoted": false
+      }
+    }
+  },
+  "changelog": {
+    "id": "10228",
+    "items": [
+      {
+        "field": "resolution",
+        "fieldtype": "jira",
+        "fieldId": "resolution",
+        "from": null,
+        "fromString": null,
+        "to": "10000",
+        "toString": "Done"
+      }
+    ]
+  }
+}

--- a/server/testdata/webhook-server-issue-updated-commented-3.json
+++ b/server/testdata/webhook-server-issue-updated-commented-3.json
@@ -1,0 +1,344 @@
+{
+  "timestamp": 1561757536066,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_commented",
+  "user": {
+    "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+    "name": "TestUser",
+    "key": "testUser",
+    "emailAddress": "test.user@test.com",
+    "avatarUrls": {
+      "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+      "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+      "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+      "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "Etc/UTC"
+  },
+  "issue": {
+    "id": "10231",
+    "self": "http://test-server.azure.com:8080/rest/api/2/issue/10231",
+    "key": "PRJA-42",
+    "fields": {
+      "issuetype": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/issuetype/10005",
+        "id": "10005",
+        "description": "An improvement or enhancement to an existing feature or task.",
+        "iconUrl": "http://test-server.azure.com:8080/secure/viewavatar?size=xsmall&avatarId=10310&avatarType=issuetype",
+        "name": "Improvement",
+        "subtask": false,
+        "avatarId": 10310
+      },
+      "timespent": null,
+      "project": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/project/10002",
+        "id": "10002",
+        "key": "PRJA",
+        "name": "ProjectA",
+        "avatarUrls": {
+          "48x48": "http://test-server.azure.com:8080/secure/projectavatar?avatarId=10324",
+          "24x24": "http://test-server.azure.com:8080/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "http://test-server.azure.com:8080/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "http://test-server.azure.com:8080/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "customfield_10110": null,
+      "customfield_10111": null,
+      "aggregatetimespent": null,
+      "resolution": null,
+      "customfield_10112": null,
+      "customfield_10114": "0|i000rr:",
+      "customfield_10104": null,
+      "customfield_10105": "0|i001ef:",
+      "customfield_10107": null,
+      "customfield_10108": null,
+      "customfield_10109": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": "2019-06-28T21:31:59.605+0000",
+      "watches": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/issue/PRJA-42/watchers",
+        "watchCount": 2,
+        "isWatching": true
+      },
+      "created": "2019-06-28T21:16:13.654+0000",
+      "priority": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/priority/3",
+        "iconUrl": "http://test-server.azure.com:8080/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "customfield_10100": null,
+      "labels": [],
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/user?username=dylan",
+        "name": "dylan",
+        "key": "dylan",
+        "emailAddress": "dylan@mattermost.com",
+        "avatarUrls": {
+          "48x48": "http://test-server.azure.com:8080/secure/useravatar?avatarId=10339",
+          "24x24": "http://test-server.azure.com:8080/secure/useravatar?size=small&avatarId=10339",
+          "16x16": "http://test-server.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10339",
+          "32x32": "http://test-server.azure.com:8080/secure/useravatar?size=medium&avatarId=10339"
+        },
+        "displayName": "Dylan H",
+        "active": true,
+        "timeZone": "Etc/UTC"
+      },
+      "updated": "2019-06-28T21:31:58.040+0000",
+      "status": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "http://test-server.azure.com:8080/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "http://test-server.azure.com:8080/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      "components": [],
+      "timeoriginalestimate": null,
+      "description": "test\n\n_Issue created from a [message in Mattermost|https://chrisp.ngrok.io/testteam/pl/449w553cajrbfewz581uoxmb8o]_.",
+      "customfield_10130": null,
+      "customfield_10131": null,
+      "customfield_10132": null,
+      "timetracking": {},
+      "customfield_10126": null,
+      "customfield_10127": null,
+      "customfield_10128": null,
+      "customfield_10129": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "summary": "test for notifications",
+      "creator": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/user?username=creator.user",
+        "name": "creator.user",
+        "key": "creator.user",
+        "emailAddress": "creator.user@mattermost.com",
+        "avatarUrls": {
+          "48x48": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=48",
+          "24x24": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=24",
+          "16x16": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=16",
+          "32x32": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=32"
+        },
+        "displayName": "Creator User",
+        "active": true,
+        "timeZone": "America/Toronto"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/user?username=creator.user",
+        "name": "creator.user",
+        "key": "creator.user",
+        "emailAddress": "creator.user@mattermost.com",
+        "avatarUrls": {
+          "48x48": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=48",
+          "24x24": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=24",
+          "16x16": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=16",
+          "32x32": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=32"
+        },
+        "displayName": "Creator User",
+        "active": true,
+        "timeZone": "America/Toronto"
+      },
+      "customfield_10120": null,
+      "customfield_10121": null,
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10122": null,
+      "customfield_10123": null,
+      "customfield_10124": null,
+      "customfield_10125": null,
+      "customfield_10115": null,
+      "customfield_10116": null,
+      "environment": null,
+      "customfield_10117": "false",
+      "customfield_10118": null,
+      "customfield_10119": "false",
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "http://test-server.azure.com:8080/rest/api/2/issue/10231/comment/10116",
+            "id": "10116",
+            "author": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+              "name": "TestUser",
+              "key": "testUser",
+              "emailAddress": "test.user@test.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+              },
+              "displayName": "Test User",
+              "active": true,
+              "timeZone": "Etc/UTC"
+            },
+            "body": "test comment",
+            "updateAuthor": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+              "name": "TestUser",
+              "key": "testUser",
+              "emailAddress": "test.user@test.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+              },
+              "displayName": "Test User",
+              "active": true,
+              "timeZone": "Etc/UTC"
+            },
+            "created": "2019-06-28T21:20:34.131+0000",
+            "updated": "2019-06-28T21:20:34.131+0000"
+          },
+          {
+            "self": "http://test-server.azure.com:8080/rest/api/2/issue/10231/comment/10117",
+            "id": "10117",
+            "author": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=creator.user",
+              "name": "creator.user",
+              "key": "creator.user",
+              "emailAddress": "creator.user@mattermost.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=32"
+              },
+              "displayName": "Creator User",
+              "active": true,
+              "timeZone": "America/Toronto"
+            },
+            "body": "another test comment",
+            "updateAuthor": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=creator.user",
+              "name": "creator.user",
+              "key": "creator.user",
+              "emailAddress": "creator.user@mattermost.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/560996af2549a4e1727321247bbd4af9?d=mm&s=32"
+              },
+              "displayName": "Creator User",
+              "active": true,
+              "timeZone": "America/Toronto"
+            },
+            "created": "2019-06-28T21:26:42.288+0000",
+            "updated": "2019-06-28T21:26:42.288+0000"
+          },
+          {
+            "self": "http://test-server.azure.com:8080/rest/api/2/issue/10231/comment/10118",
+            "id": "10118",
+            "author": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+              "name": "TestUser",
+              "key": "testUser",
+              "emailAddress": "test.user@test.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+              },
+              "displayName": "Test User",
+              "active": true,
+              "timeZone": "Etc/UTC"
+            },
+            "body": "This is a test comment. We should act on it right away.",
+            "updateAuthor": {
+              "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+              "name": "TestUser",
+              "key": "testUser",
+              "emailAddress": "test.user@test.com",
+              "avatarUrls": {
+                "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+                "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+                "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+                "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+              },
+              "displayName": "Test User",
+              "active": true,
+              "timeZone": "Etc/UTC"
+            },
+            "created": "2019-06-28T21:32:16.057+0000",
+            "updated": "2019-06-28T21:32:16.057+0000"
+          }
+        ],
+        "maxResults": 3,
+        "total": 3,
+        "startAt": 0
+      },
+      "votes": {
+        "self": "http://test-server.azure.com:8080/rest/api/2/issue/PRJA-42/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      }
+    }
+  },
+  "comment": {
+    "self": "http://test-server.azure.com:8080/rest/api/2/issue/10231/comment/10118",
+    "id": "10118",
+    "author": {
+      "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+      "name": "TestUser",
+      "key": "testUser",
+      "emailAddress": "test.user@test.com",
+      "avatarUrls": {
+        "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+        "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+        "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+        "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+      },
+      "displayName": "Test User",
+      "active": true,
+      "timeZone": "Etc/UTC"
+    },
+    "body": "This is a test comment. We should act on it right away. cc: [~SomeOtherUser]",
+    "updateAuthor": {
+      "self": "http://test-server.azure.com:8080/rest/api/2/user?username=TestUser",
+      "name": "TestUser",
+      "key": "testUser",
+      "emailAddress": "test.user@test.com",
+      "avatarUrls": {
+        "48x48": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=48",
+        "24x24": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=24",
+        "16x16": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=16",
+        "32x32": "https://www.gravatar.com/avatar/517d2249c162fc5e14141d32c9088b31?d=mm&s=32"
+      },
+      "displayName": "Test User",
+      "active": true,
+      "timeZone": "Etc/UTC"
+    },
+    "created": "2019-06-28T21:32:16.057+0000",
+    "updated": "2019-06-28T21:32:16.057+0000"
+  }
+}

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -117,20 +117,20 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue edited": {
 			Request:                 testWebhookRequest("webhook-issue-updated-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User edited the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **edited** the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long, a little longer now",
 			CurrentInstance:         true,
 		},
 		"SERVER (old version) issue edited (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User edited the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **edited** the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long, a little longer now",
 			CurrentInstance:         true,
 		},
 		"issue renamed": {
 			Request:          testWebhookRequest("webhook-issue-updated-renamed.json"),
-			ExpectedHeadline: "Test User updated summary from \"Unit test summary\" to \"Unit test summary 1\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** summary from \"Unit test summary\" to \"Unit test summary 1\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:     "",
 			CurrentInstance:  true,
 		},
@@ -156,32 +156,32 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue attachments": {
 			Request:          testWebhookRequest("webhook-issue-updated-attachments.json"),
-			ExpectedHeadline: "Test User attached [test.gif] to, removed attachments [test.json] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **attached** [test.gif] to, **removed** attachments [test.json] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue fix version": {
 			Request:          testWebhookRequest("webhook-issue-updated-fix-version.json"),
-			ExpectedHeadline: `Test User updated Fix Version from "v1" to "v2" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** Fix Version from "v1" to "v2" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  true,
 		},
 		"issue issue type": {
 			Request:          testWebhookRequest("webhook-issue-updated-issue-type.json"),
-			ExpectedHeadline: `Test User updated issuetype from "Task" to "Bug" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** issuetype from "Task" to "Bug" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  true,
 		},
 		"issue labels": {
 			Request:          testWebhookRequest("webhook-issue-updated-labels.json"),
-			ExpectedHeadline: "Test User added labels [sad] to, removed labels [bad] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **added** labels [sad] to, **removed** labels [bad] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue lowered priority": {
 			Request:          testWebhookRequest("webhook-issue-updated-lowered-priority.json"),
-			ExpectedHeadline: `Test User updated priority from "High" to "Low" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** priority from "High" to "Low" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  true,
 		},
 		"issue multiple values": {
 			Request:                 testWebhookRequest("webhook-issue-updated-multiple-values.json"),
-			ExpectedHeadline:        `Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline:        `Test User **updated** story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			ExpectedSlackAttachment: true,
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
@@ -204,18 +204,18 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue raised priority": {
 			Request:          testWebhookRequest("webhook-issue-updated-raised-priority.json"),
-			ExpectedHeadline: `Test User updated priority from "Low" to "High" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** priority from "Low" to "High" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  true,
 		},
 		"issue rank": {
 			Request:          testWebhookRequest("webhook-issue-updated-rank.json"),
-			ExpectedHeadline: "Test User updated Rank from \"~~none~~\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** Rank from \"~~none~~\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue reopened": {
 			Request:                 testWebhookRequest("webhook-issue-updated-reopened.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **updated** story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -233,7 +233,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue resolved": {
 			Request:                 testWebhookRequest("webhook-issue-updated-resolved.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **updated** story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -251,7 +251,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"SERVER issue resolved": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-resolved.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedHeadline:        "Test User **updated** bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -269,7 +269,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"SERVER issue reopened": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-reopened.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedHeadline:        "Test User **updated** bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -286,22 +286,22 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"SERVER issue in progress": {
 			Request:          testWebhookRequest("webhook-server-issue-updated-in-progress.json"),
-			ExpectedHeadline: "Test User updated status from \"Reopened\" to \"In Progress\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedHeadline: "Test User **updated** status from \"Reopened\" to \"In Progress\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
 		},
 		"SERVER issue closed": {
 			Request:          testWebhookRequest("webhook-server-issue-updated-closed.json"),
-			ExpectedHeadline: "Test User updated status from \"Resolved\" to \"Closed\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
+			ExpectedHeadline: "Test User **updated** status from \"Resolved\" to \"Closed\" on bug [TES-4: Unit test summary 1](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/TES-4)",
 
 			CurrentInstance: true,
 		},
 		"issue sprint": {
 			Request:          testWebhookRequest("webhook-issue-updated-sprint.json"),
-			ExpectedHeadline: "Test User updated Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue started working": {
 			Request:          testWebhookRequest("webhook-issue-updated-started-working.json"),
-			ExpectedHeadline: "Test User updated status from \"To Do\" to \"In Progress\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** status from \"To Do\" to \"In Progress\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"CLOUD comment created": {
@@ -433,13 +433,13 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue edited - no Instance": {
 			Request:                 testWebhookRequest("webhook-issue-updated-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User edited the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **edited** the description of story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long, a little longer now",
 			CurrentInstance:         false,
 		},
 		"issue renamed - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-renamed.json"),
-			ExpectedHeadline: "Test User updated summary from \"Unit test summary\" to \"Unit test summary 1\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** summary from \"Unit test summary\" to \"Unit test summary 1\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:     "",
 			CurrentInstance:  false,
 		},
@@ -460,43 +460,43 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue attachments - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-attachments.json"),
-			ExpectedHeadline: "Test User attached [test.gif] to, removed attachments [test.json] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **attached** [test.gif] to, **removed** attachments [test.json] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue fix version - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-fix-version.json"),
-			ExpectedHeadline: `Test User updated Fix Version from "v1" to "v2" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** Fix Version from "v1" to "v2" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  false,
 		},
 		"issue issue type - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-issue-type.json"),
-			ExpectedHeadline: `Test User updated issuetype from "Task" to "Bug" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** issuetype from "Task" to "Bug" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  false,
 		},
 		"issue labels - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-labels.json"),
-			ExpectedHeadline: "Test User added labels [sad] to, removed labels [bad] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **added** labels [sad] to, **removed** labels [bad] from story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue lowered priority - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-lowered-priority.json"),
-			ExpectedHeadline: `Test User updated priority from "High" to "Low" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** priority from "High" to "Low" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  false,
 		},
 		"issue raised priority - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-raised-priority.json"),
-			ExpectedHeadline: `Test User updated priority from "Low" to "High" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
+			ExpectedHeadline: `Test User **updated** priority from "Low" to "High" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)`,
 			CurrentInstance:  false,
 		},
 		"issue rank - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-rank.json"),
-			ExpectedHeadline: "Test User updated Rank from \"~~none~~\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** Rank from \"~~none~~\" to \"ranked higher\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue reopened - no Instance": {
 			Request:                 testWebhookRequest("webhook-issue-updated-reopened.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **updated** story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -514,7 +514,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue resolved - no Instance": {
 			Request:                 testWebhookRequest("webhook-issue-updated-resolved.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User updated story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **updated** story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedFields: []*model.SlackAttachmentField{
 				{
 					Title: "",
@@ -531,12 +531,12 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue sprint - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-sprint.json"),
-			ExpectedHeadline: "Test User updated Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** Sprint from \"Sprint 1\" to \"Sprint 2\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue started working - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-started-working.json"),
-			ExpectedHeadline: "Test User updated status from \"To Do\" to \"In Progress\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **updated** status from \"To Do\" to \"In Progress\" on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"CLOUD comment created - no Instance": {

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -73,7 +73,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long",
 			ExpectedFields: []*model.SlackAttachmentField{
 				&model.SlackAttachmentField{
@@ -88,7 +88,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created-no-relevant-fields.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long",
 			ExpectedFields:          []*model.SlackAttachmentField{},
 			CurrentInstance:         true,
@@ -97,7 +97,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created-no-description.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			// ExpectedText:            "Unit test description, not that long",
 			ExpectedFields: []*model.SlackAttachmentField{
 				&model.SlackAttachmentField{
@@ -111,7 +111,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue created no description nor fields": {
 			Request:          testWebhookRequest("webhook-issue-created-no-description-nor-relevant-fields.json"),
 			ExpectedStatus:   http.StatusOK,
-			ExpectedHeadline: "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue edited": {
@@ -136,22 +136,22 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue assigned nobody": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned-nobody.json"),
-			ExpectedHeadline: "Test User assigned _nobody_ to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **assigned** _nobody_ to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue assigned": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned.json"),
-			ExpectedHeadline: "Test User assigned Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **assigned** Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"SERVER (old version) issue assigned (no issue_event_type_name)": {
 			Request:          testWebhookRequest("webhook-server-old-issue-updated-no-event-type-assigned.json"),
-			ExpectedHeadline: "Test User assigned Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **assigned** Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
 		"issue assigned on server": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned-on-server.json"),
-			ExpectedHeadline: "Test User assigned Test User to improvement [PRJA-37: test](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/PRJA-37)",
+			ExpectedHeadline: "Test User **assigned** Test User to improvement [PRJA-37: test](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/PRJA-37)",
 			CurrentInstance:  true,
 		},
 		"issue attachments": {
@@ -307,39 +307,39 @@ func TestWebhookHTTP(t *testing.T) {
 		"CLOUD comment created": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-created.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User commented on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **commented** on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Added a comment",
 			CurrentInstance:         true,
 		},
 		"CLOUD comment updated": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-updated.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User edited comment in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **edited comment** in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Added a comment, then edited it",
 			CurrentInstance:         true,
 		},
 		"CLOUD comment deleted": {
 			Request:          testWebhookRequest("webhook-cloud-comment-deleted.json"),
-			ExpectedHeadline: "Test User deleted comment in task [KT-7: s](https://mmtest.atlassian.net/browse/KT-7)",
+			ExpectedHeadline: "Test User **deleted comment** in task [KT-7: s](https://mmtest.atlassian.net/browse/KT-7)",
 			CurrentInstance:  true,
 		},
 		"SERVER issue commented": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-1.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk commented on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "unik",
 			CurrentInstance:         true,
 		},
 		"SERVER (old version) issue commented (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-commented.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk commented on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "unik",
 			CurrentInstance:         true,
 		},
 		"SERVER issue comment deleted": {
 			Request:          testWebhookRequest("webhook-server-issue-updated-comment-deleted.json"),
-			ExpectedHeadline: "Lev Brouk deleted comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline: "Lev Brouk **deleted comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:     "",
 			CurrentInstance:  true,
 		},
@@ -352,21 +352,21 @@ func TestWebhookHTTP(t *testing.T) {
 		"SERVER issue comment edited": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-comment-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk edited comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "and higher eeven higher",
 			CurrentInstance:         true,
 		},
 		"SERVER (old version) issue comment edited (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-comment-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk edited comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "and higher eeven higher",
 			CurrentInstance:         true,
 		},
 		"SERVER issue commented notify": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-2.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User commented on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
+			ExpectedHeadline:        "Test User **commented** on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
 			ExpectedText:            "This is a test comment. We should act on it right away.",
 			CurrentInstance:         true,
 		},
@@ -389,7 +389,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long",
 			ExpectedFields: []*model.SlackAttachmentField{
 				&model.SlackAttachmentField{
@@ -404,7 +404,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created-no-relevant-fields.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Unit test description, not that long",
 			ExpectedFields:          []*model.SlackAttachmentField{},
 			CurrentInstance:         false,
@@ -413,7 +413,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-issue-created-no-description.json"),
 			ExpectedStatus:          http.StatusOK,
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			// ExpectedText:            "Unit test description, not that long",
 			ExpectedFields: []*model.SlackAttachmentField{
 				&model.SlackAttachmentField{
@@ -427,7 +427,7 @@ func TestWebhookHTTP(t *testing.T) {
 		"issue created no description nor fields - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-created-no-description-nor-relevant-fields.json"),
 			ExpectedStatus:   http.StatusOK,
-			ExpectedHeadline: "Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue edited - no Instance": {
@@ -445,17 +445,17 @@ func TestWebhookHTTP(t *testing.T) {
 		},
 		"issue assigned nobody - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned-nobody.json"),
-			ExpectedHeadline: "Test User assigned _nobody_ to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **assigned** _nobody_ to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue assigned - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned.json"),
-			ExpectedHeadline: "Test User assigned Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline: "Test User **assigned** Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  false,
 		},
 		"issue assigned on server - no Instance": {
 			Request:          testWebhookRequest("webhook-issue-updated-assigned-on-server.json"),
-			ExpectedHeadline: "Test User assigned Test User to improvement [PRJA-37: test](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/PRJA-37)",
+			ExpectedHeadline: "Test User **assigned** Test User to improvement [PRJA-37: test](http://some-instance-test.centralus.cloudapp.azure.com:8080/browse/PRJA-37)",
 			CurrentInstance:  false,
 		},
 		"issue attachments - no Instance": {
@@ -542,46 +542,46 @@ func TestWebhookHTTP(t *testing.T) {
 		"CLOUD comment created - no Instance": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-created.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User commented on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **commented** on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Added a comment",
 			CurrentInstance:         false,
 		},
 		"CLOUD comment updated - no Instance": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-updated.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User edited comment in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
+			ExpectedHeadline:        "Test User **edited comment** in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			ExpectedText:            "Added a comment, then edited it",
 			CurrentInstance:         false,
 		},
 		"CLOUD comment deleted - no Instance": {
 			Request:          testWebhookRequest("webhook-cloud-comment-deleted.json"),
-			ExpectedHeadline: "Test User deleted comment in task [KT-7: s](https://mmtest.atlassian.net/browse/KT-7)",
+			ExpectedHeadline: "Test User **deleted comment** in task [KT-7: s](https://mmtest.atlassian.net/browse/KT-7)",
 			CurrentInstance:  false,
 		},
 		"SERVER issue commented - no Instance": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-1.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk commented on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "unik",
 			CurrentInstance:         false,
 		},
 		"SERVER issue comment deleted - no Instance": {
 			Request:          testWebhookRequest("webhook-server-issue-updated-comment-deleted.json"),
-			ExpectedHeadline: "Lev Brouk deleted comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline: "Lev Brouk **deleted comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:     "",
 			CurrentInstance:  false,
 		},
 		"SERVER issue comment edited - no Instance": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-comment-edited.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Lev Brouk edited comment in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
+			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:            "and higher eeven higher",
 			CurrentInstance:         false,
 		},
 		"SERVER issue commented notify - no Instance": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-2.json"),
 			ExpectedSlackAttachment: true,
-			ExpectedHeadline:        "Test User commented on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
+			ExpectedHeadline:        "Test User **commented** on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
 			ExpectedText:            "This is a test comment. We should act on it right away.",
 			CurrentInstance:         false,
 		},

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -301,7 +301,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	wh.notifications = append(wh.notifications, webhookNotification{
 		jiraUsername:  jwh.Issue.Fields.Assignee.Name,
 		jiraAccountID: jwh.Issue.Fields.Assignee.AccountID,
-		message:       fmt.Sprintf("%s commented on %s:\n>%s", commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body),
+		message:       fmt.Sprintf("%s **commented** on %s:\n>%s", commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body),
 		postType:      PostTypeComment,
 		commentSelf:   jwh.Comment.Self,
 	})

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -183,7 +183,7 @@ func parseWebhookChangeLog(jwh *JiraWebhook) Webhook {
 }
 
 func parseWebhookCreated(jwh *JiraWebhook) Webhook {
-	wh := newWebhook(jwh, eventCreated, "created")
+	wh := newWebhook(jwh, eventCreated, "**created**")
 	wh.text = jwh.mdIssueDescription()
 
 	if jwh.Issue.Fields == nil {
@@ -215,7 +215,7 @@ func parseWebhookCreated(jwh *JiraWebhook) Webhook {
 }
 
 func parseWebhookDeleted(jwh *JiraWebhook) Webhook {
-	wh := newWebhook(jwh, eventDeleted, "deleted")
+	wh := newWebhook(jwh, eventDeleted, "**deleted**")
 	if jwh.Issue.Fields != nil && jwh.Issue.Fields.Resolution == nil {
 		wh.eventTypes = wh.eventTypes.Add(eventDeletedUnresolved)
 	}
@@ -239,7 +239,7 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 	wh := &webhook{
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventCreatedComment),
-		headline:    fmt.Sprintf("%s commented on %s", commentAuthor, jwh.mdKeySummaryLink()),
+		headline:    fmt.Sprintf("%s **commented** on %s", commentAuthor, jwh.mdKeySummaryLink()),
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
@@ -326,7 +326,7 @@ func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {
 	return &webhook{
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventDeletedComment),
-		headline:    fmt.Sprintf("%s deleted comment in %s", user, jwh.mdKeySummaryLink()),
+		headline:    fmt.Sprintf("%s **deleted comment** in %s", user, jwh.mdKeySummaryLink()),
 	}, nil
 }
 
@@ -338,7 +338,7 @@ func parseWebhookCommentUpdated(jwh *JiraWebhook) (Webhook, error) {
 	wh := &webhook{
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventUpdatedComment),
-		headline:    fmt.Sprintf("%s edited comment in %s", mdUser(&jwh.Comment.UpdateAuthor), jwh.mdKeySummaryLink()),
+		headline:    fmt.Sprintf("%s **edited comment** in %s", mdUser(&jwh.Comment.UpdateAuthor), jwh.mdKeySummaryLink()),
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
@@ -347,7 +347,7 @@ func parseWebhookCommentUpdated(jwh *JiraWebhook) (Webhook, error) {
 }
 
 func parseWebhookAssigned(jwh *JiraWebhook, from, to string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedAssignee, "assigned %s to", jwh.mdIssueAssignee())
+	wh := newWebhook(jwh, eventUpdatedAssignee, "**assigned** %s to", jwh.mdIssueAssignee())
 	fromFixed := from
 	if fromFixed == "" {
 		fromFixed = "_nobody_"
@@ -384,13 +384,13 @@ func appendNotificationForAssignee(wh *webhook) {
 }
 
 func parseWebhookReopened(jwh *JiraWebhook, from string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedReopened, "reopened")
+	wh := newWebhook(jwh, eventUpdatedReopened, "**reopened**")
 	wh.fieldInfo = webhookField{"reopened", "resolution", from, "Open"}
 	return wh
 }
 
 func parseWebhookResolved(jwh *JiraWebhook, to string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedResolved, "resolved")
+	wh := newWebhook(jwh, eventUpdatedResolved, "**resolved**")
 	wh.fieldInfo = webhookField{"resolved", "resolution", "Open", to}
 	return wh
 }

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -243,7 +243,7 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
-	appendCommentNotifications(wh, "mentioned you in a new comment on")
+	appendCommentNotifications(wh, "**mentioned** you in a new comment on")
 
 	return wh, nil
 }
@@ -342,7 +342,7 @@ func parseWebhookCommentUpdated(jwh *JiraWebhook) (Webhook, error) {
 		text:        truncate(jwh.Comment.Body, 3000),
 	}
 
-	appendCommentNotifications(wh, "mentioned you in a comment update on")
+	appendCommentNotifications(wh, "**mentioned** you in a comment update on")
 	return wh, nil
 }
 
@@ -379,7 +379,7 @@ func appendNotificationForAssignee(wh *webhook) {
 	wh.notifications = append(wh.notifications, webhookNotification{
 		jiraUsername:  jwh.Issue.Fields.Assignee.Name,
 		jiraAccountID: jwh.Issue.Fields.Assignee.AccountID,
-		message:       fmt.Sprintf("%s assigned you to %s", jwh.mdUser(), jwh.mdKeySummaryLink()),
+		message:       fmt.Sprintf("%s **assigned** you to %s", jwh.mdUser(), jwh.mdKeySummaryLink()),
 	})
 }
 
@@ -396,13 +396,13 @@ func parseWebhookResolved(jwh *JiraWebhook, to string) *webhook {
 }
 
 func parseWebhookUpdatedField(jwh *JiraWebhook, eventType string, field, fieldId, from, to string) *webhook {
-	wh := newWebhook(jwh, eventType, "updated %s from %q to %q on", field, from, to)
+	wh := newWebhook(jwh, eventType, "**updated** %s from %q to %q on", field, from, to)
 	wh.fieldInfo = webhookField{field, fieldId, from, to}
 	return wh
 }
 
 func parseWebhookUpdatedDescription(jwh *JiraWebhook, from, to string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedDescription, "edited the description of")
+	wh := newWebhook(jwh, eventUpdatedDescription, "**edited** the description of")
 	fromFmttd := "\n**From:** " + truncate(from, 500)
 	toFmttd := "\n**To:** " + truncate(to, 500)
 	wh.fieldInfo = webhookField{"description", "description", fromFmttd, toFmttd}
@@ -411,13 +411,13 @@ func parseWebhookUpdatedDescription(jwh *JiraWebhook, from, to string) *webhook 
 }
 
 func parseWebhookUpdatedAttachments(jwh *JiraWebhook, from, to string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedAttachment, mdAddRemove(from, to, "attached", "removed attachments"))
+	wh := newWebhook(jwh, eventUpdatedAttachment, mdAddRemove(from, to, "**attached**", "**removed** attachments"))
 	wh.fieldInfo = webhookField{name: "attachments"}
 	return wh
 }
 
 func parseWebhookUpdatedLabels(jwh *JiraWebhook, from, to, fromWithDefault, toWithDefault string) *webhook {
-	wh := newWebhook(jwh, eventUpdatedLabels, mdAddRemove(from, to, "added labels", "removed labels"))
+	wh := newWebhook(jwh, eventUpdatedLabels, mdAddRemove(from, to, "**added** labels", "**removed** labels"))
 	wh.fieldInfo = webhookField{"labels", "labels", fromWithDefault, toWithDefault}
 	return wh
 }
@@ -426,7 +426,7 @@ func parseWebhookUpdatedLabels(jwh *JiraWebhook, from, to, fromWithDefault, toWi
 func mergeWebhookEvents(events []*webhook) Webhook {
 	merged := &webhook{
 		JiraWebhook: events[0].JiraWebhook,
-		headline:    events[0].mdUser() + " updated " + events[0].mdKeySummaryLink(),
+		headline:    events[0].mdUser() + " **updated** " + events[0].mdKeySummaryLink(),
 		eventTypes:  NewStringSet(),
 	}
 

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -35,12 +35,12 @@ func TestEventTypeFormat(t *testing.T) {
 	}{
 		"issue created format":                        {"testdata/webhook-issue-created.json", "Test User **created** story"},
 		"issue updated assigned format":               {"testdata/webhook-issue-updated-assigned.json", "Test User **assigned** Test User to story"},
-		"issue updated reopened format":               {"testdata/webhook-issue-updated-reopened.json", "Test User updated story"},
+		"issue updated reopened format":               {"testdata/webhook-issue-updated-reopened.json", "Test User **updated** story"},
 		"issue updated reopened format one changelog": {"testdata/webhook-issue-updated-reopened-one-changelog.json", "Test User **reopened** story"},
-		"issue updated resolved format":               {"testdata/webhook-issue-updated-resolved.json", "Test User updated story"},
+		"issue updated resolved format":               {"testdata/webhook-issue-updated-resolved.json", "Test User **updated** story"},
 		"issue updated resolved format one changelog": {"testdata/webhook-issue-updated-resolved-one-changelog.json", "Test User **resolved** story"},
 		"issue deleted":                               {"testdata/webhook-issue-deleted.json", "Test User **deleted** task"},
-		"issue updated commented created":             {"testdata/webhook-server-issue-updated-commented-2.json", "Test User **commented** on improvement"},
+		"issue updated commented created":             {"testdata/webhook-server-issue-updated-commented-3.json", "Test User **commented** on improvement"},
 		"issue updated comment edited":                {"testdata/webhook-server-issue-updated-comment-edited.json", "Lev Brouk **edited comment** in story"},
 		"issue updated comment deleted":               {"testdata/webhook-server-issue-updated-comment-deleted.json", "Lev Brouk **deleted comment** in story"},
 	} {
@@ -54,7 +54,27 @@ func TestEventTypeFormat(t *testing.T) {
 		w := wh.(*webhook)
 		require.NotNil(t, w)
 		require.Contains(t, w.headline, value.expected)
-		//fmt.Println(i, value)
+	}
+}
+
+func TestNotificationsFormat(t *testing.T) {
+	for _, value := range map[string]struct {
+		filename string
+		expected string
+	}{
+		"issue updated commented created": {"testdata/webhook-server-issue-updated-commented-3.json", "Test User **mentioned** you in a new comment on improvement"},
+	} {
+		f, err := os.Open(value.filename)
+		require.NoError(t, err)
+		defer f.Close()
+		bb, err := ioutil.ReadAll(f)
+		require.Nil(t, err)
+		wh, err := ParseWebhook(bb)
+		require.NoError(t, err)
+		w := wh.(*webhook)
+		require.NotNil(t, w)
+		require.NotNil(t, w.notifications)
+		require.Contains(t, w.notifications[0].message, value.expected)
 	}
 }
 

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -24,8 +24,38 @@ func TestMarkdown(t *testing.T) {
 	w := wh.(*webhook)
 	require.NotNil(t, w)
 	require.Equal(t,
-		"Test User created story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
+		"Test User **created** story [TES-41: Unit test summary](https://some-instance-test.atlassian.net/browse/TES-41)",
 		w.headline)
+}
+
+func TestEventTypeFormat(t *testing.T) {
+	for _, value := range map[string]struct {
+		filename string
+		expected string
+	}{
+		"issue created format":                        {"testdata/webhook-issue-created.json", "Test User **created** story"},
+		"issue updated assigned format":               {"testdata/webhook-issue-updated-assigned.json", "Test User **assigned** Test User to story"},
+		"issue updated reopened format":               {"testdata/webhook-issue-updated-reopened.json", "Test User updated story"},
+		"issue updated reopened format one changelog": {"testdata/webhook-issue-updated-reopened-one-changelog.json", "Test User **reopened** story"},
+		"issue updated resolved format":               {"testdata/webhook-issue-updated-resolved.json", "Test User updated story"},
+		"issue updated resolved format one changelog": {"testdata/webhook-issue-updated-resolved-one-changelog.json", "Test User **resolved** story"},
+		"issue deleted":                               {"testdata/webhook-issue-deleted.json", "Test User **deleted** task"},
+		"issue updated commented created":             {"testdata/webhook-server-issue-updated-commented-2.json", "Test User **commented** on improvement"},
+		"issue updated comment edited":                {"testdata/webhook-server-issue-updated-comment-edited.json", "Lev Brouk **edited comment** in story"},
+		"issue updated comment deleted":               {"testdata/webhook-server-issue-updated-comment-deleted.json", "Lev Brouk **deleted comment** in story"},
+	} {
+		f, err := os.Open(value.filename)
+		require.NoError(t, err)
+		defer f.Close()
+		bb, err := ioutil.ReadAll(f)
+		require.Nil(t, err)
+		wh, err := ParseWebhook(bb)
+		require.NoError(t, err)
+		w := wh.(*webhook)
+		require.NotNil(t, w)
+		require.Contains(t, w.headline, value.expected)
+		//fmt.Println(i, value)
+	}
 }
 
 func TestWebhookVariousErrors(t *testing.T) {


### PR DESCRIPTION
#### Summary

Added bold to some verbs. 

In the case of a reopened and resolved ticket, if there are more than one changelog, the text is "updated" to I didn't make it bold.

#### Ticket Link

https://github.com/mattermost/mattermost-plugin-jira/issues/168

#### Screenshots

![Screenshot from 2019-12-02 10-10-08](https://user-images.githubusercontent.com/2747834/69962575-14621b80-14ed-11ea-9662-1021386f7537.png)
![Screenshot from 2019-12-02 10-10-36](https://user-images.githubusercontent.com/2747834/69962576-14621b80-14ed-11ea-9ddf-e832474d3b72.png)
![Screenshot from 2019-12-02 10-11-46](https://user-images.githubusercontent.com/2747834/69962578-14621b80-14ed-11ea-9e3f-8a485adf64b5.png)
![Screenshot from 2019-12-02 10-12-30](https://user-images.githubusercontent.com/2747834/69962579-14fab200-14ed-11ea-9bb9-5ed8e2c256c2.png)
![Screenshot from 2019-12-02 10-13-07](https://user-images.githubusercontent.com/2747834/69962580-14fab200-14ed-11ea-92ae-f74b318d0221.png)
![Screenshot from 2019-12-02 10-13-44](https://user-images.githubusercontent.com/2747834/69962581-14fab200-14ed-11ea-882e-2b821e470706.png)
![Screenshot from 2019-12-02 10-14-15](https://user-images.githubusercontent.com/2747834/69962582-14fab200-14ed-11ea-855a-2bb440aaf185.png)
![Screenshot from 2019-12-02 10-14-55](https://user-images.githubusercontent.com/2747834/69962586-15934880-14ed-11ea-9b07-6bb3f4788746.png)
![Screenshot from 2019-12-02 10-15-31](https://user-images.githubusercontent.com/2747834/69962587-15934880-14ed-11ea-84d4-de8e2aef4553.png)
![Screenshot from 2019-12-02 10-16-04](https://user-images.githubusercontent.com/2747834/69962588-15934880-14ed-11ea-83c2-410e40527e93.png)
