### PR TITLE
MM-19674: use respondXXX in http handlers

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -219,7 +219,7 @@ func httpWorkflowTriggerSetup(p *Plugin, w http.ResponseWriter, r *http.Request)
 
 	if params.BaseTrigger.BaseType != "jira_event" {
 		return respondErr(w, http.StatusBadRequest,
-			errors.New("Unsupported trigger type."))
+			errors.New("Unsupported trigger type"))
 	}
 
 	var trigger WorkflowTrigger

--- a/server/instance.go
+++ b/server/instance.go
@@ -77,7 +77,7 @@ type withInstanceFunc func(ji Instance, w http.ResponseWriter, r *http.Request) 
 func withInstance(store CurrentInstanceStore, w http.ResponseWriter, r *http.Request, f withInstanceFunc) (int, error) {
 	ji, err := store.LoadCurrentJIRAInstance()
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return respondErr(w, http.StatusInternalServerError, err)
 	}
 	return f(ji, w, r)
 }

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -66,7 +66,7 @@ func withCloudInstance(p *Plugin, w http.ResponseWriter, r *http.Request, f with
 	return withInstance(p.currentInstanceStore, w, r, func(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
 		jci, ok := ji.(*jiraCloudInstance)
 		if !ok {
-			return http.StatusBadRequest, errors.New("Must be a JIRA Cloud instance, is " + ji.GetType())
+			return respondErr(w, http.StatusBadRequest, errors.New("Must be a JIRA Cloud instance, is "+ji.GetType()))
 		}
 		return f(jci, w, r)
 	})

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -45,7 +45,7 @@ func withServerInstance(p *Plugin, w http.ResponseWriter, r *http.Request, f wit
 	return withInstance(p.currentInstanceStore, w, r, func(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
 		jsi, ok := ji.(*jiraServerInstance)
 		if !ok {
-			return http.StatusBadRequest, errors.New("Must be a Jira Server instance, is " + ji.GetType())
+			return respondErr(w, http.StatusBadRequest, errors.New("Must be a Jira Server instance, is "+ji.GetType()))
 		}
 		return f(jsi, w, r)
 	})

--- a/server/issue.go
+++ b/server/issue.go
@@ -165,7 +165,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 		}
 
 		return respondErr(w, http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to create issue. %s"))
+			errors.WithMessage(err, "failed to create issue"))
 	}
 
 	// Reply with an ephemeral post with the Jira issue formatted as slack attachment.

--- a/server/stats.go
+++ b/server/stats.go
@@ -50,24 +50,25 @@ func (p *Plugin) initStats() {
 
 func httpAPIStats(p *Plugin, w http.ResponseWriter, r *http.Request) (int, error) {
 	if r.Method != http.MethodGet {
-		return http.StatusMethodNotAllowed,
-			errors.New("method " + r.Method + " is not allowed, must be GET")
+		return respondErr(w, http.StatusMethodNotAllowed,
+			errors.New("method "+r.Method+" is not allowed, must be GET"))
 	}
 	conf := p.getConfig()
 
 	isAdmin, err := authorizedSysAdmin(p, r.Header.Get("Mattermost-User-Id"))
 	if !isAdmin {
 		if conf.StatsSecret == "" {
-			return http.StatusForbidden, errors.New("Access forbidden: must be authenticated as an admin, or provide the stats API secret.")
+			return respondErr(w, http.StatusForbidden,
+				errors.New("Access forbidden: must be authenticated as an admin, or provide the stats API secret."))
 		}
 		var status int
 		status, err = verifyHTTPSecret(conf.StatsSecret, r.FormValue("secret"))
 		if err != nil {
-			return status, err
+			return respondErr(w, status, err)
 		}
 	}
 	if conf.stats == nil {
-		return http.StatusNotFound, errors.New("No stats available")
+		return respondErr(w, http.StatusNotFound, errors.New("No stats available"))
 	}
 
 	out := "{"


### PR DESCRIPTION
#### Summary
There was some funky error handling in http functions, streamlined it, should now consistently use `respondErr` when returning errors in http handlers.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-19674