### PR TITLE
Include chrome-specific error message in third-party cookie connect error

### DIFF
--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -110,7 +110,7 @@ func (p *Plugin) httpACUserInteractive(w http.ResponseWriter, r *http.Request, i
 		return respondErr(w, http.StatusUnauthorized, errors.New(
 			`Mattermost failed to recognize your user account. `+
 				`Please make sure third-party cookies are not disabled in your browser settings. `+
-				`Make sure you are signed into Mattermost on `+siteURL+`.`+
+				`Make sure you are signed into Mattermost on `+siteURL+`. `+
 				`Chrome is currently experiencing an issue with this authentication method. If you are using Chrome, please try using a different browser to connect your account, until this is resolved.`))
 	}
 

--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -110,7 +110,8 @@ func (p *Plugin) httpACUserInteractive(w http.ResponseWriter, r *http.Request, i
 		return respondErr(w, http.StatusUnauthorized, errors.New(
 			`Mattermost failed to recognize your user account. `+
 				`Please make sure third-party cookies are not disabled in your browser settings. `+
-				`Make sure you are signed into Mattermost on `+siteURL+`.`))
+				`Make sure you are signed into Mattermost on `+siteURL+`.`+
+				`Chrome is currently experiencing an issue with this authentication method. If you are using Chrome, please try using a different browser to connect your account, until this is resolved.`))
 	}
 
 	requestedUserId, secret, err := p.ParseAuthToken(mmToken)


### PR DESCRIPTION
Currently if a user tries to connect to a Jira Cloud instance, we use the Atlassian Connect authentication method. This no longer works with Chrome, due to browser security updates, and will start failing on other browser platforms as well.

We will provide an alternative form of authentication, but for the time being (3.0 release), we should show a disclaimer if the user is using Chrome to use a different browser.

Current text:
> Mattermost failed to recognize your user account. Please make sure third-party cookies are not disabled in your browser settings. Make sure you are signed into Mattermost on (MM URL).

Proposed text to add to the end:
> Chrome is currently experiencing an issue with this authentication method. If you are using Chrome, please try using a different browser to connect your account, until this is resolved.`

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/630

See https://github.com/mattermost/mattermost-plugin-jira/issues/606