### PR TITLE
[GH-490] Fix connect link on /jira info output

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -537,7 +537,7 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 	case uinfo.IsConnected:
 		resp += fmt.Sprintf("Connected to Jira %s as %s.\n", uinfo.JIRAURL, uinfo.JIRAUser.DisplayName)
 	case uinfo.InstanceInstalled:
-		resp += fmt.Sprintf("Jira %s is installed, but you are not connected. Please [connect](%s/%s).\n",
+		resp += fmt.Sprintf("Jira %s is installed, but you are not connected. Please [connect](%s%s).\n",
 			uinfo.JIRAURL, p.GetPluginURL(), routeUserConnect)
 	default:
 		return p.responsef(header, resp+"\nNo Jira instance installed, please contact your system administrator.")


### PR DESCRIPTION
#### Summary
This PR removes the extra `/` from the connect URL indicated in `/jira info` output when a Jira instance is not yet connected. That seems to be the only place where this URL is constructed so I thought adding new method on `Plugin` wouldn't be necessary.

Alternative solution: `strings.TrimLeft` on `routeUserConnect`.

#### Ticket Link
Fixes #490 
