### PR TITLE
Close modal on missing required fields

### DIFF
--- a/webapp/src/components/modals/create_issue/create_issue_form.tsx
+++ b/webapp/src/components/modals/create_issue/create_issue_form.tsx
@@ -218,9 +218,14 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
         this.setState({submitting: true});
         this.props.create(issue).then(({error}) => {
             if (error) {
+                if (requiredFieldsNotCovered.length && error.message.includes('required fields')) {
+                    this.handleClose();
+                    return;
+                }
                 this.setState({error: error.message, submitting: false});
                 return;
             }
+
             this.handleClose();
         });
     }


### PR DESCRIPTION
#### Summary

There was a regression on the Create Issue modal staying open when the user has required fields not covered in the form submission. This PR makes sure the modal closes when this scenario occurs.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/638