### PR TITLE
[MM-20940] Reintroduce css for back and close buttons for full screen modal

### DIFF
--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
@@ -11,13 +11,13 @@ $full-screen-modal-transition: 100ms;
     overflow: auto;
 
     .back {
-        top: 48px;
-        left: 48px;
+        top: 8px;
+        left: 16px;
     }
 
     .close-x {
-        top: 48px;
-        right: 48px;
+        top: 8px;
+        right: 16px;
     }
 
     .close-x, .back {


### PR DESCRIPTION
#### Summary

The css adjustments for the two buttons were accidentally removed here
https://github.com/mattermost/mattermost-plugin-jira/commit/ad3cc4c2581e73c91a9fa520a4ec7a8299a4e0b3#diff-0f8116c7c9b5c1bb6abab32cd1b3cd5f

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20940