### PR TITLE
[MM-21189] Fix plugin reducer initialization

### DIFF
--- a/webapp/src/hooks/hooks.js
+++ b/webapp/src/hooks/hooks.js
@@ -7,8 +7,9 @@ import {isUserConnected, getInstalledInstanceType, isInstanceInstalled, getPlugi
 import PluginId from 'plugin_id';
 
 export default class Hooks {
-    constructor(store) {
+    constructor(store, settings) {
         this.store = store;
+        this.settings = settings;
     }
 
     slashCommandWillBePostedHook = (message, contextArgs) => {
@@ -18,7 +19,13 @@ export default class Hooks {
         }
 
         const pluginSettings = getPluginSettings(this.store.getState());
-        const shouldEnableCreate = pluginSettings && pluginSettings.ui_enabled;
+
+        let shouldEnableCreate = false;
+        if (pluginSettings) {
+            shouldEnableCreate = pluginSettings.ui_enabled;
+        } else if (this.settings) {
+            shouldEnableCreate = this.settings.ui_enabled;
+        }
 
         if (messageTrimmed && messageTrimmed.startsWith('/jira create') && shouldEnableCreate) {
             if (!isInstanceInstalled(this.store.getState())) {

--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -19,9 +19,9 @@ import {handleConnectChange, getConnected, handleInstanceStatusChange, getSettin
 import Hooks from './hooks/hooks';
 
 const setupUILater = (registry: PluginRegistry, store: Store<object, Action<object>>): () => Promise<void> => async () => {
-    const settings = await store.dispatch(getSettings());
-
     registry.registerReducer(reducers);
+
+    const settings = await store.dispatch(getSettings());
 
     try {
         await getConnected()(store.dispatch, store.getState);
@@ -35,7 +35,7 @@ const setupUILater = (registry: PluginRegistry, store: Store<object, Action<obje
 
         registry.registerRootComponent(ChannelSettingsModal);
 
-        const hooks = new Hooks(store);
+        const hooks = new Hooks(store, settings);
         registry.registerSlashCommandWillBePostedHook(hooks.slashCommandWillBePostedHook);
     } finally {
         registry.registerWebSocketEventHandler(`custom_${PluginId}_connect`, handleConnectChange(store));


### PR DESCRIPTION
#### Summary

This PR fixes an issue where the plugin's reducers were not being initialized until after the plugin settings were fetched, causing the `RECEIVED_PLUGIN_SETTINGS` action to not be processed. There is also a backup for supplying the fetched settings to the Hooks constructor directly.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-21189