### PR TITLE
Avoid defaultUserInstanceID reducer error

### DIFF
--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -37,7 +37,10 @@ function userCanConnect(state = false, action) {
 function defaultUserInstanceID(state = '', action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_CONNECTED:
-        return action.data.user ? action.data.user.default_instance_id : state;
+        if (action.data.user && action.data.user.default_instance_id) {
+            return action.data.user.default_instance_id;
+        }
+        return state;
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary

The `defaultUserInstanceID` reducer was returning `undefined`. This means `action.data.user` was defined, but `action.data.user.default_instance_id` was not present. This PR protects against this so no error happens.

I'm not sure why the websocket message on community has an entirely different structure for the `user` property in the following websocket messages:

Correct websocket message I see locally

```json
 {
  "event": "custom_jira_connect",
  "data": {
    "can_connect": false,
    "instances": [
      {
        "instance_id": "http://localhost:8080",
        "type": "server"
      },
      {
        "instance_id": "https://mmtest.atlassian.net",
        "type": "cloud"
      },
      {
        "instance_id": "http://dkh-jira.ngrok.io",
        "type": "server"
      }
    ],
    "is_connected": true,
    "user": {
      "connected_instances": [
        {
          "instance_id": "http://localhost:8080",
          "type": "server"
        },
        {
          "instance_id": "https://mmtest.atlassian.net",
          "type": "cloud"
        },
        {
          "instance_id": "http://dkh-jira.ngrok.io",
          "type": "server"
        }
      ],
      "default_instance_id": "https://mmtest.atlassian.net",
      "mattermost_user_id": "j6couwhw6brkdgm1w1x1gy8sbw"
    }
  },
  "broadcast": {
    "omit_users": null,
    "user_id": "j6couwhw6brkdgm1w1x1gy8sbw",
    "channel_id": "",
    "team_id": ""
  },
  "seq": 7
}
```

Community websocket message that causes the error

```json
{
  "event": "custom_jira_connect",
  "data": {
    "can_connect": false,
    "instances": [
      {
        "instance_id": "https://mattermost.atlassian.net",
        "type": "cloud"
      }
    ],
    "is_connected": true,
    "user": {
      "id": "",
      "delete_at": 0,
      "username": "",
      "auth_service": "",
      "email": "",
      "nickname": "",
      "first_name": "",
      "last_name": "",
      "position": "",
      "roles": "",
      "locale": "",
      "timezone": null
    }
  },
  "broadcast": {
    "omit_users": null,
    "user_id": "9bhmru975pypfcajzb9i5zcd1r",
    "channel_id": "",
    "team_id": ""
  },
  "seq": 12
}
```

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/646