### PR TITLE
Implement `/jira v2revert`

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -486,14 +486,12 @@ func executeV2Revert(p *Plugin, c *plugin.Context, header *model.CommandArgs, ar
 	}
 
 	preMessage := `#### |/jira v2revert| will revert the V3 Jira plugin database to V2. Please use the |--force| flag to complete this command.` + "\n"
-
-	// inform user the --force is required to complete the command
 	if len(args) == 1 && args[0] == "--force" {
 		msg := MigrateV3ToV2(p)
 		if msg != "" {
 			return p.responsef(header, msg)
 		}
-		preMessage = `#### Successfully reverted the V3 Jira plugin database to V2.  The Jira plugin has been disabled.` + "\n"
+		preMessage = `#### Successfully reverted the V3 Jira plugin database to V2. The Jira plugin has been disabled.` + "\n"
 
 		go func() {
 			_ = p.API.DisablePlugin(manifest.Id)
@@ -509,7 +507,7 @@ Downgrade to install the V2 compatible Jira plugin and use the reverted V2 data 
 If you ran |v2revert| unintentionally and would like to continue using the current version of the plugin (|v3+|) you can re-enable the plugin through |System Console| > |PLUGINS| > |Plugin Management|.  This will perform the necessary migration steps to use a |v3+| version of the Jira plugin.`
 
 	message = preMessage + message
-	message = strings.Replace(message, "|", "`", -1)
+	message = strings.ReplaceAll(message, "|", "`")
 
 	p.Tracker.TrackV2Revert(header.UserId)
 

--- a/server/command.go
+++ b/server/command.go
@@ -497,8 +497,9 @@ func executeV2Revert(p *Plugin, c *plugin.Context, header *model.CommandArgs, ar
 			_ = p.API.DisablePlugin(manifest.Id)
 		}()
 	}
+	message := `**Please note that if you have multiple configured Jira instances this command will result in all non-legacy instances being removed.**
 
-	message := `After successfully reverting, please **choose one** of the following:
+After successfully reverting, please **choose one** of the following:
 
 ##### 1. Install Jira plugin |v2.4.0|
 Downgrade to install the V2 compatible Jira plugin and use the reverted V2 data models created by the |v2revert| command. The Jira plugin |v2.4.0| can be found via the marketplace or GitHub releases page.

--- a/server/command.go
+++ b/server/command.go
@@ -501,7 +501,7 @@ func executeV2Revert(p *Plugin, c *plugin.Context, header *model.CommandArgs, ar
 	message := `After successfully reverting, please **choose one** of the following:
 
 ##### 1. Install Jira plugin |v2.4.0|
-Downgrade to install the V2 compatible Jira plugin and use the reverted V2 data models created by the |v2revert| command.
+Downgrade to install the V2 compatible Jira plugin and use the reverted V2 data models created by the |v2revert| command. The Jira plugin |v2.4.0| can be found via the marketplace or GitHub releases page.
 
 ##### 2. Continue using the |v3| data model of the plugin
 If you ran |v2revert| unintentionally and would like to continue using the current version of the plugin (|v3+|) you can re-enable the plugin through |System Console| > |PLUGINS| > |Plugin Management|.  This will perform the necessary migration steps to use a |v3+| version of the Jira plugin.`

--- a/server/command.go
+++ b/server/command.go
@@ -498,11 +498,11 @@ func executeV2Revert(p *Plugin, c *plugin.Context, header *model.CommandArgs, ar
 	message := `After successfully reverting, please **choose one** of the following:
 
 ##### 1. Install Jira plugin |v2.4.1|
-Downgrade to install the v2 compatible Jira plugin and use the reverted V2 data models created by the |v2revert| command.
+Downgrade to install the V2 compatible Jira plugin and use the reverted V2 data models created by the |v2revert| command.
 
 ##### 2. Continue using the |v3| data model of the plugin
 After running |/jira v2revert| and downgrading the Jira plugin, you can migrate to Jira |v3.0+| by simply installing the v3 plugin again.
-If you ran |v2revert| unintentionally and would like to continue using the current version of the plugin (|v3+|) you can restarting the plugin through |System Console| > |PLUGINS| > |Plugin Management|.  This will perform the necessary migration steps to use a v3+ version of the Jira plugin.
+If you ran |v2revert| unintentionally and would like to continue using the current version of the plugin (|v3+|) you can restart the plugin through |System Console| > |PLUGINS| > |Plugin Management|.  This will perform the necessary migration steps to use a |v3+| version of the Jira plugin.
 
 * how to handle multiserver? use default? does it matter?`
 

--- a/server/jiraTracker/tracker.go
+++ b/server/jiraTracker/tracker.go
@@ -5,11 +5,13 @@ import "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry"
 const (
 	userConnectedEvent    = "userConnected"
 	userDisconnectedEvent = "userDisconnected"
+	v2RevertEvent         = "v2RevertSubmitted"
 )
 
 type Tracker interface {
 	TrackUserConnected(userID string)
 	TrackUserDisconnected(userID string)
+	TrackV2Revert(userID string)
 }
 
 func New(t telemetry.Tracker) Tracker {
@@ -28,4 +30,8 @@ func (t *tracker) TrackUserConnected(userID string) {
 
 func (t *tracker) TrackUserDisconnected(userID string) {
 	t.tracker.TrackUserEvent(userDisconnectedEvent, userID, map[string]interface{}{})
+}
+
+func (t *tracker) TrackV2Revert(userID string) {
+	t.tracker.TrackUserEvent(v2RevertEvent, userID, map[string]interface{}{})
 }

--- a/server/kv.go
+++ b/server/kv.go
@@ -651,15 +651,15 @@ func MigrateV3ToV2(p *Plugin) string {
 		return err.Error()
 	}
 
-	err = p.API.KVSet(v2keyKnownJiraInstances, data)
-	if err != nil {
-		return err.Error()
+	appErr := p.API.KVSet(v2keyKnownJiraInstances, data)
+	if appErr != nil {
+		return appErr.Error()
 	}
 
 	// delete instance/v3 key
-	err = p.API.KVDelete(keyInstances)
-	if err != nil {
-		return err.Error()
+	appErr = p.API.KVDelete(keyInstances)
+	if appErr != nil {
+		return appErr.Error()
 	}
 
 	return msg

--- a/server/kv.go
+++ b/server/kv.go
@@ -683,7 +683,7 @@ func MigrateV3InstancesToV2(p *Plugin) (jiraV2Instances, string) {
 	// if there are no V2 legacy instances, don't allow migrating/reverting to old V2 version.
 	legacyInstance := v3instances.GetV2Legacy()
 	if legacyInstance == nil {
-		return nil, "No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version."
+		return nil, "No Jira V2 legacy instances found. V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version."
 	}
 
 	// Convert the V3 instances back to V2

--- a/server/kv.go
+++ b/server/kv.go
@@ -672,8 +672,6 @@ func MigrateV3ToV2(p *Plugin) string {
 // - v2keyCurrentJIRAInstance ("current_jira_instance") stored an Instance; will
 //   be used to set the default instance.
 func MigrateV3InstancesToV2(p *Plugin) (jiraV2Instances, string) {
-
-	// Check if V3 instances exist
 	v3instances, err := p.instanceStore.LoadInstances()
 	if err != nil {
 		return nil, err.Error()
@@ -682,9 +680,8 @@ func MigrateV3InstancesToV2(p *Plugin) (jiraV2Instances, string) {
 		return nil, fmt.Sprint("(none installed)")
 	}
 
-	legacyInstance := v3instances.GetV2Legacy()
-
 	// if there are no V2 legacy instances, don't allow migrating/reverting to old V2 version.
+	legacyInstance := v3instances.GetV2Legacy()
 	if legacyInstance == nil {
 		return nil, "No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version."
 	}

--- a/server/kv.go
+++ b/server/kv.go
@@ -682,31 +682,16 @@ func MigrateV3InstancesToV2(p *Plugin) (jiraV2Instances, string) {
 		return nil, fmt.Sprint("(none installed)")
 	}
 
+	legacyInstance := v3instances.GetV2Legacy()
+
 	// if there are no V2 legacy instances, don't allow migrating/reverting to old V2 version.
-	numV2legacyInstances := 0
+	if legacyInstance == nil {
+		return nil, "No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version."
+	}
 
 	// Convert the V3 instances back to V2
 	v2instances := jiraV2Instances{}
-	for _, key := range v3instances.IDs() {
-		instanceID := types.ID(key)
-
-		instance, err := p.instanceStore.LoadInstance(instanceID)
-		if err != nil {
-			return nil, err.Error()
-		}
-
-		if instance.Common().IsV2Legacy == true {
-			numV2legacyInstances += 1
-		}
-
-		ID := instance.GetID()
-		instanceType := instance.Common().Type
-		v2instances[string(ID)] = string(instanceType)
-	}
-
-	if numV2legacyInstances == 0 {
-		return nil, "No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version."
-	}
+	v2instances[string(legacyInstance.InstanceID)] = string(legacyInstance.Common().Type)
 
 	return v2instances, ""
 }

--- a/server/kv_migrate_test.go
+++ b/server/kv_migrate_test.go
@@ -111,7 +111,12 @@ func TestMigrateV3InstancesToV2(t *testing.T) {
 			expectKnown:   nil,
 			expectMessage: "No Jira V2 legacy instances found. V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version.",
 		},
-		"2 Instances 1 legacy": {
+		"1 instance no legacy": {
+			v3Instances:   `[{"InstanceID":"https://mmtest.atlassian.net","Type":"cloud","IsV2Legacy":false}]`,
+			expectKnown:   nil,
+			expectMessage: "No Jira V2 legacy instances found. V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version.",
+		},
+		"2 instances 1 legacy": {
 			v3Instances:   `[{"InstanceID":"https://mmtest.atlassian.net","Type":"cloud","IsV2Legacy":true},{"InstanceID":"http://localhost:8080","Type":"server","IsV2Legacy":false}]`,
 			expectKnown:   jiraV2Instances{"https://mmtest.atlassian.net": "cloud"},
 			expectMessage: "",

--- a/server/kv_migrate_test.go
+++ b/server/kv_migrate_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
@@ -103,11 +102,10 @@ func TestMigrateV2Instances(t *testing.T) {
 
 func TestMigrateV3InstancesToV2(t *testing.T) {
 	tests := map[string]struct {
-		expectKnown    jiraV2Instances
-		currentV3      string
-		v3Instances    string
-		expectInstance string
-		expectMessage  string
+		currentV3     string
+		v3Instances   string
+		expectKnown   jiraV2Instances
+		expectMessage string
 	}{
 		"No Instance Installed": {
 			expectMessage: "unexpected end of JSON input",
@@ -164,7 +162,6 @@ func TestMigrateV3InstancesToV2(t *testing.T) {
 			api.On("LogError", mock.AnythingOfTypeArgument("string")).Return(nil)
 			api.On("LogDebug", mock.AnythingOfTypeArgument("string")).Return(nil)
 
-			// get mock v3 instances
 			api.On("KVGet", keyInstances).Return([]byte(tc.v3Instances), nil)
 
 			api.On("KVGet", "jira_instance_37d007a56d816107ce5b52c10342db37").Return([]byte(tc.currentV3), nil)
@@ -174,11 +171,8 @@ func TestMigrateV3InstancesToV2(t *testing.T) {
 			p.SetAPI(api)
 			store := NewStore(p)
 			p.instanceStore = store
-			manifest.Version = "3.0.0"
 
 			v2Instances, msg := MigrateV3InstancesToV2(p)
-			fmt.Printf("v2Instances = %+v\n", v2Instances)
-
 			require.Equal(t, tc.expectKnown, v2Instances)
 			require.Equal(t, tc.expectMessage, msg)
 		})

--- a/server/kv_migrate_test.go
+++ b/server/kv_migrate_test.go
@@ -109,7 +109,7 @@ func TestMigrateV3InstancesToV2(t *testing.T) {
 		"no v2legacy instances found": {
 			v3Instances:   `[{"InstanceID":"https://mmtest.atlassian.net","Type":"cloud","IsV2Legacy":false},{"InstanceID":"http://localhost:8080","Type":"server","IsV2Legacy":false}]`,
 			expectKnown:   nil,
-			expectMessage: "No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version.",
+			expectMessage: "No Jira V2 legacy instances found. V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version.",
 		},
 		"2 Instances 1 legacy": {
 			v3Instances:   `[{"InstanceID":"https://mmtest.atlassian.net","Type":"cloud","IsV2Legacy":true},{"InstanceID":"http://localhost:8080","Type":"server","IsV2Legacy":false}]`,

--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -100,6 +100,9 @@ func (store mockInstanceStore) CreateInactiveCloudInstance(types.ID) error {
 func (store mockInstanceStore) DeleteInstance(types.ID) error {
 	return nil
 }
+func (store mockInstanceStore) DeleteInstances() error {
+	return nil
+}
 func (store mockInstanceStore) LoadInstance(types.ID) (Instance, error) {
 	return &testInstance{}, nil
 }
@@ -113,5 +116,8 @@ func (store mockInstanceStore) StoreInstance(instance Instance) error {
 	return nil
 }
 func (store mockInstanceStore) StoreInstances(*Instances) error {
+	return nil
+}
+func (store mockInstanceStore) StoreKnownJIRAInstancesAsV2(jiraV2Instances) error {
 	return nil
 }

--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -100,9 +100,6 @@ func (store mockInstanceStore) CreateInactiveCloudInstance(types.ID) error {
 func (store mockInstanceStore) DeleteInstance(types.ID) error {
 	return nil
 }
-func (store mockInstanceStore) DeleteInstances() error {
-	return nil
-}
 func (store mockInstanceStore) LoadInstance(types.ID) (Instance, error) {
 	return &testInstance{}, nil
 }
@@ -116,8 +113,5 @@ func (store mockInstanceStore) StoreInstance(instance Instance) error {
 	return nil
 }
 func (store mockInstanceStore) StoreInstances(*Instances) error {
-	return nil
-}
-func (store mockInstanceStore) StoreKnownJIRAInstancesAsV2(jiraV2Instances) error {
 	return nil
 }


### PR DESCRIPTION
#### Summary
This PR adds a `/jira v2revert` slash command and also telemetry tracking for when the command is used.

The plugin key `known_jira_instances` is generated by iterating through the `v3/instances` objects and extracting the `ID` (URL) and `type` (Ex `{http://some.jira.com: cloud}`)
The V3 user keys, of the form `user_xxx` are left in the database after `v2revert` is run. I'm 0/5 if we decide to remove them.  

**Some checks were made to help ensure the command is not run unintentionally:**

- If no V2Legacy instances, this is a fresh v3.0.  Don’t allow them to v2revert.  The following message is returned to the user.
  `No Jira V2 legacy instances found.  V3 to V2 Jira migrations are only allowed when the Jira plugin has been previously migrated from a V2 version.`
- use `--force` is required to confirm revert
- don’t show v2revert in autocomplete.  This shouldn’t be a heavily advertised feature.

**Known issues after `v2revert` and downgrading to jira `v2.4.0`**	

These issues are caused when the mattermost server version is `v5.26+`.  The issue is the `withRefs` has been removed but `v2.4.0` still has them in the codebase.  @levb and I discussed and the decision was made to patch `v2.4.0` nor create the fix and release `v2.4.1`
  - /jira subscribe does not open modal
  - post menu (create & attach) do not show in the dropdown
  - slash commands work

#### Ticket Link
fixes #619 