### PR TITLE
[MM-21218] Display placeholder text when a channel has no subscriptions

### DIFF
--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -146,7 +146,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
         } else {
             subscriptionRows = (
                 <p>
-                    {'Click "Create Subscription" to receive Jira notifications in this channel.'}
+                    {'Click "Create Subscription" to receive Jira issue notifications in this channel.'}
                 </p>
             );
         }

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -128,8 +128,8 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
         }
 
         let subscriptionRows;
-        if (channelSubscriptions.length){
-            subscriptionRows =  (
+        if (channelSubscriptions.length) {
+            subscriptionRows = (
                 <table className='table'>
                     <thead>
                         <tr>
@@ -143,11 +143,10 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
                     </tbody>
                 </table>
             );
-        }
-        else {
+        } else {
             subscriptionRows = (
                 <p>
-                    Click "Create Subscription" to receive Jira notifications in this channel.
+                    {'Click "Create Subscription" to receive Jira notifications in this channel.'}
                 </p>
             );
         }

--- a/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_settings/select_channel_subscription.tsx
@@ -90,7 +90,7 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
     }
 
     render(): React.ReactElement {
-        const {channel, omitDisplayName} = this.props;
+        const {channel, channelSubscriptions, omitDisplayName} = this.props;
         const {error, showConfirmModal, subscriptionToDelete} = this.state;
 
         let errorDisplay = null;
@@ -127,20 +127,30 @@ export default class SelectChannelSubscriptionInternal extends React.PureCompone
             titleMessage = <h2 className='text-center'>{'Jira Subscriptions'}</h2>;
         }
 
-        const subscriptionRows = (
-            <table className='table'>
-                <thead>
-                    <tr>
-                        <th scope='col'>{'Name'}</th>
-                        <th scope='col'>{'Project'}</th>
-                        <th scope='col'>{'Actions'}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {this.props.channelSubscriptions.map(this.renderRow)}
-                </tbody>
-            </table>
-        );
+        let subscriptionRows;
+        if (channelSubscriptions.length){
+            subscriptionRows =  (
+                <table className='table'>
+                    <thead>
+                        <tr>
+                            <th scope='col'>{'Name'}</th>
+                            <th scope='col'>{'Project'}</th>
+                            <th scope='col'>{'Actions'}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {channelSubscriptions.map(this.renderRow)}
+                    </tbody>
+                </table>
+            );
+        }
+        else {
+            subscriptionRows = (
+                <p>
+                    Click "Create Subscription" to receive Jira notifications in this channel.
+                </p>
+            );
+        }
 
         return (
             <div>


### PR DESCRIPTION
## Summary
This PR adds placeholder text when a user tries to select a subscription but none exist.

#### Ticket Link
Fixes #426
