### PR TITLE
Updating jira icon alignment in menu

### DIFF
--- a/webapp/src/components/icon.tsx
+++ b/webapp/src/components/icon.tsx
@@ -11,21 +11,23 @@ export default class JiraIcon extends React.PureComponent<Props> {
     public render() {
         let iconStyle = {};
         if (this.props.type === 'menu') {
-            iconStyle = {flex: '0 0 auto', width: '20px', height: '20px', fill: '#0052CC', marginRight: '8px', background: 'white', borderRadius: '50px', padding: '2px'};
+            iconStyle = {flex: '0 0 auto', width: '20px', height: '20px', fill: '#0052CC', background: 'white', borderRadius: '50px', padding: '2px'};
         }
 
         return (
-            <svg
-                aria-hidden='true'
-                focusable='false'
-                role='img'
-                viewBox='0 0 496 512'
-                width='14'
-                height='14'
-                style={iconStyle}
-            >
-                <path d='M490 241.7C417.1 169 320.6 71.8 248.5 0 83 164.9 6 241.7 6 241.7c-7.9 7.9-7.9 20.7 0 28.7C138.8 402.7 67.8 331.9 248.5 512c379.4-378 15.7-16.7 241.5-241.7 8-7.9 8-20.7 0-28.6zm-241.5 90l-76-75.7 76-75.7 76 75.7-76 75.7z'/>
-            </svg>
+            <span className='MenuItem__icon'>
+                <svg
+                    aria-hidden='true'
+                    focusable='false'
+                    role='img'
+                    viewBox='0 0 496 512'
+                    width='14'
+                    height='14'
+                    style={iconStyle}
+                >
+                    <path d='M490 241.7C417.1 169 320.6 71.8 248.5 0 83 164.9 6 241.7 6 241.7c-7.9 7.9-7.9 20.7 0 28.7C138.8 402.7 67.8 331.9 248.5 512c379.4-378 15.7-16.7 241.5-241.7 8-7.9 8-20.7 0-28.6zm-241.5 90l-76-75.7 76-75.7 76 75.7-76 75.7z'/>
+                </svg>
+            </span>
         );
     }
 }


### PR DESCRIPTION
Needs to go in for jira 2.3.
Fixes the alignment for the icons.
This class should be used now as a wrapper for all plugins that introduce icon in the menu dropdown.

![Screenshot 2019-12-05 at 6 05 07 PM](https://user-images.githubusercontent.com/11034289/70238030-3c21df80-178a-11ea-951c-81989aedd12d.png)
