### PR TITLE
[GH-491] Fix posts for jira comments indenting a quote text that has line breaks

### DIFF
--- a/server/testdata/webhook-issue-comment-created-indentation.json
+++ b/server/testdata/webhook-issue-comment-created-indentation.json
@@ -1,0 +1,232 @@
+{
+    "timestamp": 1593218697100,
+    "webhookEvent": "jira:issue_updated",
+    "issue_event_type_name": "issue_commented",
+    "user": {
+        "self": "http://localhost:8082/rest/api/2/user?username=farapira",
+        "name": "farapira",
+        "key": "farapira",
+        "emailAddress": "sample@yahoo.com",
+        "avatarUrls": {
+            "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+            "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+            "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+            "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+        },
+        "displayName": "User",
+        "active": true,
+        "timeZone": "GMT"
+    },
+    "issue": {
+        "id": "10101",
+        "self": "http://localhost:8082/rest/api/2/issue/10101",
+        "key": "TEST-4",
+        "fields": {
+            "issuetype": {
+                "self": "http://localhost:8082/rest/api/2/issuetype/10001",
+                "id": "10001",
+                "description": "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+                "iconUrl": "http://localhost:8082/images/icons/issuetypes/story.svg",
+                "name": "Story",
+                "subtask": false
+            },
+            "components": [],
+            "timespent": null,
+            "timeoriginalestimate": null,
+            "description": "Creating an issue for unit testing",
+            "project": {
+                "self": "http://localhost:8082/rest/api/2/project/10000",
+                "id": "10000",
+                "key": "TEST",
+                "name": "Test",
+                "avatarUrls": {
+                    "48x48": "http://localhost:8082/secure/projectavatar?avatarId=10324",
+                    "24x24": "http://localhost:8082/secure/projectavatar?size=small&avatarId=10324",
+                    "16x16": "http://localhost:8082/secure/projectavatar?size=xsmall&avatarId=10324",
+                    "32x32": "http://localhost:8082/secure/projectavatar?size=medium&avatarId=10324"
+                }
+            },
+            "fixVersions": [],
+            "aggregatetimespent": null,
+            "resolution": null,
+            "timetracking": {},
+            "customfield_10106": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "resolutiondate": null,
+            "workratio": -1,
+            "summary": "unit testing",
+            "lastViewed": "2020-06-27T00:44:24.621+0000",
+            "watches": {
+                "self": "http://localhost:8082/rest/api/2/issue/TEST-4/watchers",
+                "watchCount": 1,
+                "isWatching": true
+            },
+            "creator": {
+                "self": "http://localhost:8082/rest/api/2/user?username=Test",
+                "name": "Test",
+                "key": "test",
+                "emailAddress": "sample@gmail.com",
+                "avatarUrls": {
+                    "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+                    "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+                    "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+                    "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+                },
+                "displayName": "Aida Pirahmadi",
+                "active": true,
+                "timeZone": "GMT"
+            },
+            "subtasks": [],
+            "created": "2020-06-27T00:43:53.099+0000",
+            "reporter": {
+                "self": "http://localhost:8082/rest/api/2/user?username=Test",
+                "name": "Test",
+                "key": "test",
+                "emailAddress": "sample@gmail.com",
+                "avatarUrls": {
+                    "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+                    "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+                    "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+                    "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+                },
+                "displayName": "Aida Pirahmadi",
+                "active": true,
+                "timeZone": "GMT"
+            },
+            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4829bc9b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@98c463[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b999b83[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4de4ed4f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@411be8a4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@46d0af22[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d271f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6b367a18[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75f6f112[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@361ce931[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@245303bb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7ced5b93[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "priority": {
+                "self": "http://localhost:8082/rest/api/2/priority/3",
+                "iconUrl": "http://localhost:8082/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+            },
+            "customfield_10100": "0|i0000n:",
+            "customfield_10101": null,
+            "customfield_10102": null,
+            "labels": [],
+            "environment": null,
+            "timeestimate": null,
+            "aggregatetimeoriginalestimate": null,
+            "versions": [],
+            "duedate": null,
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "comment": {
+                "comments": [
+                    {
+                        "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+                        "id": "10503",
+                        "author": {
+                            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
+                            "name": "farapira",
+                            "key": "farapira",
+                            "emailAddress": "sample@yahoo.com",
+                            "avatarUrls": {
+                                "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+                                "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+                                "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+                                "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+                            },
+                            "displayName": "User",
+                            "active": true,
+                            "timeZone": "GMT"
+                        },
+                        "body": "[~Test] creating a test comment\r\n\r\na second line for the test comment",
+                        "updateAuthor": {
+                            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
+                            "name": "farapira",
+                            "key": "farapira",
+                            "emailAddress": "sample@yahoo.com",
+                            "avatarUrls": {
+                                "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+                                "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+                                "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+                                "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+                            },
+                            "displayName": "User",
+                            "active": true,
+                            "timeZone": "GMT"
+                        },
+                        "created": "2020-06-27T00:44:57.013+0000",
+                        "updated": "2020-06-27T00:44:57.013+0000"
+                    }
+                ],
+                "maxResults": 1,
+                "total": 1,
+                "startAt": 0
+            },
+            "issuelinks": [],
+            "votes": {
+                "self": "http://localhost:8082/rest/api/2/issue/TEST-4/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 20,
+                "total": 0,
+                "worklogs": []
+            },
+            "assignee": null,
+            "updated": "2020-06-27T00:43:53.099+0000",
+            "status": {
+                "self": "http://localhost:8082/rest/api/2/status/10000",
+                "description": "",
+                "iconUrl": "http://localhost:8082/",
+                "name": "To Do",
+                "id": "10000",
+                "statusCategory": {
+                    "self": "http://localhost:8082/rest/api/2/statuscategory/2",
+                    "id": 2,
+                    "key": "new",
+                    "colorName": "blue-gray",
+                    "name": "To Do"
+                }
+            }
+        }
+    },
+    "comment": {
+        "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+        "id": "10503",
+        "author": {
+            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
+            "name": "farapira",
+            "key": "farapira",
+            "emailAddress": "sample@yahoo.com",
+            "avatarUrls": {
+                "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+                "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+                "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+                "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+            },
+            "displayName": "User",
+            "active": true,
+            "timeZone": "GMT"
+        },
+        "body": "[~Test] creating a test comment\r\n\r\na second line for the test comment",
+        "updateAuthor": {
+            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
+            "name": "farapira",
+            "key": "farapira",
+            "emailAddress": "sample@yahoo.com",
+            "avatarUrls": {
+                "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+                "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+                "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+                "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+            },
+            "displayName": "User",
+            "active": true,
+            "timeZone": "GMT"
+        },
+        "created": "2020-06-27T00:44:57.013+0000",
+        "updated": "2020-06-27T00:44:57.013+0000"
+    }
+}

--- a/server/testdata/webhook-issue-comment-created-indentation.json
+++ b/server/testdata/webhook-issue-comment-created-indentation.json
@@ -3,9 +3,9 @@
     "webhookEvent": "jira:issue_updated",
     "issue_event_type_name": "issue_commented",
     "user": {
-        "self": "http://localhost:8082/rest/api/2/user?username=farapira",
-        "name": "farapira",
-        "key": "farapira",
+        "self": "http://localhost:8082/rest/api/2/user?username=test",
+        "name": "test",
+        "key": "test",
         "emailAddress": "sample@yahoo.com",
         "avatarUrls": {
             "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
@@ -124,9 +124,9 @@
                         "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
                         "id": "10503",
                         "author": {
-                            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
-                            "name": "farapira",
-                            "key": "farapira",
+                            "self": "http://localhost:8082/rest/api/2/user?username=test",
+                            "name": "test",
+                            "key": "test",
                             "emailAddress": "sample@yahoo.com",
                             "avatarUrls": {
                                 "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
@@ -140,9 +140,9 @@
                         },
                         "body": "[~Test] creating a test comment\r\n\r\na second line for the test comment",
                         "updateAuthor": {
-                            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
-                            "name": "farapira",
-                            "key": "farapira",
+                            "self": "http://localhost:8082/rest/api/2/user?username=test",
+                            "name": "test",
+                            "key": "test",
                             "emailAddress": "sample@yahoo.com",
                             "avatarUrls": {
                                 "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
@@ -196,9 +196,9 @@
         "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
         "id": "10503",
         "author": {
-            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
-            "name": "farapira",
-            "key": "farapira",
+            "self": "http://localhost:8082/rest/api/2/user?username=test",
+            "name": "test",
+            "key": "test",
             "emailAddress": "sample@yahoo.com",
             "avatarUrls": {
                 "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
@@ -212,9 +212,9 @@
         },
         "body": "[~Test] creating a test comment\r\n\r\na second line for the test comment",
         "updateAuthor": {
-            "self": "http://localhost:8082/rest/api/2/user?username=farapira",
-            "name": "farapira",
-            "key": "farapira",
+            "self": "http://localhost:8082/rest/api/2/user?username=test",
+            "name": "test",
+            "key": "test",
             "emailAddress": "sample@yahoo.com",
             "avatarUrls": {
                 "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",

--- a/server/testdata/webhook-issue-comment-created-indentation.json
+++ b/server/testdata/webhook-issue-comment-created-indentation.json
@@ -73,7 +73,7 @@
                     "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
                     "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
                 },
-                "displayName": "Aida Pirahmadi",
+                "displayName": "user",
                 "active": true,
                 "timeZone": "GMT"
             },
@@ -90,11 +90,11 @@
                     "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
                     "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
                 },
-                "displayName": "Aida Pirahmadi",
+                "displayName": "user",
                 "active": true,
                 "timeZone": "GMT"
             },
-            "customfield_10000": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4829bc9b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@98c463[overall=PullRequestOverallBean{stateCount=0, state='OPEN', details=PullRequestOverallDetails{openCount=0, mergedCount=0, declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b999b83[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4de4ed4f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@411be8a4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@46d0af22[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d271f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6b367a18[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75f6f112[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@361ce931[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}], branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@245303bb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7ced5b93[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]], devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+            "customfield_10000": "",
             "aggregateprogress": {
                 "progress": 0,
                 "total": 0

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -344,6 +344,13 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedText:     "",
 			CurrentInstance:  true,
 		},
+		"SERVER issue comment created indentation": {
+			Request:         testWebhookRequest("webhook-issue-comment-created-indentation.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline: "User **commented** on story [TEST-4: unit testing](http://localhost:8082/browse/TEST-4)",
+			ExpectedText:     "> [~Test] creating a test comment\r\n> \r\n> a second line for the test comment",
+			CurrentInstance:  true,
+		},
 		"SERVER (old version) issue comment deleted (no issue_event_type_name)": {
 			Request:         testWebhookRequest("webhook-server-old-issue-updated-no-event-type-comment-deleted.json"),
 			ExpectedIgnored: true,

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -331,6 +331,13 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedText:            "> unik",
 			CurrentInstance:         true,
 		},
+		"SERVER issue comment created indentation": {
+			Request:         testWebhookRequest("webhook-issue-comment-created-indentation.json"),
+			ExpectedSlackAttachment: true,
+			ExpectedHeadline: "User **commented** on story [TEST-4: unit testing](http://localhost:8082/browse/TEST-4)",
+			ExpectedText:     "> [~Test] creating a test comment\r\n> \r\n> a second line for the test comment",
+			CurrentInstance:  true,
+		},
 		"SERVER (old version) issue commented (no issue_event_type_name)": {
 			Request:                 testWebhookRequest("webhook-server-old-issue-updated-no-event-type-commented.json"),
 			ExpectedSlackAttachment: true,
@@ -342,13 +349,6 @@ func TestWebhookHTTP(t *testing.T) {
 			Request:          testWebhookRequest("webhook-server-issue-updated-comment-deleted.json"),
 			ExpectedHeadline: "Lev Brouk **deleted comment** in story [PRJX-14: As a user, I can find important items on the board by using the customisable ...](http://sales-jira.centralus.cloudapp.azure.com:8080/browse/PRJX-14)",
 			ExpectedText:     "",
-			CurrentInstance:  true,
-		},
-		"SERVER issue comment created indentation": {
-			Request:         testWebhookRequest("webhook-issue-comment-created-indentation.json"),
-			ExpectedSlackAttachment: true,
-			ExpectedHeadline: "User **commented** on story [TEST-4: unit testing](http://localhost:8082/browse/TEST-4)",
-			ExpectedText:     "> [~Test] creating a test comment\r\n> \r\n> a second line for the test comment",
 			CurrentInstance:  true,
 		},
 		"SERVER (old version) issue comment deleted (no issue_event_type_name)": {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -257,7 +257,6 @@ func appendCommentNotifications(wh *webhook, verb string) {
 
 	message := fmt.Sprintf("%s %s %s:\n%s",
 		commentAuthor, verb, jwh.mdKeySummaryLink(), wh.text)
-	
 	assigneeMentioned := false
 
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {
@@ -311,11 +310,10 @@ func appendCommentNotifications(wh *webhook, verb string) {
 
 func quoteIssueComment(comment string) string {
 	lines := strings.Split(comment, "\n");
-	for i := 0; i < len(lines); i++ {
-		lines[i] = "> " + lines[i]; 
+	for i, line := range lines {
+		lines[i] = "> " + line 
 	}
-	quotedComment := strings.Join(lines, "\n");
-	return quotedComment
+	return strings.Join(lines, "\n")
 }
 
 func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -311,7 +311,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 func quoteIssueComment(comment string) string {
 	lines := strings.Split(comment, "\n");
 	for i, line := range lines {
-		lines[i] = "> " + line 
+		lines[i] = "> " + line
 	}
 	return strings.Join(lines, "\n")
 }

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -255,9 +255,9 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	jwh := wh.JiraWebhook
 	commentAuthor := mdUser(&jwh.Comment.UpdateAuthor)
 
-	message := fmt.Sprintf("%s %s %s:\n>%s",
-		commentAuthor, verb, jwh.mdKeySummaryLink(), jwh.Comment.Body)
-
+	message := fmt.Sprintf("%s %s %s:\n%s",
+		commentAuthor, verb, jwh.mdKeySummaryLink(), wh.text)
+	
 	assigneeMentioned := false
 
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {
@@ -310,7 +310,12 @@ func appendCommentNotifications(wh *webhook, verb string) {
 }
 
 func quoteIssueComment(comment string) string {
-	return fmt.Sprintf("> %s", comment)
+	words := strings.Split(comment, "\n");
+	for i := 0; i < len(words); i++ {
+		words[i] = "> " + words[i]; 
+	}
+	quotedComment := strings.Join(words, "\n");
+	return quotedComment
 }
 
 func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -256,7 +256,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	commentAuthor := mdUser(&jwh.Comment.UpdateAuthor)
 
 	message := fmt.Sprintf("%s %s %s:\n%s",
-		commentAuthor, verb, jwh.mdKeySummaryLink(), wh.text)
+		commentAuthor, verb, jwh.mdKeySummaryLink(), quoteIssueComment(jwh.Comment.Body))
 	assigneeMentioned := false
 
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -309,11 +309,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 }
 
 func quoteIssueComment(comment string) string {
-	lines := strings.Split(comment, "\n")
-	for i, line := range lines {
-		lines[i] = "> " + line
-	}
-	return strings.Join(lines, "\n")
+	return "> " + strings.ReplaceAll(comment, "\n", "\n> ")
 }
 
 func parseWebhookCommentDeleted(jwh *JiraWebhook) (Webhook, error) {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -310,11 +310,11 @@ func appendCommentNotifications(wh *webhook, verb string) {
 }
 
 func quoteIssueComment(comment string) string {
-	words := strings.Split(comment, "\n");
-	for i := 0; i < len(words); i++ {
-		words[i] = "> " + words[i]; 
+	lines := strings.Split(comment, "\n");
+	for i := 0; i < len(lines); i++ {
+		lines[i] = "> " + lines[i]; 
 	}
-	quotedComment := strings.Join(words, "\n");
+	quotedComment := strings.Join(lines, "\n");
 	return quotedComment
 }
 

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -309,7 +309,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 }
 
 func quoteIssueComment(comment string) string {
-	lines := strings.Split(comment, "\n");
+	lines := strings.Split(comment, "\n")
 	for i, line := range lines {
 		lines[i] = "> " + line
 	}


### PR DESCRIPTION
![75927524-21ffa800-5e32-11ea-8173-839cbbce1eac](https://user-images.githubusercontent.com/54151510/85657986-98d1e280-b667-11ea-8377-276c8de51023.png)
![Screen Shot 2020-06-24 at 1 48 12 AM](https://user-images.githubusercontent.com/54151510/85658063-ad15df80-b667-11ea-8290-cbbb10a91148.png)

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request indents all the text of a post for a jira comment that has line breaks.


#### Ticket Link
https://github.com/mattermost/mattermost-plugin-jira/issues/491


