### PR TITLE
bump go version from 1.12 to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-plugin-jira
 
-go 1.12
+go 1.13
 
 require (
 	github.com/andygrunwald/go-jira v1.10.0


### PR DESCRIPTION
### Summary 
This ticket bumps the go version.

The bump was initially a request to adjust the `mattermost-server` references to `/v5`.  Looking into the imports, I did not see any references other than `/v5`

I used the following to extract any `mattermost-server` imports.
`rg mattermost-server | grep -v 'mattermost-server/v5'`

https://github.com/mattermost/mattermost-plugin-jira/issues/452