### PR TITLE
[GH-167] Render JIRA webhook comments as quoted messages

### DIFF
--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -38,6 +38,7 @@ type testWebhookWrapper struct {
 func (wh testWebhookWrapper) Events() StringSet {
 	return wh.Webhook.Events()
 }
+
 func (wh *testWebhookWrapper) PostToChannel(p *Plugin, channelId, fromUserId string) (*model.Post, int, error) {
 	post, status, err := wh.Webhook.PostToChannel(p, channelId, fromUserId)
 	if post != nil {
@@ -308,14 +309,14 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-cloud-comment-created.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **commented** on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
-			ExpectedText:            "Added a comment",
+			ExpectedText:            "> Added a comment",
 			CurrentInstance:         true,
 		},
 		"CLOUD comment updated": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-updated.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **edited comment** in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
-			ExpectedText:            "Added a comment, then edited it",
+			ExpectedText:            "> Added a comment, then edited it",
 			CurrentInstance:         true,
 		},
 		"CLOUD comment deleted": {
@@ -327,14 +328,14 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-1.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "unik",
+			ExpectedText:            "> unik",
 			CurrentInstance:         true,
 		},
 		"SERVER (old version) issue commented (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-commented.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "unik",
+			ExpectedText:            "> unik",
 			CurrentInstance:         true,
 		},
 		"SERVER issue comment deleted": {
@@ -353,21 +354,21 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-comment-edited.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "and higher eeven higher",
+			ExpectedText:            "> and higher eeven higher",
 			CurrentInstance:         true,
 		},
 		"SERVER (old version) issue comment edited (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-comment-edited.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "and higher eeven higher",
+			ExpectedText:            "> and higher eeven higher",
 			CurrentInstance:         true,
 		},
 		"SERVER issue commented notify": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-2.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **commented** on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
-			ExpectedText:            "This is a test comment. We should act on it right away.",
+			ExpectedText:            "> This is a test comment. We should act on it right away.",
 			CurrentInstance:         true,
 		},
 		"SERVER: ignored comment created": {
@@ -543,14 +544,14 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-cloud-comment-created.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **commented** on story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
-			ExpectedText:            "Added a comment",
+			ExpectedText:            "> Added a comment",
 			CurrentInstance:         false,
 		},
 		"CLOUD comment updated - no Instance": {
 			Request:                 testWebhookRequest("webhook-cloud-comment-updated.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **edited comment** in story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
-			ExpectedText:            "Added a comment, then edited it",
+			ExpectedText:            "> Added a comment, then edited it",
 			CurrentInstance:         false,
 		},
 		"CLOUD comment deleted - no Instance": {
@@ -562,7 +563,7 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-1.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **commented** on story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "unik",
+			ExpectedText:            "> unik",
 			CurrentInstance:         false,
 		},
 		"SERVER issue comment deleted - no Instance": {
@@ -575,14 +576,14 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-comment-edited.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Lev Brouk **edited comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
-			ExpectedText:            "and higher eeven higher",
+			ExpectedText:            "> and higher eeven higher",
 			CurrentInstance:         false,
 		},
 		"SERVER issue commented notify - no Instance": {
 			Request:                 testWebhookRequest("webhook-server-issue-updated-commented-2.json"),
 			ExpectedSlackAttachment: true,
 			ExpectedHeadline:        "Test User **commented** on improvement [PRJA-42: test for notifications](http://test-server.azure.com:8080/browse/PRJA-42)",
-			ExpectedText:            "This is a test comment. We should act on it right away.",
+			ExpectedText:            "> This is a test comment. We should act on it right away.",
 			CurrentInstance:         false,
 		},
 		"SERVER: ignored comment created - no Instance": {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -242,7 +242,7 @@ func parseWebhookCommentCreated(jwh *JiraWebhook) (Webhook, error) {
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventCreatedComment),
 		headline:    fmt.Sprintf("%s **commented** on %s", commentAuthor, jwh.mdKeySummaryLink()),
-		text:        truncate(jwh.Comment.Body, 3000),
+		text:        truncate(quoteIssueComment(jwh.Comment.Body), 3000),
 	}
 
 	appendCommentNotifications(wh, "**mentioned** you in a new comment on")
@@ -309,6 +309,10 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	})
 }
 
+func quoteIssueComment(comment string) string {
+	return fmt.Sprintf("> %s", comment)
+}
+
 func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {
 	if jwh.Issue.ID == "" {
 		return nil, ErrWebhookIgnored
@@ -341,7 +345,7 @@ func parseWebhookCommentUpdated(jwh *JiraWebhook) (Webhook, error) {
 		JiraWebhook: jwh,
 		eventTypes:  NewStringSet(eventUpdatedComment),
 		headline:    fmt.Sprintf("%s **edited comment** in %s", mdUser(&jwh.Comment.UpdateAuthor), jwh.mdKeySummaryLink()),
-		text:        truncate(jwh.Comment.Body, 3000),
+		text:        truncate(quoteIssueComment(jwh.Comment.Body), 3000),
 	}
 
 	appendCommentNotifications(wh, "**mentioned** you in a comment update on")

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -116,4 +117,22 @@ func TestJiraLink(t *testing.T) {
 
 	jwh.Issue.Self = "http://localhost:8080/foo/bar/rest/api/2/issue/10006"
 	assert.Equal(t, "[1](http://localhost:8080/foo/bar/QWERTY)", jwh.mdJiraLink("1", "/QWERTY"))
+}
+
+func TestWebhookQuotedComment(t *testing.T) {
+	for _, value := range []string{
+		"testdata/webhook-server-issue-updated-commented-3.json",
+		"testdata/webhook-server-issue-updated-comment-edited.json",
+	} {
+		f, err := os.Open(value)
+		require.NoError(t, err)
+		defer f.Close()
+		bb, err := ioutil.ReadAll(f)
+		require.Nil(t, err)
+		wh, err := ParseWebhook(bb)
+		require.NoError(t, err)
+		w := wh.(*webhook)
+		require.NotNil(t, w)
+		assert.True(t, strings.HasPrefix(w.text, ">"))
+	}
 }


### PR DESCRIPTION
#### Summary
This PR changes webhook handling for events of type "issue commented" and "issue comment edited" in order to render them as quoted messages in Mattermost.

Thanks for reviewing!

#### Screenshots

##### Issue commented
Before
![image](https://user-images.githubusercontent.com/450960/73955776-2e144a80-4904-11ea-988a-0cc562492396.png)

After
![image](https://user-images.githubusercontent.com/450960/73955820-44baa180-4904-11ea-88fb-a4a1dc02acc6.png)

##### Issue comment edited
Before
![image](https://user-images.githubusercontent.com/450960/73955864-57cd7180-4904-11ea-9214-570eb7edb41c.png)

After
![image](https://user-images.githubusercontent.com/450960/73955883-61ef7000-4904-11ea-8ade-9ba2084667d7.png)

#### Ticket Link
Fixes #167.
