### PR TITLE
Avoid double slash in webapp API calls when SiteURL is not present

### DIFF
--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -13,7 +13,7 @@ const getPluginState = (state) => state['plugins-' + PluginId] || {};
 export const getPluginServerRoute = (state) => {
     const config = getConfig(state);
 
-    let basePath = '/';
+    let basePath = '';
     if (config && config.SiteURL) {
         basePath = new URL(config.SiteURL).pathname;
 


### PR DESCRIPTION
#### Summary

We've applied this fix for a different plugin but did not apply it here. If the SiteURL is not set, the code was making the API calls go to `//plugins/jira`. Now it will use `/plugins/jira`.