### PR TITLE
[GH-529] No attachment text when error happens while uploading attachment

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -633,12 +633,12 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			mattermostName, jiraName, mime, e := client.AddAttachment(api, attach.IssueKey, fileId, conf.maxAttachmentSize)
 			if e != nil {
 				notifyOnFailedAttachment(ji, mattermostUserId, attach.IssueKey, e, "file: %s", mattermostName)
-			}
-
-			if isImageMIME(mime) || isEmbbedableMIME(mime) {
-				extraText += "\n\nAttachment: !" + jiraName + "!"
 			} else {
-				extraText += "\n\nAttachment: [^" + jiraName + "]"
+				if isImageMIME(mime) || isEmbbedableMIME(mime) {
+					extraText += "\n\nAttachment: !" + jiraName + "!"
+				} else {
+					extraText += "\n\nAttachment: [^" + jiraName + "]"
+				}
 			}
 		}
 		if extraText == "" {

--- a/server/issue.go
+++ b/server/issue.go
@@ -633,13 +633,14 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 			mattermostName, jiraName, mime, e := client.AddAttachment(api, attach.IssueKey, fileId, conf.maxAttachmentSize)
 			if e != nil {
 				notifyOnFailedAttachment(ji, mattermostUserId, attach.IssueKey, e, "file: %s", mattermostName)
-			} else {
-				if isImageMIME(mime) || isEmbbedableMIME(mime) {
-					extraText += "\n\nAttachment: !" + jiraName + "!"
-				} else {
-					extraText += "\n\nAttachment: [^" + jiraName + "]"
-				}
+				continue
 			}
+			if isImageMIME(mime) || isEmbbedableMIME(mime) {
+				extraText += "\n\nAttachment: !" + jiraName + "!"
+			} else {
+				extraText += "\n\nAttachment: [^" + jiraName + "]"
+			}
+
 		}
 		if extraText == "" {
 			return

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -20,6 +20,7 @@ import (
 const (
 	nonExistantIssueKey   = "FAKE-1"
 	noPermissionsIssueKey = "SUDO-1"
+	attachCommentErrorKey = "ATTACH-1"
 	existingIssueKey      = "REAL-1"
 	nonExistantProjectKey = "FP"
 	noIssueFoundError     = "We couldn't find the issue key. Please confirm the issue key and try again. You may not have permissions to access this issue."
@@ -57,6 +58,16 @@ func (client testClient) GetTransitions(issueKey string) ([]jira.Transition, err
 
 func (client testClient) DoTransition(issueKey string, transitionID string) error {
 	return nil
+}
+
+func (client testClient) AddComment(issueKey string, comment *jira.Comment) (*jira.Comment, error) {
+	if issueKey == noPermissionsIssueKey {
+		return nil, errors.New("you do not have the permission to comment on this issue")
+	} else if issueKey == attachCommentErrorKey {
+		return nil, errors.New("Unanticipated error")
+	}
+
+	return nil, nil
 }
 
 func TestTransitionJiraIssue(t *testing.T) {
@@ -193,4 +204,173 @@ func TestRouteIssueTransition(t *testing.T) {
 		})
 	}
 
+}
+
+func TestRouteAttachCommentToIssue(t *testing.T) {
+	api := &plugintest.API{}
+
+	api.On("LogError",
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string")).Return(nil)
+
+	api.On("LogDebug",
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string")).Return(nil)
+
+	siteURL := "https://somelink.com"
+	api.On("GetConfig").Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})
+
+	api.On("GetPost", "error_post").Return(nil, &model.AppError{Id: "1"})
+	api.On("GetPost", "post_not_found").Return(nil, (*model.AppError)(nil))
+
+	api.On("GetPost", "0").Return(&model.Post{UserId: "0"}, (*model.AppError)(nil))
+	api.On("GetUser", "0").Return(nil, &model.AppError{Id: "1"})
+
+	api.On("GetPost", "1").Return(&model.Post{UserId: "1"}, (*model.AppError)(nil))
+	api.On("GetUser", "1").Return(&model.User{Username: "username"}, (*model.AppError)(nil))
+
+	api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(nil, (*model.AppError)(nil))
+
+	p := Plugin{}
+	p.SetAPI(api)
+
+	p.userStore = getMockUserStoreKV()
+	p.currentInstanceStore = mockCurrentInstanceStore{&p}
+
+	tests := map[string]struct {
+		method  string
+		header  string
+		request *struct {
+			PostId      string `json:"post_id"`
+			CurrentTeam string `json:"current_team"`
+			IssueKey    string `json:"issueKey"`
+		}
+		expectedCode int
+	}{
+		"Wrong method": {
+			method:       "GET",
+			header:       "",
+			request:      nil,
+			expectedCode: http.StatusMethodNotAllowed,
+		},
+		"No header": {
+			method:       "POST",
+			header:       "",
+			request:      nil,
+			expectedCode: http.StatusUnauthorized,
+		},
+		"User not found": {
+			method:       "POST",
+			header:       "nobody",
+			request:      nil,
+			expectedCode: http.StatusInternalServerError,
+		},
+		"Failed to load post": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId: "error_post",
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		"Post not found": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId: "post_not_found",
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		"Post user not found": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId: "0",
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		"No permissions to comment on issue": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId:   "1",
+				IssueKey: noPermissionsIssueKey,
+			},
+			expectedCode: http.StatusNotFound,
+		},
+		"Failed to attach the comment": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId:   "1",
+				IssueKey: attachCommentErrorKey,
+			},
+			expectedCode: http.StatusInternalServerError,
+		},
+		"Succesfully created notification post": {
+			method: "POST",
+			header: "1",
+			request: &struct {
+				PostId      string `json:"post_id"`
+				CurrentTeam string `json:"current_team"`
+				IssueKey    string `json:"issueKey"`
+			}{
+				PostId:   "1",
+				IssueKey: existingIssueKey,
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			bb, err := json.Marshal(tt.request)
+			assert.Nil(t, err)
+
+			request := httptest.NewRequest(tt.method, routeAPIAttachCommentToIssue, strings.NewReader(string(bb)))
+			request.Header.Add("Mattermost-User-Id", tt.header)
+			w := httptest.NewRecorder()
+			p.ServeHTTP(&plugin.Context{}, w, request)
+			assert.Equal(t, tt.expectedCode, w.Result().StatusCode, "no request data")
+		})
+	}
 }

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -257,42 +257,40 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 	p.userStore = getMockUserStoreKV()
 	p.currentInstanceStore = mockCurrentInstanceStore{&p}
 
+	type requestStruct struct {
+		PostId      string `json:"post_id"`
+		CurrentTeam string `json:"current_team"`
+		IssueKey    string `json:"issueKey"`
+	}
+
 	tests := map[string]struct {
-		method  string
-		header  string
-		request *struct {
-			PostId      string `json:"post_id"`
-			CurrentTeam string `json:"current_team"`
-			IssueKey    string `json:"issueKey"`
-		}
+		method       string
+		header       string
+		request      *requestStruct
 		expectedCode int
 	}{
 		"Wrong method": {
 			method:       "GET",
 			header:       "",
-			request:      nil,
+			request:      &requestStruct{},
 			expectedCode: http.StatusMethodNotAllowed,
 		},
 		"No header": {
 			method:       "POST",
 			header:       "",
-			request:      nil,
+			request:      &requestStruct{},
 			expectedCode: http.StatusUnauthorized,
 		},
 		"User not found": {
 			method:       "POST",
 			header:       "nobody",
-			request:      nil,
+			request:      &requestStruct{},
 			expectedCode: http.StatusInternalServerError,
 		},
 		"Failed to load post": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId: "error_post",
 			},
 			expectedCode: http.StatusInternalServerError,
@@ -300,11 +298,7 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 		"Post not found": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId: "post_not_found",
 			},
 			expectedCode: http.StatusInternalServerError,
@@ -312,11 +306,7 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 		"Post user not found": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId: "0",
 			},
 			expectedCode: http.StatusInternalServerError,
@@ -324,11 +314,7 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 		"No permissions to comment on issue": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId:   "1",
 				IssueKey: noPermissionsIssueKey,
 			},
@@ -337,11 +323,7 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 		"Failed to attach the comment": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId:   "1",
 				IssueKey: attachCommentErrorKey,
 			},
@@ -350,11 +332,7 @@ func TestRouteAttachCommentToIssue(t *testing.T) {
 		"Succesfully created notification post": {
 			method: "POST",
 			header: "1",
-			request: &struct {
-				PostId      string `json:"post_id"`
-				CurrentTeam string `json:"current_team"`
-				IssueKey    string `json:"issueKey"`
-			}{
+			request: &requestStruct{
 				PostId:   "1",
 				IssueKey: existingIssueKey,
 			},


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Attachment text not shown if error occurs while adding attachment.
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/529
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

