### PR TITLE
Check for nil diagnostic setting

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -185,6 +185,11 @@ func (p *Plugin) OnConfigurationChange() error {
 		p.registerJiraCommand(ec.EnableAutocomplete, instances.Len() > 1)
 	}
 
+	diagnostics := false
+	if p.API.GetConfig().LogSettings.EnableDiagnostics != nil {
+		diagnostics = *p.API.GetConfig().LogSettings.EnableDiagnostics
+	}
+
 	// create new tracker on each configuration change
 	p.Tracker = jiraTracker.New(telemetry.NewTracker(
 		p.telemetryClient,
@@ -192,7 +197,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		p.API.GetServerVersion(),
 		manifest.Id,
 		manifest.Version,
-		*p.API.GetConfig().LogSettings.EnableDiagnostics,
+		diagnostics,
 	))
 
 	return nil


### PR DESCRIPTION
#### Summary

If the `EnableDiagnostics` config value is false, it is read as a nil pointer at runtime. This causes the plugin to panic during activation.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/636