### PR TITLE
MM-16948 Check if Jira server url actually is a Jira Cloud URL

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -360,6 +360,13 @@ func executeInstallServer(p *Plugin, c *plugin.Context, header *model.CommandArg
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
+	isJiraCloudURL, err := utils.IsJiraCloudURL(jiraURL)
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
+	if isJiraCloudURL {
+		return p.responsef(header, "The Jira URL you provided looks like a Jira Cloud URL - install it with:\n```\n/jira install cloud %s\n```", jiraURL)
+	}
 
 	const addResponseFormat = `` +
 		`Server instance has been installed. To finish the configuration, add an Application Link in your Jira instance following these steps:

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -55,3 +55,11 @@ func Map(vs []string, f func(string) string) []string {
 	}
 	return vsm
 }
+
+func IsJiraCloudURL(jiraURL string) (bool, error) {
+	u, err := url.Parse(jiraURL)
+	if err != nil {
+		return false, err
+	}
+	return strings.HasSuffix(u.Hostname(), ".atlassian.net"), nil
+}

--- a/server/utils/utils_test.go
+++ b/server/utils/utils_test.go
@@ -138,3 +138,13 @@ func TestByteSizeString(t *testing.T) {
 		})
 	}
 }
+
+func TestIsJiraCloudURL(t *testing.T) {
+	cloudLinkIsCloud, err := IsJiraCloudURL("https://mmtest.atlassian.net")
+	require.Nil(t, err)
+	assert.True(t, cloudLinkIsCloud)
+
+	serverLinkIsCloud, err := IsJiraCloudURL("https://somelink.com:1234/jira")
+	require.Nil(t, err)
+	assert.False(t, serverLinkIsCloud)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
If Jira instance is being installed as a server instance but the URL looks like a Jira Cloud URL, return a friendly error message with a hint.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/425
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

