### PR TITLE
[MM-20738] When Jira UI config var is set to false, initialize webapp except for create and attach

### DIFF
--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -13,6 +13,7 @@ export default {
 
     RECEIVED_CONNECTED: `${PluginId}_connected`,
     RECEIVED_INSTANCE_STATUS: `${PluginId}_instance_status`,
+    RECEIVED_PLUGIN_SETTINGS: `${PluginId}_plugin_settings`,
 
     RECEIVED_JIRA_ISSUE_METADATA: `${PluginId}_received_metadata`,
     RECEIVED_JIRA_PROJECT_METADATA: `${PluginId}_received_projects`,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -217,18 +217,25 @@ export const fetchChannelSubscriptions = (channelId) => {
     };
 };
 
-export function getSettings(getState) {
-    let data;
-    const baseUrl = getPluginServerRoute(getState());
-    try {
-        data = doFetch(`${baseUrl}/api/v2/settingsinfo`, {
-            method: 'get',
-        });
-    } catch (error) {
-        return {error};
-    }
+export function getSettings() {
+    return async (dispatch, getState) => {
+        let data;
+        const baseUrl = getPluginServerRoute(getState());
+        try {
+            data = await doFetch(`${baseUrl}/api/v2/settingsinfo`, {
+                method: 'get',
+            });
 
-    return data;
+            dispatch({
+                type: ActionTypes.RECEIVED_PLUGIN_SETTINGS,
+                data,
+            });
+        } catch (error) {
+            return {error};
+        }
+
+        return data;
+    };
 }
 
 export function getConnected() {

--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -3,7 +3,7 @@
 
 import {isDesktopApp, isMinimumDesktopAppVersion} from '../utils/user_agent';
 import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost} from '../actions';
-import {isUserConnected, getInstalledInstanceType, isInstanceInstalled} from '../selectors';
+import {isUserConnected, getInstalledInstanceType, isInstanceInstalled, getPluginSettings} from '../selectors';
 import PluginId from 'plugin_id';
 
 export default class Hooks {
@@ -17,7 +17,10 @@ export default class Hooks {
             messageTrimmed = message.trim();
         }
 
-        if (messageTrimmed && messageTrimmed.startsWith('/jira create')) {
+        const pluginSettings = getPluginSettings(this.store.getState());
+        const shouldEnableCreate = pluginSettings && pluginSettings.ui_enabled;
+
+        if (messageTrimmed && messageTrimmed.startsWith('/jira create') && shouldEnableCreate) {
             if (!isInstanceInstalled(this.store.getState())) {
                 this.store.dispatch(sendEphemeralPost('There is no Jira instance installed. Please contact your system administrator.'));
                 return Promise.resolve({});

--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -19,21 +19,21 @@ import {handleConnectChange, getConnected, handleInstanceStatusChange, getSettin
 import Hooks from './hooks/hooks';
 
 const setupUILater = (registry: PluginRegistry, store: Store<object, Action<object>>): () => Promise<void> => async () => {
-    const settings = await getSettings(store.getState);
-    if (!settings.ui_enabled) {
-        return;
-    }
+    const settings = await store.dispatch(getSettings());
 
     registry.registerReducer(reducers);
 
     try {
         await getConnected()(store.dispatch, store.getState);
 
-        registry.registerRootComponent(CreateIssueModal);
+        if (settings.ui_enabled) {
+            registry.registerRootComponent(CreateIssueModal);
+            registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);
+            registry.registerRootComponent(AttachCommentToIssueModal);
+            registry.registerPostDropdownMenuComponent(AttachCommentToIssuePostMenuAction);
+        }
+
         registry.registerRootComponent(ChannelSettingsModal);
-        registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);
-        registry.registerRootComponent(AttachCommentToIssueModal);
-        registry.registerPostDropdownMenuComponent(AttachCommentToIssuePostMenuAction);
 
         const hooks = new Hooks(store);
         registry.registerSlashCommandWillBePostedHook(hooks.slashCommandWillBePostedHook);

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -38,6 +38,15 @@ function instanceType(state = '', action) {
     }
 }
 
+function pluginSettings(state = null, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_PLUGIN_SETTINGS:
+        return action.data;
+    default:
+        return state;
+    }
+}
+
 const createModalVisible = (state = false, action) => {
     switch (action.type) {
     case ActionTypes.OPEN_CREATE_ISSUE_MODAL:
@@ -170,6 +179,7 @@ export default combineReducers({
     userConnected,
     instanceInstalled,
     instanceType,
+    pluginSettings,
     createModalVisible,
     createModal,
     attachCommentToIssueModalVisible,

--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -57,4 +57,6 @@ export const isUserConnected = (state) => getPluginState(state).userConnected;
 
 export const isInstanceInstalled = (state) => getPluginState(state).instanceInstalled;
 
+export const getPluginSettings = (state) => getPluginState(state).pluginSettings;
+
 export const getInstalledInstanceType = (state) => getPluginState(state).instanceType;


### PR DESCRIPTION
#### Summary

When the `Allow users to attach and create Jira issues in Mattermost` config var is set to false, the webapp portion of the plugin was not being initialized in general. This can cause problems with `/jira subscribe` and `/jira connect`.

This PR makes it so only the "create" and "attach" features are disabled as noted in the config.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20738

#### Screenshots

Here is the relevant setting in the config:

![image](https://user-images.githubusercontent.com/6913320/70092491-5f168d00-15ec-11ea-9657-39c8b1df3c45.png)

#### QA Test Steps

With `Allow users to attach and create Jira issues in Mattermost` set to true:
- `/jira subscribe` should work
- `/jira create` should work
- Both post dot menu actions for create and attach should appear

With `Allow users to attach and create Jira issues in Mattermost` set to false:
- `/jira subscribe` should work
- `/jira create` should not work
- Neither post dot menu action for create or attach should not appear