### PR TITLE
GH-531 Add info about /jira webhook

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -88,6 +88,6 @@
         "default": false
       }
     ],
-    "footer": "Use this webhook URL format to [configure the Jira integration.](https://github.com/mattermost/mattermost-plugin-jira/blob/master/readme.md)  `https://SITEURL/plugins/jira/api/v2/webhook?secret=WEBHOOKSECRET`"
+    "footer": "Use `/jira webhook` to see fully expanded URL to [configure the Jira integration.](https://github.com/mattermost/mattermost-plugin-jira/blob/master/readme.md)"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -88,6 +88,6 @@
         "default": false
       }
     ],
-    "footer": "Use `/jira webhook` to see fully expanded URL to [configure the Jira integration.](https://github.com/mattermost/mattermost-plugin-jira/blob/master/readme.md)"
+    "footer": "Run `/jira webhook` command inside of a channel to see fully expanded URL to [configure the Jira integration.](https://github.com/mattermost/mattermost-plugin-jira/blob/master/readme.md) URL format: `https://SITEURL/plugins/jira/api/v2/webhook?secret=WEBHOOKSECRET`"
   }
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -164,6 +164,8 @@ func TestPlugin_ExecuteCommand_Installation(t *testing.T) {
 	api.On("KVGet", "known_jira_instances").Return(nil, nil)
 	api.On("KVGet", "rsa_key").Return(nil, nil)
 	api.On("PublishWebSocketEvent", mock.AnythingOfTypeArgument("string"), mock.Anything, mock.Anything)
+	api.On("GetTeam", mock.AnythingOfTypeArgument("string")).Return(&model.Team{Name: "TestTeam"}, nil)
+	api.On("GetChannel", mock.AnythingOfTypeArgument("string")).Return(&model.Channel{Name: "TestChannel"}, nil)
 
 	sysAdminUser := &model.User{
 		Id:    mockUserIDSysAdmin,

--- a/webapp/src/components/form_button.jsx
+++ b/webapp/src/components/form_button.jsx
@@ -33,7 +33,7 @@ export default class FormButton extends PureComponent {
             contents = (
                 <span>
                     <span
-                        className='fa fa-spinner icon--rotate'
+                        className='fa fa-spin fa-spinner'
                         title={'Loading Icon'}
                     />
                     {savingMessage}


### PR DESCRIPTION


#### Summary
 jira plugin config UI changed and `/jira webhook` added there
jira webhook URL added in outputs of `/jira install` and `/jira uninstall`

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/531

