### PR TITLE
[MM-17816] Reporter is not automatically set for `/jira create` on Jira Server, when required field is missing

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -306,7 +306,11 @@ func MakeCreateIssueURL(ji Instance, project *jira.Project, issue *jira.Issue) s
 	q.Add("issuetype", issue.Fields.Type.ID)
 	q.Add("summary", issue.Fields.Summary)
 	q.Add("description", issue.Fields.Description)
-	q.Add("reporter", issue.Fields.Reporter.Name)
+
+	// Add reporter for only server instances
+	if ji.GetType() == JIRATypeServer {
+		q.Add("reporter", issue.Fields.Reporter.Name)
+	}
 
 	// if no priority, ID field does not exist
 	if issue.Fields.Priority != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -306,6 +306,7 @@ func MakeCreateIssueURL(ji Instance, project *jira.Project, issue *jira.Issue) s
 	q.Add("issuetype", issue.Fields.Type.ID)
 	q.Add("summary", issue.Fields.Summary)
 	q.Add("description", issue.Fields.Description)
+	q.Add("reporter", issue.Fields.Reporter.Name)
 
 	// if no priority, ID field does not exist
 	if issue.Fields.Priority != nil {


### PR DESCRIPTION
**Summary**

[MM-17816] Reporter is not automatically set for `/jira create` on Jira Server, when required field is missing

**Ticket Link**
[https://mattermost.atlassian.net/browse/MM-19256](https://mattermost.atlassian.net/browse/MM-19256)

Fixes #393  

[MM-17816]: https://mattermost.atlassian.net/browse/MM-17816