### PR TITLE
[GH-640] Allow install of instances when have a fresh Jira install

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -581,7 +581,7 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 
 	instances, _ := p.instanceStore.LoadInstances()
 	if !p.enterpriseChecker.HasEnterpriseFeatures() {
-		if len(instances.IDs()) >= 1 {
+		if instances != nil && len(instances.IDs()) > 0 {
 			return p.responsef(header, "You need an Enterprise License to install multiple Jira instances")
 		}
 	}

--- a/server/instances.go
+++ b/server/instances.go
@@ -95,7 +95,7 @@ func (p *Plugin) InstallInstance(instance Instance) error {
 	err := UpdateInstances(p.instanceStore,
 		func(instances *Instances) error {
 			if !p.enterpriseChecker.HasEnterpriseFeatures() {
-				if len(instances.IDs()) >= 1 {
+				if instances != nil && len(instances.IDs()) > 0 {
 					return errors.Errorf("You need an Enterprise License to install multiple Jira instances")
 				}
 			}


### PR DESCRIPTION
#### Summary
The `/jira install` command was panicking on a fresh Jira instance install because the returned instances IDs is nil, not an empty array.

#### Ticket Link
#640 