### PR TITLE
[MM-485] - Update `commonHelpText` and `sysAdminHelpText` to include all slash commands

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -21,10 +21,10 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +	
+	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
-	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +	
-	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +		
+	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +
+	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -24,7 +24,7 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Receive performance metrics and authenticated users between Jira/Mattermost\n" +
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
 	"* `/jira help` - Launch the Jira plugin command line help syntax\n" +
-	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +
+	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -21,7 +21,7 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Receive performance metrics and authenticated users between Jira/Mattermost\n" +
+	"* `/jira stats` - Retrieve version information about the Jira plugin\n" +
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
 	"* `/jira help` - Launch the Jira plugin command line help syntax\n" +
 	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -702,7 +702,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Jira",
 		Description:      "Integration with Jira.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: connect, assign, disconnect, create, transition, stats, info, webhook,  view, subscribe, settings, install cloud/server, uninstall cloud/server, help",
+		AutoCompleteDesc: "Available commands: connect, assign, disconnect, create, transition, info, view, settings, help",
 		AutoCompleteHint: "[command]",
 	}
 }

--- a/server/command.go
+++ b/server/command.go
@@ -21,7 +21,7 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +
+	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Receive performance metrics and authenticated users between Jira/Mattermost\n" +
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
 	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +
 	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -24,7 +24,7 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +	
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
 	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +	
-	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +		
+	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +		
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin" 
+	"github.com/mattermost/mattermost-server/v5/plugin"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/expvar"
 	"github.com/mattermost/mattermost-plugin-jira/server/utils"
@@ -21,10 +21,6 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +	
-	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
-	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +	
-	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +		
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -21,6 +21,10 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
+	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +	
+	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
+	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +	
+	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +		
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -23,7 +23,7 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
 	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Receive performance metrics and authenticated users between Jira/Mattermost\n" +
 	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
-	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +
+	"* `/jira help` - Launch the Jira plugin command line help syntax\n" +
 	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plug-in gets sent a stream of pre-configured events from the Jira server\n" +
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -702,7 +702,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Jira",
 		Description:      "Integration with Jira.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: connect, assign, disconnect, create, transition, view, subscribe, settings, install cloud/server, uninstall cloud/server, help",
+		AutoCompleteDesc: "Available commands: connect, assign, disconnect, create, transition, stats, info, webhook,  view, subscribe, settings, install cloud/server, uninstall cloud/server, help",
 		AutoCompleteHint: "[command]",
 	}
 }

--- a/server/command.go
+++ b/server/command.go
@@ -21,11 +21,8 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
-	"* `/jira stats` - Retrieve version information about the Jira plugin\n" +
-	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
+	"* `/jira info` - Display information about the current user and the Jira plug-in\n" +
 	"* `/jira help` - Launch the Jira plugin command line help syntax\n" +
-	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +
-	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +
 	"  * [setting] can be `notifications`\n" +
@@ -38,7 +35,10 @@ const sysAdminHelpText = "\n###### For System Administrators:\n" +
 	"Uninstall:\n" +
 	"* `/jira uninstall cloud <URL>` - Disconnect Mattermost from a Jira Cloud instance located at <URL>\n" +
 	"* `/jira uninstall server <URL>` - Disconnect Mattermost from a Jira Server or Data Center instance located at <URL>\n" +
-	"* `/jira subscribe list` - List of Jira Notification subscription rules across all channels\n"
+	"* `/jira stats` - Display usage statistics\n" +
+	"* `/jira webhook` -  Configure the Mattermost webhook to receive JQL queries\n" +
+	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
+	"* `/jira subscribe list` - Display all the the subscription rules setup across all the channels and teams on your Mattermost instance\n"
 
 // Available settings
 const (

--- a/server/command.go
+++ b/server/command.go
@@ -36,7 +36,7 @@ const sysAdminHelpText = "\n###### For System Administrators:\n" +
 	"* `/jira uninstall cloud <URL>` - Disconnect Mattermost from a Jira Cloud instance located at <URL>\n" +
 	"* `/jira uninstall server <URL>` - Disconnect Mattermost from a Jira Server or Data Center instance located at <URL>\n" +
 	"* `/jira stats` - Display usage statistics\n" +
-	"* `/jira webhook` -  Configure the Mattermost webhook to receive JQL queries\n" +
+	"* `/jira webhook` -  Show the Mattermost webhook to receive JQL queries\n" +
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira subscribe list` - Display all the the subscription rules setup across all the channels and teams on your Mattermost instance\n"
 

--- a/server/command.go
+++ b/server/command.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v5/plugin" 
 
 	"github.com/mattermost/mattermost-plugin-jira/server/expvar"
 	"github.com/mattermost/mattermost-plugin-jira/server/utils"
@@ -21,6 +21,10 @@ const commonHelpText = "\n* `/jira connect` - Connect your Mattermost account to
 	"* `/jira unassign <issue-key>` - Unassign the Jira issue\n" +
 	"* `/jira create <text (optional)>` - Create a new Issue with 'text' inserted into the description field\n" +
 	"* `/jira transition <issue-key> <state>` - Change the state of a Jira issue\n" +
+	"* `/jira stats` - Poll basic statistics about the Jira plug-in.  Recevie performace metrics and authenticated users between Jira/Mattermost\n" +	
+	"* `/jira info` - Retrieve information about the current user and the Jira plug-in\n" +
+	"* `/jira help` - Launch the Jira plug-in command line help syntax\n" +	
+	"* `/jira webhook` - Execute the Jira plug-in webhook. The Jira plugin gets sent a stream of pre-configured events from the Jira server\n" +		
 	"* `/jira subscribe` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira view <issue-key>` - View the details of a specific Jira issue\n" +
 	"* `/jira settings [setting] [value]` - Update your user settings\n" +


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

*Problem*
jiraCommandHandler contains the mappings of slash commands to their corresponding command handler functions. The following slash commands are missing and should be added to the HelpText variables.

*Resolution*
Mapped the following commands with their descriptions to the handler functions. 
webhook
stats
info
help

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/485


