### PR TITLE
Add unassign slash command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -18,6 +18,7 @@ const helpTextHeader = "###### Mattermost Jira Plugin - Slash Command Help\n"
 const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to your Jira account\n" +
 	"* `/jira disconnect` - Disconnect your Mattermost account from your Jira account\n" +
 	"* `/jira assign <issue-key> <assignee>` - Change the assignee of a Jira issue\n" +
+	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
@@ -57,6 +58,7 @@ var jiraCommandHandler = CommandHandler{
 		"settings":           executeSettings,
 		"transition":         executeTransition,
 		"assign":             executeAssign,
+		"unassign":           executeUnassign,
 		"uninstall/cloud":    executeUninstallCloud,
 		"uninstall/server":   executeUninstallServer,
 		"webhook":            executeWebhookURL,
@@ -517,6 +519,20 @@ func executeUninstallServer(p *Plugin, c *plugin.Context, header *model.CommandA
 	const uninstallInstructions = `Jira instance successfully disconnected. Go to **Settings > Applications > Application Links** to remove the application in your Jira Server or Data Center instance.`
 
 	return p.responsef(header, uninstallInstructions)
+}
+
+func executeUnassign(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	if len(args) < 1 {
+		return p.responsef(header, "Please specify an issue key in the form `/jira unassign <issue-key>`.")
+	}
+	issueKey := strings.ToUpper(args[0])
+
+	msg, err := p.unassignJiraIssue(header.UserId, issueKey)
+	if err != nil {
+		return p.responsef(header, "%v", err)
+	}
+
+	return p.responsef(header, msg)
 }
 
 func executeAssign(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/issue.go
+++ b/server/issue.go
@@ -739,6 +739,9 @@ func (p *Plugin) unassignJiraIssue(mmUserId, issueKey string) (string, error) {
 	}
 
 	if err := client.UpdateAssignee(issueKey, &jira.User{}); err != nil {
+		if StatusCode(err) == http.StatusForbidden {
+			return "You do not have the appropriate permissions to perform this action. Please contact your Jira administrator.", nil
+		}
 		return "", err
 	}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -715,6 +715,39 @@ func (p *Plugin) getIssueAsSlackAttachment(ji Instance, jiraUser JIRAUser, issue
 	return parseIssue(issue), nil
 }
 
+func (p *Plugin) unassignJiraIssue(mmUserId, issueKey string) (string, error) {
+	ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
+	if err != nil {
+		return "", err
+	}
+
+	jiraUser, err := ji.GetPlugin().userStore.LoadJIRAUser(ji, mmUserId)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := ji.GetClient(jiraUser)
+	if err != nil {
+		return "", err
+	}
+
+	// check for valid issue key
+	_, err = client.GetIssue(issueKey, nil)
+	if err != nil {
+		errorMsg := fmt.Sprintf("We couldn't find the issue key `%s`.  Please confirm the issue key and try again.", issueKey)
+		return errorMsg, nil
+	}
+
+	if err := client.UpdateAssignee(issueKey, &jira.User{}); err != nil {
+		return "", err
+	}
+
+	permalink := fmt.Sprintf("%v/browse/%v", ji.GetURL(), issueKey)
+
+	msg := fmt.Sprintf("Unassigned Jira issue [%s](%s)", issueKey, permalink)
+	return msg, nil
+}
+
 const MinUserSearchQueryLength = 3
 
 func (p *Plugin) assignJiraIssue(mmUserId, issueKey, userSearch string) (string, error) {


### PR DESCRIPTION
#### Summary
This PR adds the `/jira unassign` slash command.

#### Command testing cases
A) When successful, the command does two things:
- [x] removes the assignee of a Jira issue.
- [x] sends an ephemeral message back to the channel the user posted their command with text
		Unassigned Jira issue <issueKey>

B) The following is a list of error cases and the returned ephemeral message. The ephemeral message should have the same profile picture and username as other messages posted by the Jira plugin.

- [x] if user doesn't have permissions for the action, return ephemeral message "You do not have the appropriate permissions to perform this action. Please contact your Jira administrator.
- [x] if "/jira unassign" is posted, return ephemeral message "Please specify an issue key in the form /jira unassign <issue-key>"
- [x] if it is not found, return ephemeral message "We couldn't find the issue key. Please confirm the issue key and try again."

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-jira/issues/92