### PR TITLE
Change Cloud auth to only use the encoded user id

### DIFF
--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -104,22 +104,9 @@ func (p *Plugin) httpACUserInteractive(w http.ResponseWriter, r *http.Request, i
 		},
 	}
 
-	mattermostUserId := r.Header.Get("Mattermost-User-ID")
-	if mattermostUserId == "" {
-		siteURL := p.GetSiteURL()
-		return respondErr(w, http.StatusUnauthorized, errors.New(
-			`Mattermost failed to recognize your user account. `+
-				`Please make sure third-party cookies are not disabled in your browser settings. `+
-				`Make sure you are signed into Mattermost on `+siteURL+`.`))
-	}
-
-	requestedUserId, secret, err := p.ParseAuthToken(mmToken)
+	mattermostUserId, secret, err := p.ParseAuthToken(mmToken)
 	if err != nil {
 		return respondErr(w, http.StatusUnauthorized, err)
-	}
-
-	if mattermostUserId != requestedUserId {
-		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized, user id does not match link"))
 	}
 
 	mmuser, appErr := p.API.GetUser(mattermostUserId)


### PR DESCRIPTION
#### Summary

This PR removes a check for the MM user's id in the HTTP header. This PR is sort of an RFC to see if this is something we can proceed with.

Here's a description of the flow before this PR (taken from https://github.com/mattermost/mattermost-plugin-jira/issues/606#issuecomment-689962904):

- We generate a secret at runtime to store in a one time store
- We create a JWT containing the user's id and the secret, and to have Jira place it in the URL params when the iframe is loaded
- When the user is loading the iframe, we check:
    - The JWT is valid, and the secret it contains matches what we have tied to the user in the one time store
    - The user's MM session cookie is valid


With this PR, we skip the MM cookie check, and just use the encoded payload that contains the user id and OTS secret.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/606