### PR TITLE
[GH-612] Add ability to change telemetry key to production key on release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
+# Include custom makefile, if present
+ifneq ($(wildcard build/custom.mk),)
+	include build/custom.mk
+endif
+
 ## Checks the code style, tests, builds and bundles the plugin.
 all: check-style test dist
 

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,0 +1,5 @@
+# Include custom targets and environment variables here
+ifndef MM_RUDDER_WRITE_KEY
+	MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
+endif
+GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"'

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -2,4 +2,4 @@
 ifndef MM_RUDDER_WRITE_KEY
 	MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
 endif
-GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"'
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"

--- a/server/utils/telemetry/rudder.go
+++ b/server/utils/telemetry/rudder.go
@@ -2,10 +2,12 @@ package telemetry
 
 import rudder "github.com/rudderlabs/analytics-go"
 
-const (
-	rudderDataPlaneURL = "https://pdat.matterlytics.com"
-	rudderWriteKey     = "1d5bMvdrfWClLxgK1FvV3s4U1tg"
-)
+// rudderDataPlaneURL is set to the common Data Plane URL for all Mattermost Projects.
+// It can be set during build time. More info in the package documentation.
+const rudderDataPlaneURL = "https://pdat.matterlytics.com"
+
+// rudderWriteKey is set during build time. More info in the package documentation.
+var rudderWriteKey string
 
 func NewRudderClient() (Client, error) {
 	return NewRudderClientWithCredentials(rudderWriteKey, rudderDataPlaneURL)


### PR DESCRIPTION
#### Summary
Allow setting rudderWriteKey during build time.

I used the following as references:
https://github.com/mattermost/mattermost-plugin-zoom/pull/148
https://github.com/mattermost/mattermost-plugin-todo/pull/101
https://github.com/mattermost/mattermost-plugin-mscalendar/pull/152

#### Ticket Link
fixes #612 