### PR TITLE
[GH-561] Remove invalid help text on Jira Attach search box

### DIFF
--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -154,10 +154,6 @@ export default class JiraIssueSelector extends Component {
                 />
                 {validationError}
                 {issueError}
-                <div className={'help-text'}>
-                    {'Returns issues sorted by most recently updated.'} <br/>
-                    {'Tip: Use AND, OR, *, ~, and other modifiers like in a JQL query.'}
-                </div>
             </div>
         );
     }


### PR DESCRIPTION
#### Summary
This PR remove the help text from the attach message to issue modal. 

Before:
![image](https://user-images.githubusercontent.com/7575921/83663885-e38f9b80-a58e-11ea-9540-e80c3799da10.png)

After:
![image](https://user-images.githubusercontent.com/7575921/83663861-d83c7000-a58e-11ea-9257-bb8d7429371c.png)


#### Ticket Link
#561 