### PR TITLE
[MM-21054] Remove hardcoded boolean in atomicModify

### DIFF
--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -639,7 +639,6 @@ func (p *Plugin) atomicModify(key string, modify func(initialValue []byte) ([]by
 
 		var setError *model.AppError
 		success, setError = p.API.KVCompareAndSet(key, initialBytes, newValue)
-		success = true
 		if setError != nil {
 			return errors.Wrap(setError, "problem writing value")
 		}


### PR DESCRIPTION
#### Summary

When reviewing the task "Make access to KV store atomically safe when saving/removing subscriptions" https://github.com/mattermost/mattermost-plugin-github/issues/141#issuecomment-547648457, it was discovered that there is a potential bug with the `atomicModify` function in the Jira plugin, leftover from  a change of which plugin API method is used. There is more context in the linked comment.

The `success` value returned from `API.KVCompareAndSet` is overwritten with a hardcoded boolean. Using the value returned from `KVCompareAndSet` seems to be the correct method here.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-21054

#### Background

An issue occurred on community, where an existing subscription failed to save because of an error `modification error: Existing subscription does not exist`. This error could be caused by any number of things, but this line in the code came to mind, and probably needs to be cleaned up.

https://community-release.mattermost.com/core/pl/wu6axnostigmmdkuy6diq7qfyw