### PR TITLE
Improve disconnect message when user is not connected to any instances

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -353,8 +353,11 @@ func executeDisconnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, 
 	}
 	disconnected, err := p.DisconnectUser(jiraURL, types.ID(header.UserId))
 	if errors.Cause(err) == kvstore.ErrNotFound {
-		return p.responsef(header, "Could not complete the **disconnection** request. You do not currently have a Jira account at %q linked to your Mattermost account."+err.Error(),
-			jiraURL)
+		errorStr := "Your account is not connected to Jira. Please use `/jira connect` to connect your account."
+		if jiraURL != "" {
+			errorStr = fmt.Sprintf("You do not currently have a Jira account at %s linked to your Mattermost account. Please use `/jira connect` to connect your account.", jiraURL)
+		}
+		return p.responsef(header, errorStr)
 	}
 	if err != nil {
 		return p.responsef(header, "Could not complete the **disconnection** request. Error: %v", err)


### PR DESCRIPTION
Currently when you run `/jira disconnect` when:
- There is more than one instance installed
- and the user is not connected to any instance

This is the output of the command:
> Could not complete the disconnection request. You do not currently have a Jira account at "" linked to your Mattermost account.your account is not connected to Jira. Please use `/jira connect`: not found

We can instead have just this portion if the user does not provide a jira URL in their request:
> Your account is not connected to Jira. Please use `/jira connect` to connect your account.

Otherwise the error will read as:
> You do not currently have a Jira account at (JIRA URL) linked to your Mattermost account. Please use `/jira connect` to connect your account.

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/631