### PR TITLE
GH-392: Allow system admins to provide a block of text to display in output of `/jira help`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -69,6 +69,13 @@
         "type": "text",
         "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
         "default": ""
+      },
+      {
+        "key": "JiraAdminAdditionalHelpText",
+        "display_name": "Additional Help Text to be shown with Jira Help",
+        "type": "text",
+        "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
+        "default": ""
       }
     ],
     "footer": "Use this webhook URL format to [configure the Jira integration.](https://about.mattermost.com/default-jira-plugin)  `https://SITEURL/plugins/jira/api/v2/webhook?secret=WEBHOOKSECRET`"

--- a/server/command.go
+++ b/server/command.go
@@ -13,8 +13,9 @@ import (
 	"github.com/mattermost/mattermost-plugin-jira/server/utils"
 )
 
-const commonHelpText = "###### Mattermost Jira Plugin - Slash Command Help\n" +
-	"* `/jira connect` - Connect your Mattermost account to your Jira account\n" +
+const helpTextHeader = "###### Mattermost Jira Plugin - Slash Command Help\n"
+
+const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to your Jira account\n" +
 	"* `/jira disconnect` - Disconnect your Mattermost account from your Jira account\n" +
 	"* `/jira assign <issue-key> <assignee>` - Change the assignee of a Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
@@ -90,7 +91,16 @@ func commandHelp(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 func (p *Plugin) help(args *model.CommandArgs) *model.CommandResponse {
 	authorized, _ := authorizedSysAdmin(p, args.UserId)
 
-	helpText := commonHelpText
+	helpText := helpTextHeader
+	jiraAdminAdditionalHelpText := p.getConfig().JiraAdminAdditionalHelpText
+
+	// Check if JIRA admin has provided additional help text to be shown up along with regular output
+	if jiraAdminAdditionalHelpText != "" {
+		helpText += "    " + jiraAdminAdditionalHelpText
+	}
+
+	helpText += commonHelpText
+
 	if authorized {
 		helpText += sysAdminHelpText
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -59,6 +59,9 @@ type externalConfig struct {
 
 	// Disable statistics gathering
 	DisableStats bool `json:"disable_stats"`
+
+	// Additional Help Text to be shown in the output of '/jira help' command
+	JiraAdminAdditionalHelpText string
 }
 
 const currentInstanceTTL = 1 * time.Second


### PR DESCRIPTION
…with the output of  command

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
In system console, jira admin can specify extra help-text to be shown along with the output of command /jira help.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/392

