### PR TITLE
[MM-19170] Add support for "Components" Jira field

### DIFF
--- a/server/event_types.go
+++ b/server/event_types.go
@@ -23,6 +23,7 @@ const (
 	eventUpdatedFixVersion     = "event_updated_fix_version"
 	eventUpdatedAffectsVersion = "event_updated_affects_version"
 	eventUpdatedReporter       = "event_updated_reporter"
+	eventUpdatedComponents     = "event_updated_components"
 )
 
 var legacyEvents = NewStringSet(

--- a/server/issue.go
+++ b/server/issue.go
@@ -748,6 +748,12 @@ func getIssueFieldValue(issue *jira.Issue, key string) StringSet {
 			result = result.Add(v.ID)
 		}
 		return result
+	case "components":
+		result := NewStringSet()
+		for _, v := range issue.Fields.Components {
+			result = result.Add(v.ID)
+		}
+		return result
 	default:
 		value := getIssueCustomFieldValue(issue, key)
 		if value != nil {

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -429,6 +429,26 @@ func TestGetChannelsSubscribed(t *testing.T) {
 			}),
 			ChannelIds: []string{},
 		},
+		"CLOUD - components selected": {
+			WebhookTestData: "webhook-issue-updated-components.json",
+			Subs: withExistingChannelSubscriptions([]ChannelSubscription{
+				ChannelSubscription{
+					Id:        model.NewId(),
+					ChannelId: "sampleChannelId",
+					Filters: SubscriptionFilters{
+						Events:     NewStringSet("event_updated_any"),
+						Projects:   NewStringSet("TES"),
+						IssueTypes: NewStringSet("10002"),
+						Fields: []FieldFilter{{
+							Key:       "components",
+							Values:    NewStringSet("10000"),
+							Inclusion: "include_any",
+						}},
+					},
+				},
+			}),
+			ChannelIds: []string{"sampleChannelId"},
+		},
 		"CLOUD - custom field selected": {
 			WebhookTestData: "webhook-cloud-issue-updated-custom-field.json",
 			Subs: withExistingChannelSubscriptions([]ChannelSubscription{

--- a/server/testdata/webhook-issue-updated-components.json
+++ b/server/testdata/webhook-issue-updated-components.json
@@ -1,0 +1,330 @@
+{
+    "timestamp": 1575556703833,
+    "webhookEvent": "jira:issue_updated",
+    "issue_event_type_name": "issue_updated",
+    "user": {
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5cedcb4355a88a0fc86388ba",
+        "accountId": "5cedcb4355a88a0fc86388ba",
+        "avatarUrls": {
+            "48x48": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+            "24x24": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+            "16x16": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+            "32x32": "https://avatar-cdn.atlassian.com/d991bc281c0c0ecb0bbb2db3979ddaff?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fd991bc281c0c0ecb0bbb2db3979ddaff%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+          },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Vancouver",
+        "accountType": "atlassian"
+    },
+    "issue": {
+        "id": "10360",
+        "self": "https://some-instance-test.atlassian.net/rest/api/2/10360",
+        "key": "TES-10",
+        "fields": {
+            "statuscategorychangedate": "2019-07-13T16:28:19.215-0700",
+            "customfield_10070": null,
+            "customfield_10071": [
+                "a",
+                "thisone"
+            ],
+            "customfield_10072": null,
+            "customfield_10074": null,
+            "customfield_10075": null,
+            "customfield_10076": null,
+            "fixVersions": [
+                {
+                    "self": "https://some-instance-test.atlassian.net/rest/api/2/version/10004",
+                    "id": "10004",
+                    "description": "",
+                    "name": "version 1",
+                    "archived": false,
+                    "released": false
+                },
+                {
+                    "self": "https://some-instance-test.atlassian.net/rest/api/2/version/10005",
+                    "id": "10005",
+                    "description": "",
+                    "name": "version 2",
+                    "archived": false,
+                    "released": false
+                }
+            ],
+            "customfield_10077": null,
+            "customfield_10078": null,
+            "resolution": null,
+            "customfield_10079": null,
+            "lastViewed": "2019-12-05T05:38:04.380-0800",
+            "customfield_10060": null,
+            "customfield_10061": null,
+            "customfield_10062": null,
+            "customfield_10064": null,
+            "customfield_10065": null,
+            "customfield_10067": "Mexican",
+            "priority": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/3",
+                "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10068": null,
+            "customfield_10069": null,
+            "labels": [
+                "ee",
+                "eeee",
+                "tt",
+                "ww"
+            ],
+            "timeestimate": null,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "issuelinks": [
+                {
+                    "id": "10005",
+                    "self": "https://some-instance-test.atlassian.net/rest/api/2/issueLink/10005",
+                    "type": {
+                        "id": "10003",
+                        "name": "Relates",
+                        "inward": "relates to",
+                        "outward": "relates to",
+                        "self": "https://some-instance-test.atlassian.net/rest/api/2/issueLinkType/10003"
+                    },
+                    "outwardIssue": {
+                        "id": "10357",
+                        "key": "TES-7",
+                        "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/10357",
+                        "fields": {
+                            "summary": "s",
+                            "status": {
+                                "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10004",
+                                "description": "",
+                                "iconUrl": "https://some-instance-test.atlassian.net/",
+                                "name": "To Do",
+                                "id": "10004",
+                                "statusCategory": {
+                                    "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+                                    "id": 2,
+                                    "key": "new",
+                                    "colorName": "blue-gray",
+                                    "name": "To Do"
+                                }
+                            },
+                            "priority": {
+                                "self": "https://some-instance-test.atlassian.net/rest/api/2/priority/2",
+                                "iconUrl": "https://some-instance-test.atlassian.net/images/icons/priorities/high.svg",
+                                "name": "High",
+                                "id": "2"
+                            },
+                            "issuetype": {
+                                "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10002",
+                                "id": "10002",
+                                "description": "A task that needs to be done.",
+                                "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype",
+                                "name": "Task",
+                                "subtask": false,
+                                "avatarId": 10318
+                            }
+                        }
+                    }
+                }
+            ],
+            "assignee": null,
+            "status": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/status/10004",
+                "description": "",
+                "iconUrl": "https://some-instance-test.atlassian.net/",
+                "name": "To Do",
+                "id": "10004",
+                "statusCategory": {
+                    "self": "https://some-instance-test.atlassian.net/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "New"
+                }
+            },
+            "components": [
+                {
+                    "self": "https://some-instance-test.atlassian.net/rest/api/2/component/10000",
+                    "id": "10000",
+                    "name": "Special Component"
+                }
+            ],
+            "customfield_10050": null,
+            "customfield_10051": null,
+            "customfield_10052": null,
+            "customfield_10053": null,
+            "customfield_10054": null,
+            "customfield_10055": null,
+            "customfield_10056": null,
+            "customfield_10057": null,
+            "customfield_10058": null,
+            "customfield_10059": null,
+            "customfield_10049": null,
+            "aggregatetimeestimate": null,
+            "creator": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5cedcb4355a88a0fc86388ba",
+                "name": "test.user",
+                "key": "test.user",
+                "accountId": "5cedcb4355a88a0fc86388ba",
+                "emailAddress": "test.user@example.com",
+                "avatarUrls": {
+                    "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=48&s=48",
+                    "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=24&s=24",
+                    "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=16&s=16",
+                    "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=32&s=32"
+                },
+                "displayName": "Test User",
+                "active": true,
+                "timeZone": "America/Vancouver",
+                "accountType": "atlassian"
+            },
+            "subtasks": [],
+            "customfield_10040": [
+                "test.user(test.user)"
+            ],
+            "customfield_10041": null,
+            "customfield_10042": null,
+            "reporter": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/user?accountId=5cedcb4355a88a0fc86388ba",
+                "name": "test.user",
+                "key": "test.user",
+                "accountId": "5cedcb4355a88a0fc86388ba",
+                "emailAddress": "test.user@example.com",
+                "avatarUrls": {
+                    "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=48&s=48",
+                    "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=24&s=24",
+                    "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=16&s=16",
+                    "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5cedcb4355a88a0fc86388ba/0d974d79-626d-481b-bd5e-5631399158a7/128?size=32&s=32"
+                },
+                "displayName": "Test User",
+                "active": true,
+                "timeZone": "America/Vancouver",
+                "accountType": "atlassian"
+            },
+            "customfield_10043": "",
+            "customfield_10044": "test.user(test.user)",
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "customfield_10045": null,
+            "customfield_10046": null,
+            "customfield_10047": null,
+            "customfield_10048": null,
+            "customfield_10038": "0.0",
+            "customfield_10039": {
+                "hasEpicLinkFieldDependency": false,
+                "showField": false,
+                "nonEditableReason": {
+                    "reason": "PLUGIN_LICENSE_ERROR",
+                    "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+                }
+            },
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "votes": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-10/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "issuetype": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/issuetype/10002",
+                "id": "10002",
+                "description": "A task that needs to be done.",
+                "iconUrl": "https://some-instance-test.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype",
+                "name": "Task",
+                "subtask": false,
+                "avatarId": 10318
+            },
+            "timespent": null,
+            "customfield_10030": "12441600",
+            "project": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/project/10008",
+                "id": "10008",
+                "key": "TES",
+                "name": "Testing Extensions",
+                "projectTypeKey": "software",
+                "simplified": false,
+                "avatarUrls": {
+                    "48x48": "https://some-instance-test.atlassian.net/secure/projectavatar?pid=10008&avatarId=10417",
+                    "24x24": "https://some-instance-test.atlassian.net/secure/projectavatar?size=small&s=small&pid=10008&avatarId=10417",
+                    "16x16": "https://some-instance-test.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10008&avatarId=10417",
+                    "32x32": "https://some-instance-test.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10008&avatarId=10417"
+                }
+            },
+            "customfield_10031": "",
+            "customfield_10032": "example.com",
+            "customfield_10033": "true",
+            "customfield_10034": "2019-07-13 23:28:19.131",
+            "aggregatetimespent": null,
+            "customfield_10035": null,
+            "customfield_10036": null,
+            "customfield_10037": "0.0",
+            "customfield_10027": null,
+            "customfield_10028": [],
+            "customfield_10029": null,
+            "resolutiondate": null,
+            "workratio": -1,
+            "watches": {
+                "self": "https://some-instance-test.atlassian.net/rest/api/2/issue/TES-10/watchers",
+                "watchCount": 1,
+                "isWatching": true
+            },
+            "created": "2019-07-13T16:28:19.131-0700",
+            "customfield_10020": null,
+            "customfield_10021": null,
+            "customfield_10022": "0|i0025r:",
+            "customfield_10026": null,
+            "customfield_10016": null,
+            "customfield_10017": null,
+            "customfield_10018": {
+                "hasEpicLinkFieldDependency": false,
+                "showField": false,
+                "nonEditableReason": {
+                    "reason": "PLUGIN_LICENSE_ERROR",
+                    "message": "Portfolio for Jira must be licensed for the Parent Link to be available."
+                }
+            },
+            "customfield_10019": null,
+            "updated": "2019-12-05T06:38:23.829-0800",
+            "timeoriginalestimate": null,
+            "description": "wewef",
+            "customfield_10010": null,
+            "customfield_10014": "TES-33",
+            "customfield_10015": null,
+            "timetracking": {},
+            "customfield_10005": null,
+            "customfield_10006": null,
+            "security": null,
+            "customfield_10007": null,
+            "customfield_10008": null,
+            "attachment": [],
+            "customfield_10009": null,
+            "summary": "wewe",
+            "customfield_10080": null,
+            "customfield_10000": "{}",
+            "customfield_10001": null,
+            "customfield_10002": null,
+            "customfield_10003": null,
+            "customfield_10004": null,
+            "environment": null,
+            "duedate": null
+        }
+    },
+    "changelog": {
+        "id": "12849",
+        "items": [
+            {
+                "field": "Component",
+                "fieldtype": "jira",
+                "fieldId": "components",
+                "from": null,
+                "fromString": null,
+                "to": "10000",
+                "toString": "Special Component"
+            }
+        ]
+    }
+}

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -162,6 +162,8 @@ func parseWebhookChangeLog(jwh *JiraWebhook) Webhook {
 			event = parseWebhookUpdatedField(jwh, eventUpdatedAffectsVersion, field, fieldId, fromWithDefault, toWithDefault)
 		case field == "reporter":
 			event = parseWebhookUpdatedField(jwh, eventUpdatedReporter, field, fieldId, fromWithDefault, toWithDefault)
+		case field == "Component":
+			event = parseWebhookUpdatedField(jwh, eventUpdatedComponents, field, fieldId, fromWithDefault, toWithDefault)
 		case item.FieldType == "custom":
 			eventType := fmt.Sprintf("event_updated_%s", fieldId)
 			event = parseWebhookUpdatedField(jwh, eventType, field, fieldId, fromWithDefault, toWithDefault)

--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -390,6 +390,10 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
               "value": "event_updated_summary",
             },
             Object {
+              "label": "Issue Updated: Components",
+              "value": "event_updated_components",
+            },
+            Object {
               "label": "Issue Updated: Custom - Epic Link",
               "value": "event_updated_customfield_10014",
             },

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -48,6 +48,7 @@ const JiraEventOptions: ReactSelectOption[] = [
     {value: 'event_updated_sprint', label: 'Issue Updated: Sprint'},
     {value: 'event_updated_status', label: 'Issue Updated: Status'},
     {value: 'event_updated_summary', label: 'Issue Updated: Summary'},
+    {value: 'event_updated_components', label: 'Issue Updated: Components'},
 ];
 
 export type Props = SharedProps & {

--- a/webapp/src/utils/jira_issue_metadata.tsx
+++ b/webapp/src/utils/jira_issue_metadata.tsx
@@ -156,6 +156,13 @@ const allowedTypes = [
     'security',
 ];
 
+const allowedArrayTypes = [
+    'component',
+    'option', // multiselect
+    'string', // labels
+    'version', // fix and affects versions
+];
+
 const avoidedCustomTypesForFilters: string[] = [
     JiraFieldCustomTypeEnums.SPRINT,
 ];
@@ -172,9 +179,7 @@ function isValidFieldForFilter(field: JiraField): boolean {
 
     return allowedTypes.includes(type) || (custom && acceptedCustomTypesForFilters.includes(custom)) ||
     type === 'option' || // single select
-    (type === 'array' && items === 'option') || // multiselect
-    (type === 'array' && items === 'version') || // fix and affects versions
-    (type === 'array' && items === 'string'); // labels
+    (type === 'array' && allowedArrayTypes.includes(items));
 }
 
 export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null, projectKeys: string[]): FilterField[] {


### PR DESCRIPTION
#### Summary

This PR adds support for the `Components` Jira field. It is now accessible as a subscription event type and field filter.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19170
https://github.com/mattermost/mattermost-plugin-jira/issues/338