### PR TITLE
rename `respondErr` function

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -22,22 +22,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-jira/server/utils"
 )
 
-func makePost(userId, channelId, message string) *model.Post {
-	return &model.Post{
-		UserId:    userId,
-		ChannelId: channelId,
-		Message:   message,
-	}
-}
-
-func respondEphemeralErr(plugin *Plugin, status int, e error, mmuserID, jiraBotID, channelID, message string) (int, error) {
-	_ = plugin.API.SendEphemeralPost(mmuserID, makePost(jiraBotID, channelID, message))
-	if e != nil {
-		return status, e
-	}
-	return status, errors.New(message)
-}
-
 func httpAPITransitionIssue(ji Instance, w http.ResponseWriter, r *http.Request) (int, error) {
 	requestData := model.PostActionIntegrationRequestFromJson(r.Body)
 	if requestData == nil {

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -150,5 +150,5 @@ func TestRouteIssueTransition(t *testing.T) {
 	request.Header.Set("Mattermost-User-Id", "connected_user")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(&plugin.Context{}, w, request)
-	assert.Equal(t, 400, w.Result().StatusCode)
+	assert.Equal(t, 200, w.Result().StatusCode)
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -166,19 +166,3 @@ func parseJIRAIssuesFromText(text string, keys []string) []string {
 
 	return issues
 }
-
-func respondEphemeralErr(plugin *Plugin, status int, e error, mmuserID, jiraBotID, channelID, message string) (int, error) {
-	_ = plugin.API.SendEphemeralPost(mmuserID, makePost(jiraBotID, channelID, message))
-	if e != nil {
-		return status, e
-	}
-	return status, errors.New(message)
-}
-
-func makePost(userId, channelId, message string) *model.Post {
-	return &model.Post{
-		UserId:    userId,
-		ChannelId: channelId,
-		Message:   message,
-	}
-}

--- a/server/utils.go
+++ b/server/utils.go
@@ -166,3 +166,19 @@ func parseJIRAIssuesFromText(text string, keys []string) []string {
 
 	return issues
 }
+
+func respondEphemeralErr(plugin *Plugin, status int, e error, mmuserID, jiraBotID, channelID, message string) (int, error) {
+	_ = plugin.API.SendEphemeralPost(mmuserID, makePost(jiraBotID, channelID, message))
+	if e != nil {
+		return status, e
+	}
+	return status, errors.New(message)
+}
+
+func makePost(userId, channelId, message string) *model.Post {
+	return &model.Post{
+		UserId:    userId,
+		ChannelId: channelId,
+		Message:   message,
+	}
+}


### PR DESCRIPTION
#### Summary
The most recent commit is causing a build error because function `respondErr` exists twice.

The two function signatures are below:
```go
// server/issue.go
func respondErr(w http.ResponseWriter, code int, err error) (int, error) {}

//server/http.go
func respondErr(plugin *Plugin, status int, e error, mmuserID, jiraBotID, channelID, message string) (int, error) {}
```

I've added my suggestion for renaming the function in `issue.go` and chose to rename this function because it is used in fewer locations.

The suggestion is `s/responseErr/respondEphemeralErr/` because this response is specifically sending an ephemeral post.

#### Additional Information
These are the commits that are causing the build failure.
`issue.go` - https://github.com/mattermost/mattermost-plugin-jira/pull/454/files
`http.go` - https://github.com/mattermost/mattermost-plugin-jira/pull/500/files

#### Ticket Link
N/A

