### PR TITLE
Refactor plugin key generation code

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -298,7 +298,7 @@ func (p *Plugin) GetPluginKey() string {
 	prefix := "mattermost_"
 	escaped := regexpNonAlnum.ReplaceAllString(sURL, "_")
 
-	start := int(math.Min(float64(len(escaped)), 32)) - len(escaped)
+	start := len(escaped) - int(math.Min(float64(len(escaped)), 32))
 	return prefix + escaped[start:]
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -294,13 +295,11 @@ func (p *Plugin) AddAutolinks(key, baseURL string) error {
 
 func (p *Plugin) GetPluginKey() string {
 	sURL := p.GetSiteURL()
-	key := "mattermost_" + regexpNonAlnum.ReplaceAllString(sURL, "_")
-	if len(key) <= 32 {
-		return key
-	}
-	start := len(sURL) - 30
-	end := len(sURL)
-	return "__" + sURL[start:end]
+	prefix := "mattermost_"
+	escaped := regexpNonAlnum.ReplaceAllString(sURL, "_")
+
+	start := int(math.Min(float64(len(escaped)), 32)) - len(escaped)
+	return prefix + escaped[start:]
 }
 
 func (p *Plugin) GetPluginURLPath() string {


### PR DESCRIPTION
#### Summary

This PR improves the generation of the plugin key by making it a bit more deterministic.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/532

@levb This wasn't occurring for you because your ngrok URL is less than 22 chars long. The issue is occurring with URLs that are between 22 and 29 chars long.