### PR TITLE
Bump version to v3.0.0-beta2.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
   "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
   "icon_path": "assets/icon.svg",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0-beta2.1",
   "min_server_version": "5.24.0",
   "server": {
     "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "jira",
-	Version: "3.0.0-beta2",
+	Version: "3.0.0-beta2.1",
 }

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -1,2 +1,2 @@
 export const id = 'jira';
-export const version = '3.0.0-beta2';
+export const version = '3.0.0-beta2.1';


### PR DESCRIPTION
#### Summary
Bump version to `v3.0.0-beta2.1`

The previously released `v3.0.0-beta2` had a critical bug that needed to be fixed.  `v3.0.0-beta2` was also removed from the releases.

This bump includes the bug fix #641 and will be release post merging this ticket.

#### Ticket Link
 #647 