### PR TITLE
Remove `by mattermost-jira-plugin` link/text

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -239,8 +239,7 @@ func httpAPICreateIssue(ji Instance, w http.ResponseWriter, r *http.Request) (in
 	}
 
 	// Reply with an ephemeral post with the Jira issue formatted as slack attachment.
-	startLink := fmt.Sprintf("/plugins/%s%s", manifest.Id, routeUserStart)
-	msg := fmt.Sprintf("Created Jira issue [%s](%s/browse/%s) by [mattermost-jira-plugin](%s)", created.Key, ji.GetURL(), created.Key, startLink)
+	msg := fmt.Sprintf("Created Jira issue [%s](%s/browse/%s)", created.Key, ji.GetURL(), created.Key)
 
 	reply := &model.Post{
 		Message:   msg,
@@ -659,8 +658,7 @@ func httpAPIAttachCommentToIssue(ji Instance, w http.ResponseWriter, r *http.Req
 		rootId = post.RootId
 	}
 
-	startLink := fmt.Sprintf("/plugins/%s%s", manifest.Id, routeUserStart)
-	msg := fmt.Sprintf("Message attached to [%s](%s/browse/%s) by [mattermost-jira-plugin](%s)", attach.IssueKey, ji.GetURL(), attach.IssueKey, startLink)
+	msg := fmt.Sprintf("Message attached to [%s](%s/browse/%s)", attach.IssueKey, ji.GetURL(), attach.IssueKey)
 
 	// Reply to the post with the issue link that was created
 	reply := &model.Post{


### PR DESCRIPTION
#### Summary
remove "by mattermost-jira-plugin" trailer to create and attach messages.  This was discussed at length in the issue ticket and determined too confusing for some users.

#### Ticket Link
Fixes #551 