### PR TITLE
[GH-549] fix transition slack attachment transition

### DIFF
--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -58,7 +58,7 @@ func getTransitionActions(client Client, issue *jira.Issue) ([]*model.PostAction
 		if transition.Name != issue.Fields.Status.Name {
 			options = append(options, &model.PostActionOptions{
 				Text:  transition.Name,
-				Value: transition.Name,
+				Value: transition.To.Name,
 			})
 		}
 	}


### PR DESCRIPTION
#### Summary
In the case that a `transition name` does not match the `to state` in the slack attachment options picker, the user would receive an error such as below:

Note that `Start Progress` in this case is the `transition name` and the list `In Progress, Solved, Close` are the states.

`2020-05-26T13:45:03.351+0200    error   mlog/sugar.go:23        ERROR:  {"plugin_id": "jira", "Status": "500", "Error": "\"Start Progress\" is not a valid state. Please use one of: \"In Progress, Solved, Closed\"", "Host": "", "RequestURI": "", "Method": "POST", "query": ""}`

To fix this, the options picker value needs to be the state name, not the transition name.  The current modification will show the transition name in the picker, but the underlying value will be the `to state`

#### Testing
I modified my jira testing project. [Jira link](https://mmtest.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=JTP)

In that instance I made the following workflow change (note the subtle spelling change)

From:
  transition name: `Backlog`
  to state name: `Backlog`

To:
  transition name: `Backlog`
  to state name: `Bcaklog`  <-- differs

### Screenshots
Note the label value in the picker still differs form the state value. Is there any reason we want to show the transition names here and not the state names?

![image](https://user-images.githubusercontent.com/7575921/83689583-e7361900-a5b4-11ea-85a7-e84db6a14aa4.png)

![image](https://user-images.githubusercontent.com/7575921/83689617-f61ccb80-a5b4-11ea-827b-fd60aed21bb1.png)

#### Ticket Link
Fixes: #549 