### PR TITLE
[GH-145] Add link to ephemeral message after uninstall

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -441,18 +441,18 @@ func executeUninstall(p *Plugin, c *plugin.Context, header *model.CommandArgs, a
 		return p.responsef(header, "No current Jira instance to uninstall")
 	}
 
-	instanceType := args[0]
 	var ok bool
-	if instanceType == "cloud" {
+	switch args[0] {
+	case "cloud":
 		_, ok = ji.(*jiraCloudInstance)
-	} else if instanceType == "server" {
+	case "server":
 		_, ok = ji.(*jiraServerInstance)
-	} else {
+	default:
 		return p.help(header)
 	}
 
 	if !ok {
-		return p.responsef(header, fmt.Sprintf("The current Jira instance is not a %s instance", instanceType))
+		return p.responsef(header, fmt.Sprintf("The current Jira instance is not a %s instance", args[0]))
 	}
 
 	if jiraURL != ji.GetURL() {

--- a/server/command.go
+++ b/server/command.go
@@ -480,14 +480,8 @@ func executeUninstall(p *Plugin, c *plugin.Context, header *model.CommandArgs, i
 		&model.WebsocketBroadcast{},
 	)
 
-	var uninstallInstructions string
-	if instanceType == "cloud" {
-		uninstallInstructions = `Jira instance successfully disconnected. Go to [**Settings > Apps > Manage Apps**](%s/plugins/servlet/upm) to remove the application in your Jira Cloud instance.`
-	} else {
-		uninstallInstructions = `Jira instance successfully disconnected. Go to [**Settings > Applications > Application Links**](%s/plugins/servlet/applinks/listApplicationLinks) to remove the application in your Jira Server or Data Center instance.`
-	}
-
-	return p.responsef(header, uninstallInstructions, jiraURL)
+	uninstallInstructions := `Jira instance successfully disconnected. Go to [**the respective app management URL**](%s) to remove the application from your Jira instance.`
+	return p.responsef(header, uninstallInstructions, ji.GetManageAppsURL())
 }
 
 func executeUnassign(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -474,7 +474,7 @@ func executeUninstall(p *Plugin, c *plugin.Context, header *model.CommandArgs, a
 		&model.WebsocketBroadcast{},
 	)
 
-	uninstallInstructions := `Jira instance successfully disconnected. Navigate to [**your app management URL**](%s) in order to remove the application from your Jira instance.`
+	uninstallInstructions := `Jira instance successfully uninstalled. Navigate to [**your app management URL**](%s) in order to remove the application from your Jira instance.`
 	return p.responsef(header, uninstallInstructions, ji.GetManageAppsURL())
 }
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -268,7 +268,7 @@ func TestPlugin_ExecuteCommand_Uninstall(t *testing.T) {
 		},
 		"no params - user is not sys admin": {
 			commandArgs:       &model.CommandArgs{Command: "/jira uninstall", UserId: mockUserIDNonSysAdmin},
-			expectedMsgPrefix: strings.TrimSpace(helpTextHeader + commonHelpText),
+			expectedMsgPrefix: "`/jira uninstall` can only be run by a System Administrator.",
 		},
 		"uninstall with invalid option": {
 			commandArgs:       &model.CommandArgs{Command: "/jira uninstall foo", UserId: mockUserIDSysAdmin},

--- a/server/instance.go
+++ b/server/instance.go
@@ -26,6 +26,7 @@ type Instance interface {
 	GetType() string
 	GetURL() string
 	GetUserConnectURL(mattermostUserId string) (string, error)
+	GetManageAppsURL() string
 	Init(p *Plugin)
 }
 

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -118,6 +118,10 @@ func (jci jiraCloudInstance) GetURL() string {
 	return jci.AtlassianSecurityContext.BaseURL
 }
 
+func (jci jiraCloudInstance) GetManageAppsURL() string {
+	return fmt.Sprintf("%s/plugins/servlet/upm", jci.GetURL())
+}
+
 func (jci jiraCloudInstance) GetClient(jiraUser JIRAUser) (Client, error) {
 	client, _, err := jci.getJIRAClientForUser(jiraUser)
 	if err != nil {

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/andygrunwald/go-jira"
@@ -37,6 +38,10 @@ func NewJIRAServerInstance(p *Plugin, jiraURL string) Instance {
 
 func (jsi jiraServerInstance) GetURL() string {
 	return jsi.JIRAServerURL
+}
+
+func (jsi jiraServerInstance) GetManageAppsURL() string {
+	return fmt.Sprintf("%s/plugins/servlet/applinks/listApplicationLinks", jsi.GetURL())
 }
 
 type withServerInstanceFunc func(jsi *jiraServerInstance, w http.ResponseWriter, r *http.Request) (int, error)

--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -30,6 +30,9 @@ func keyWithMockInstance(key string) string {
 func (jti jiraTestInstance) GetURL() string {
 	return mockCurrentInstanceURL
 }
+func (jti jiraTestInstance) GetManageAppsURL() string {
+	return fmt.Sprintf("%s/apps/manage", mockCurrentInstanceURL)
+}
 func (jti jiraTestInstance) GetPlugin() *Plugin {
 	return &Plugin{userStore: mockUserStore{}}
 }


### PR DESCRIPTION
#### Summary
This PR links the appropriate Jira settings page after `uninstall cloud|server` is successful. I took the liberty to perform some refactoring so only one function is used to perform the uninstall.

I have also added a test with basic cases. My original intent was to have more tests but I am not sure about the best way to setup a test for the `uninstall` command.

Thanks for reviewing!

#### Screenshots

![image](https://user-images.githubusercontent.com/450960/74112429-db08f480-4b9c-11ea-8ba8-f9e168ed04da.png)

![image](https://user-images.githubusercontent.com/450960/74112437-e6f4b680-4b9c-11ea-994b-046f0203d094.png)

#### Ticket Link
Fixes #145.
