### PR TITLE
MM-21696: New config setting: Hide issue descriptions and comments

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -79,6 +79,13 @@
         "type": "text",
         "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
         "default": ""
+      },
+      {
+        "key": "HideDecriptionComment",
+        "display_name": "Hide issue descriptions and comments",
+        "type": "bool",
+        "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
+        "default": false
       }
     ],
     "footer": "Use this webhook URL format to [configure the Jira integration.](https://about.mattermost.com/default-jira-plugin)  `https://SITEURL/plugins/jira/api/v2/webhook?secret=WEBHOOKSECRET`"

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -67,6 +67,9 @@ type externalConfig struct {
 
 	// Additional Help Text to be shown in the output of '/jira help' command
 	JiraAdminAdditionalHelpText string
+
+	// Hide issue descriptions and comments in Webhook and Subscription messages
+	HideDecriptionComment bool
 }
 
 const currentInstanceTTL = 1 * time.Second

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -59,7 +59,7 @@ func (wh webhook) PostToChannel(p *Plugin, channelId, fromUserId string) (*model
 	}
 
 	text := ""
-	if !p.getConfig().HideDecriptionComment && wh.text != "" {
+	if wh.text != "" && !p.getConfig().HideDecriptionComment {
 		text = wh.text
 		// Get instance for replacing accountids in text. If no instance is available, just skip it.
 		ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -56,25 +56,26 @@ func (wh webhook) PostToChannel(p *Plugin, channelId, fromUserId string) (*model
 	post := &model.Post{
 		ChannelId: channelId,
 		UserId:    fromUserId,
-		// Props: map[string]interface{}{
-		// 	"from_webhook":  "true",
-		// 	"use_user_icon": "true",
-		// },
 	}
-	if wh.text != "" || len(wh.fields) != 0 {
+
+	text := ""
+	if !p.getConfig().HideDecriptionComment && wh.text != "" {
+		text = wh.text
 		// Get instance for replacing accountids in text. If no instance is available, just skip it.
 		ji, err := p.currentInstanceStore.LoadCurrentJIRAInstance()
 		if err == nil {
-			wh.text = replaceJiraAccountIds(ji, wh.text)
+			text = replaceJiraAccountIds(ji, text)
 		}
+	}
 
+	if text != "" || len(wh.fields) != 0 {
 		model.ParseSlackAttachment(post, []*model.SlackAttachment{
 			{
 				// TODO is this supposed to be themed?
 				Color:    "#95b7d0",
 				Fallback: wh.headline,
 				Pretext:  wh.headline,
-				Text:     wh.text,
+				Text:     text,
 				Fields:   wh.fields,
 			},
 		})


### PR DESCRIPTION
#### Summary
Added a config option to drop issue description and comment bodies from webhook and subscription posts. They should continue displaying in DMs and ephemeral posts without changes.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-21696

Config: 
![image](https://user-images.githubusercontent.com/1187448/77022072-d70f8580-6945-11ea-83a1-77d1e5d78cd5.png)

Hide ON:
![image](https://user-images.githubusercontent.com/1187448/77022096-ebec1900-6945-11ea-82ea-e16c4bc27042.png)

Hide OFF (default) as before,
![image](https://user-images.githubusercontent.com/1187448/77022121-fc9c8f00-6945-11ea-9974-4efd0e436e74.png)
