### PR TITLE
Delay opening subscribe modal until we know the user has permissions

### DIFF
--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -23,7 +23,7 @@ export default class ChannelSettingsModal extends PureComponent<Props> {
     componentDidUpdate(prevProps: Props) {
         if (prevProps.channel && !this.props.channel) {
             this.handleModalClosed();
-        } else if(!prevProps.channel && this.props.channel) {
+        } else if (!prevProps.channel && this.props.channel) {
             this.handleModalOpened();
         }
     }

--- a/webapp/src/components/modals/channel_settings/channel_settings.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings.tsx
@@ -69,7 +69,7 @@ export default class ChannelSettingsModal extends PureComponent<Props> {
     };
 
     render(): JSX.Element {
-        const isModalOpen = this.props.channel && this.state.showModal;
+        const isModalOpen = Boolean(this.props.channel && this.state.showModal);
 
         let inner;
         if (isModalOpen) {

--- a/webapp/src/components/modals/channel_settings/channel_settings_internal.tsx
+++ b/webapp/src/components/modals/channel_settings/channel_settings_internal.tsx
@@ -3,11 +3,9 @@
 
 import React from 'react';
 
-import {ChannelSubscription, ProjectMetadata, AllProjectMetadata} from 'types/model';
+import {ChannelSubscription, AllProjectMetadata} from 'types/model';
 
 import BackIcon from '../full_screen_modal/back_icon';
-
-import Loading from 'components/loading';
 
 import EditChannelSettings from './edit_channel_settings';
 import SelectChannelSubscription from './select_channel_subscription';
@@ -16,43 +14,16 @@ import {SharedProps} from './shared_props';
 type State = {
     creatingSubscription: boolean;
     selectedSubscription: ChannelSubscription | null;
-    fetching: boolean;
+}
+
+type Props = SharedProps & {
     allProjectMetadata: AllProjectMetadata | null;
 }
 
-export default class ChannelSettingsModalInner extends React.PureComponent<SharedProps, State> {
+export default class ChannelSettingsModalInner extends React.PureComponent<Props, State> {
     state = {
         creatingSubscription: false,
         selectedSubscription: null,
-        fetching: false,
-        allProjectMetadata: null,
-    };
-
-    componentDidMount(): void {
-        this.fetchData();
-    }
-
-    fetchData = async (): Promise<void> => {
-        if (!this.props.channel) {
-            return;
-        }
-
-        this.setState({fetching: true});
-        const subsResponse = await this.props.fetchChannelSubscriptions(this.props.channel.id);
-        if (subsResponse.error) {
-            this.props.sendEphemeralPost('You do not have permission to edit subscriptions for this channel. Subscribing to Jira events will create notifications in this channel when certain events occur, such as an issue being updated or created with a specific label. Speak to your Mattermost administrator to request access to this functionality.');
-            this.props.close();
-            return;
-        }
-
-        const projectResponses = await this.props.fetchJiraProjectMetadataForAllInstances();
-        if (projectResponses.error) {
-            this.props.sendEphemeralPost('Failed to fetch project metadata for any projects.');
-            this.props.close();
-            return;
-        }
-
-        this.setState({fetching: false, allProjectMetadata: projectResponses.data});
     };
 
     showEditChannelSubscription = (subscription: ChannelSubscription): void => {
@@ -78,9 +49,7 @@ export default class ChannelSettingsModalInner extends React.PureComponent<Share
         const {selectedSubscription, creatingSubscription} = this.state;
 
         let form;
-        if (!this.props.channelSubscriptions || this.state.fetching) {
-            form = <Loading/>;
-        } else if (selectedSubscription || creatingSubscription) {
+        if (selectedSubscription || creatingSubscription) {
             form = (
                 <EditChannelSettings
                     {...this.props}
@@ -93,7 +62,7 @@ export default class ChannelSettingsModalInner extends React.PureComponent<Share
             form = (
                 <SelectChannelSubscription
                     {...this.props}
-                    allProjectMetadata={this.state.allProjectMetadata}
+                    allProjectMetadata={this.props.allProjectMetadata}
                     showEditChannelSubscription={this.showEditChannelSubscription}
                     showCreateChannelSubscription={this.showCreateChannelSubscription}
                 />


### PR DESCRIPTION
#### Summary

This PR reverts some behavior changed when implementing the multi-server subscription modal. The old behavior is better UX for users that do not have subscribe permissions, and since we are showing the command to all users, I think this case should be a good experience.

#### Ticket Link

https://github.com/mattermost/mattermost-plugin-jira/issues/620

#### Description from ticket

During the multi-server implementation, how we fetch subscriptions changed slightly. This resulted in a change of how the user is shown that they don't have permissions to edit subscriptions.

Previous functionality:
- User runs `/jira subscribe`
- Ephemeral message shows `Fetching subscriptions.` Permission checks begin
- If permissions valid, show modal and show data
- If permissions not valid, do not show modal, and show error in ephemeral message

Before this PR:
- User runs `/jira subscribe`
- Modal opens. Permission checks begin. Loading spinner is shown
- If permissions valid, keep modal open and show data
- If permissions not valid, close modal, and show error in ephemeral message

The problem with the current one, is that the modal flickers if the user does not have permissions, and the request for the permission check completes quickly.

I propose reverting to the old experience for a fix, and consider showing the error message in the modal instead, after this release.