### PR TITLE
[MM-20744] Remove redundant full screen modal css

### DIFF
--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
@@ -47,7 +47,7 @@ export default class FullScreenModal extends React.Component {
                 timeout={ANIMATION_DURATION}
                 appear={true}
             >
-                <div className='FullScreenModal'>
+                <div className='FullScreenModal JiraFullScreenModal'>
                     <CloseIcon
                         className='close-x'
                         onClick={this.close}

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.scss
@@ -1,15 +1,4 @@
-$full-screen-modal-transition: 100ms;
-
-.FullScreenModal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: var(--center-channel-bg);
-    z-index: 2000;
-    overflow: auto;
-
+.JiraFullScreenModal {
     .back {
         top: 8px;
         left: 16px;
@@ -22,35 +11,5 @@ $full-screen-modal-transition: 100ms;
 
     .close-x, .back {
         position: absolute;
-        cursor: pointer;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        svg {
-            fill: var(--center-channel-color-90);
-            padding: 4px;
-            width: 40px;
-            height: 40px;
-            border-radius: 4px;
-            &:hover {
-                background: var(--button-bg-10);
-            }
-        }
-    }
-
-    // Animation
-    &-enter, &-appear {
-        opacity: 0;
-    }
-    &-enter-active, &-appear-active {
-        opacity: 1;
-        transition: opacity $full-screen-modal-transition;
-    }
-    &-exit {
-        opacity: 1;
-    }
-    &-exit-active {
-        opacity: 0;
-        transition: opacity $full-screen-modal-transition;
     }
 }

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.test.jsx
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.test.jsx
@@ -28,7 +28,7 @@ describe('components/widgets/modals/FullScreenModal', () => {
   unmountOnExit={true}
 >
   <div
-    className="FullScreenModal"
+    className="FullScreenModal JiraFullScreenModal"
   >
     <CloseIcon
       className="close-x"
@@ -58,7 +58,7 @@ describe('components/widgets/modals/FullScreenModal', () => {
   unmountOnExit={true}
 >
   <div
-    className="FullScreenModal"
+    className="FullScreenModal JiraFullScreenModal"
   >
     <CloseIcon
       className="close-x"


### PR DESCRIPTION
#### Summary

This PR removes the duplicated css for the full screen modals. What remains is only what is needed to properly position the close and back buttons closer to the top corners of the modal.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20744