### PR TITLE
[MM-20281] Show channel name at the top of subscription modal when editing a subscription

### DIFF
--- a/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
+++ b/webapp/src/components/modals/channel_settings/__snapshots__/edit_channel_settings.test.tsx.snap
@@ -8,7 +8,11 @@ exports[`components/EditChannelSettings should match snapshot 1`] = `
     className="margin-bottom x3 text-center"
   >
     <h2>
-      Add Jira Subscription
+      Add Jira Subscription in
+       
+      <strong>
+        FGFG
+      </strong>
     </h2>
   </div>
   <div
@@ -184,7 +188,11 @@ exports[`components/EditChannelSettings should match snapshot after fetching iss
     className="margin-bottom x3 text-center"
   >
     <h2>
-      Add Jira Subscription
+      Add Jira Subscription in
+       
+      <strong>
+        FGFG
+      </strong>
     </h2>
   </div>
   <div
@@ -3754,7 +3762,11 @@ exports[`components/EditChannelSettings should match snapshot with no issue meta
     className="margin-bottom x3 text-center"
   >
     <h2>
-      Add Jira Subscription
+      Add Jira Subscription in
+       
+      <strong>
+        FGFG
+      </strong>
     </h2>
   </div>
   <div
@@ -3930,7 +3942,11 @@ exports[`components/EditChannelSettings should match snapshot with no subscripti
     className="margin-bottom x3 text-center"
   >
     <h2>
-      Add Jira Subscription
+      Add Jira Subscription in
+       
+      <strong>
+        FGFG
+      </strong>
     </h2>
   </div>
   <div
@@ -4084,7 +4100,11 @@ exports[`components/EditChannelSettings should produce subscription error when a
     className="margin-bottom x3 text-center"
   >
     <h2>
-      Add Jira Subscription
+      Add Jira Subscription in
+       
+      <strong>
+        FGFG
+      </strong>
     </h2>
   </div>
   <div

--- a/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/edit_channel_settings.tsx
@@ -454,7 +454,7 @@ export default class EditChannelSettings extends PureComponent<Props, State> {
                 role='form'
             >
                 <div className='margin-bottom x3 text-center'>
-                    <h2>{'Add Jira Subscription'}</h2>
+                    <h2>{'Add Jira Subscription in'} <strong>{this.props.channel.display_name}</strong></h2>
                 </div>
                 <div style={style.modalBody}>
                     {component}


### PR DESCRIPTION
**Summary**

MM-20281 - Show channel name at the top of subscription modal when editing a subscription 

**Ticket Link**
[https://mattermost.atlassian.net/browse/MM-20281](https://mattermost.atlassian.net/browse/MM-20281)

Fixes #424 