### PR TITLE
Validate https secure protocol for jira cloud install.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ then hit **Save**.
 
 #### Step 3: Install the plugin as an application in Jira
 
-If you want to allow users to [create and manage Jira issues across Mattermost channels](#11-create-and-manage-jira-issues-in-mattermost), install the plugin as an application in your Jira instance. For Jira Server or Data Center instances, post `/jira install server <your-jira-url>` to a Mattermost channel as a Mattermost System Admin, and follow the steps posted to the channel. For Jira Cloud, post `/jira install cloud <your-jira-url>`.
+If you want to allow users to [create and manage Jira issues across Mattermost channels](#11-create-and-manage-jira-issues-in-mattermost), install the plugin as an application in your Jira instance. For Jira Server or Data Center instances, post `/jira install server <your-jira-url>` to a Mattermost channel as a Mattermost System Admin, and follow the steps posted to the channel. For Jira Cloud installs secure connections (HTTPS) are required, post `/jira install cloud https://<your-jira-url>`.   
 
 If you face issues installing the plugin, see our [Frequently Asked Questions](#5-frequently-asked-questions-faq) for troubleshooting help, or open an issue in the [Mattermost Forum](http://forum.mattermost.org).
 

--- a/server/command.go
+++ b/server/command.go
@@ -333,6 +333,10 @@ func executeInstallCloud(p *Plugin, c *plugin.Context, header *model.CommandArgs
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
+	if strings.Contains(jiraURL, "http:") {
+		jiraURL = strings.Replace(jiraURL, "http:", "https:", -1)
+		return p.responsef(header, "`/jira install cloud` requires a secure connection (HTTPS). Please run the following command:\n```\n/jira install cloud %s\n```", jiraURL)
+	}
 
 	// Create an "uninitialized" instance of Jira Cloud that will
 	// receive the /installed callback

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -210,7 +210,7 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 		},
 		"install non secure cloud instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install cloud http://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
-			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS)",
+			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS).",
 		},		
 		"install valid server instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install server https://jiralink.com", UserId: mockUserIDSysAdmin},

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -210,7 +210,7 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 		},
 		"install non secure cloud instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install cloud http://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
-			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS).",
+			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS). Please run the following command:",
 		},		
 		"install valid server instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install server https://jiralink.com", UserId: mockUserIDSysAdmin},

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -210,7 +210,7 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 		},
 		"install non secure cloud instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install cloud http://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
-			expectedMsgPrefix: "/jira install cloud` requires a secure connection (HTTPS)",
+			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS)",
 		},		
 		"install valid server instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install server https://jiralink.com", UserId: mockUserIDSysAdmin},

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -208,6 +208,10 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 			commandArgs:       &model.CommandArgs{Command: "/jira install cloud https://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
 			expectedMsgPrefix: "https://mmtest.atlassian.net has been successfully installed.",
 		},
+		"install non secure cloud instance": {
+			commandArgs:       &model.CommandArgs{Command: "/jira install cloud http://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
+			expectedMsgPrefix: "/jira install cloud` requires a secure connection (HTTPS)",
+		},		
 		"install valid server instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install server https://jiralink.com", UserId: mockUserIDSysAdmin},
 			expectedMsgPrefix: "Server instance has been installed",

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -210,7 +210,7 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 		},
 		"install non secure cloud instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install cloud http://mmtest.atlassian.net", UserId: mockUserIDSysAdmin},
-			expectedMsgPrefix: "'/jira install cloud` requires a secure connection (HTTPS). Please run the following command:",
+			expectedMsgPrefix: "`/jira install cloud` requires a secure connection (HTTPS). Please run the following command:",
 		},		
 		"install valid server instance": {
 			commandArgs:       &model.CommandArgs{Command: "/jira install server https://jiralink.com", UserId: mockUserIDSysAdmin},


### PR DESCRIPTION
Summary

Problem
When configuring webhooks, in Jira, the SITEURL must use **https**:// if connecting to a cloud instance. This ticket has two requests.

Document in the README that cloud instances will require an https endpoint.
Add validation that will reject non-https URLS for jira cloud instances. This will be handled in the code that is executed with /jira install cloud <URL>

Resolution
Validate non secure http protocol command line for cloud install.  Present user with correct command line.
Update readme file with secure protocol requirement (HTTPS)

Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/487