### PR TITLE
Add badges to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,13 @@
 
 The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/ - let us know your thoughts on the new format in the [Plugin: Jira Channel](https://community-daily.mattermost.com/core/channels/jira-plugin) on our Mattermost community!
 
+
 # Mattermost Jira Plugin
 
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-jira/master)](https://circleci.com/gh/mattermost/mattermost-plugin-jira)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-jira/master)](https://codecov.io/gh/mattermost/mattermost-plugin-jira)
-[![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-jira)](https://github.com/mattermost/mattermost-plugin-jira/releases)
-[![HW](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira/Up%20For%20Grabs?color=dark%20green&label=HW%20%28Up%20For%20Grabs%29)](https://github.com/mattermost/mattermost-plugin-jira/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Up+For+Grabs%22+label%3A%22Help+Wanted%22)
+[![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-jira)](https://github.com/mattermost/mattermost-plugin-jira/releases/latest)
+[![HW](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira/Up%20For%20Grabs?color=dark%20green&label=Help%20Wanted)](https://github.com/mattermost/mattermost-plugin-jira/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Up+For+Grabs%22+label%3A%22Help+Wanted%22)
 
 **Maintainer:** [@jfrerich](https://github.com/jfrerich)
 **Co-Maintainer:** [@levb](https://github.com/levb)

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,6 @@ The Jira/Mattermost plugin documentation is currently being updated and relocate
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-jira/master)](https://codecov.io/gh/mattermost/mattermost-plugin-jira)
 [![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-jira)](https://github.com/mattermost/mattermost-plugin-jira/releases)
 [![HW](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira/Up%20For%20Grabs?color=dark%20green&label=HW%20%28Up%20For%20Grabs%29)](https://github.com/mattermost/mattermost-plugin-jira/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Up+For+Grabs%22+label%3A%22Help+Wanted%22)
-[![Issues](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira.svg)](https://github.com/mattermost/mattermost-plugin-jira/issues)
 
 **Maintainer:** [@jfrerich](https://github.com/jfrerich)
 **Co-Maintainer:** [@levb](https://github.com/levb)

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,13 @@
 
 The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/ - let us know your thoughts on the new format in the [Plugin: Jira Channel](https://community-daily.mattermost.com/core/channels/jira-plugin) on our Mattermost community!
 
-
 # Mattermost Jira Plugin
 
-[![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-jira/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-jira)
-[![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-jira/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-jira)
+[![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-jira/master)](https://circleci.com/gh/mattermost/mattermost-plugin-jira)
+[![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-jira/master)](https://codecov.io/gh/mattermost/mattermost-plugin-jira)
+[![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-jira)](https://github.com/mattermost/mattermost-plugin-jira/releases)
+[![HW](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira/Up%20For%20Grabs?color=dark%20green&label=HW%20%28Up%20For%20Grabs%29)](https://github.com/mattermost/mattermost-plugin-jira/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Up+For+Grabs%22+label%3A%22Help+Wanted%22)
+[![Issues](https://img.shields.io/github/issues/mattermost/mattermost-plugin-jira.svg)](https://github.com/mattermost/mattermost-plugin-jira/issues)
 
 **Maintainer:** [@jfrerich](https://github.com/jfrerich)
 **Co-Maintainer:** [@levb](https://github.com/levb)


### PR DESCRIPTION
#### Summary
This PR is the proposal to add additional badges to the github repo.

The proposal is to add the following:
![image](https://user-images.githubusercontent.com/7575921/82348023-f23a5800-99bd-11ea-82f9-787c0ea39788.png)

You can view the file, with changes [here](https://github.com/mattermost/mattermost-plugin-jira/blob/add-badges-to-readme/readme.md)

#### Ticket Link
n/a