### PR TITLE
MM-22063 Adding create ticket action support for workflow.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/mattermost/mattermost-plugin-autolink v1.1.3-0.20200203183014-8c82b7dc7fa6
-	github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200121183617-b71061053ec5
+	github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200225165807-b0524a245156
 	github.com/mattermost/mattermost-server/v5 v5.19.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/mattermost-plugin-autolink v1.1.3-0.20200203183014-8c82b7dc7fa6 h1:J4DalaElqXZqxO3OWJ+PPB+pxNxgxnp7TK1pkrHYhgs=
 github.com/mattermost/mattermost-plugin-autolink v1.1.3-0.20200203183014-8c82b7dc7fa6/go.mod h1:r81Jho0lQEPfWAW7vd+EANOrIBsb228YNYnTf273vcM=
-github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200121183617-b71061053ec5 h1:7MIAQ618c6csSq2X3NtDX4ILwAiOjq06yJxVp3WXlBo=
-github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200121183617-b71061053ec5/go.mod h1:k4WZVXIMH2tWqNJU2WGBeZWisCDqcKVMgnQL8bon0FA=
+github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200225165807-b0524a245156 h1:Ho24RSSgngHqmB2ZfW+glATecTPS8Ek/937dAZIvH9o=
+github.com/mattermost/mattermost-plugin-workflow-client v0.0.0-20200225165807-b0524a245156/go.mod h1:k4WZVXIMH2tWqNJU2WGBeZWisCDqcKVMgnQL8bon0FA=
 github.com/mattermost/mattermost-server/v5 v5.18.0/go.mod h1:10vIYDohcPNDMDk3XlRUjNO9nGk9fnFHEFeSIUYR82k=
 github.com/mattermost/mattermost-server/v5 v5.19.0 h1:5hLPxmgvxjpMu7DTNTnqnuFjfQcGCKNUP1MOvoT5MkM=
 github.com/mattermost/mattermost-server/v5 v5.19.0/go.mod h1:10vIYDohcPNDMDk3XlRUjNO9nGk9fnFHEFeSIUYR82k=

--- a/server/http.go
+++ b/server/http.go
@@ -45,6 +45,7 @@ const (
 	routeUserDisconnect            = "/user/disconnect"
 	routeWorkflowRegister          = "/workflow/meta"
 	routeWorkflowTriggerSetup      = "/workflow/trigger_setup"
+	routeWorkflowCreateIssue       = "/workflow/create_issue"
 )
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
@@ -142,6 +143,12 @@ func handleHTTPRequest(p *Plugin, c *plugin.Context, w http.ResponseWriter, r *h
 				return httpWorkflowTriggerSetup(p, w, r)
 			}
 		}
+	case routeWorkflowCreateIssue:
+		{
+			if c.SourcePluginId != "" {
+				return withInstance(p.currentInstanceStore, w, r, httpWorkflowCreateIssue)
+			}
+		}
 	}
 
 	if strings.HasPrefix(r.URL.Path, routeAPISubscriptionsChannel) {
@@ -193,6 +200,15 @@ func httpWorkflowRegister(p *Plugin, w http.ResponseWriter, r *http.Request) (in
 					},
 				},
 				TriggerSetupURL: "/jira" + routeWorkflowTriggerSetup,
+			},
+		},
+		Actions: []workflowclient.ActionParams{
+			{
+				TypeName:    "create",
+				DisplayName: "Jira Create",
+				Fields:      []workflowclient.Field{},
+				VarInfos:    []workflowclient.VarInfo{},
+				URL:         "/jira" + routeWorkflowCreateIssue,
 			},
 		},
 	}

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -154,7 +154,7 @@ func (jci jiraCloudInstance) getJIRAClientForUser(jiraUser JIRAUser) (*jira.Clie
 }
 
 // Creates a "bot" client with a JWT
-func (jci jiraCloudInstance) getJIRAClientForServer() (*jira.Client, error) {
+func (jci jiraCloudInstance) getJIRAClientForBot() (*jira.Client, error) {
 	conf := jci.GetPlugin().getConfig()
 	jwtConf := &ajwt.Config{
 		Key:          jci.AtlassianSecurityContext.Key,

--- a/server/issue.go
+++ b/server/issue.go
@@ -251,7 +251,7 @@ func httpWorkflowCreateIssue(ji Instance, w http.ResponseWriter, r *http.Request
 			return http.StatusBadRequest, errors.New("UserId is required for jira server instances.")
 		}
 
-		jiraClient, err := jci.getJIRAClientForServer()
+		jiraClient, err := jci.getJIRAClientForBot()
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("unable to get jira client for server: %w", err)
 		}
@@ -656,7 +656,7 @@ func (p *Plugin) getIssueDataForCloudWebhook(ji Instance, issueKey string) (*jir
 		return nil, errors.New("Must be a JIRA Cloud instance, is " + ji.GetType())
 	}
 
-	jiraClient, err := jci.getJIRAClientForServer()
+	jiraClient, err := jci.getJIRAClientForBot()
 	if err != nil {
 		return nil, err
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -245,7 +245,7 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) AddAutolinksForCloudInstance(jci *jiraCloudInstance) error {
-	client, err := jci.getJIRAClientForServer()
+	client, err := jci.getJIRAClientForBot()
 	if err != nil {
 		return fmt.Errorf("unable to get jira client for server: %w", err)
 	}


### PR DESCRIPTION
#### Summary
Support for creating tickets with workflows. Example action that creates a JIRA ticket as the plugin.:

```json
{
    "name": "MakeTicket",
    "type": "jira_create",
    "user_id": "",
    "fields": {
        "project": {
            "key": "EXT"
        },
        "issuetype": {
            "name": "Bug"
        },
        "summary": "This is a test ticket from workflow {{.Instance.Number}}",
        "description": "Message: {{.Trigger.TestTrigger.Message}}"
    }
}
```

Creating tickets as the plugin only works on JIRA cloud. Creating tickets as the user should work on both. 

Requires: https://github.com/mattermost/mattermost-plugin-workflow/pull/71