### PR TITLE
[GH-663] Saved subscription project value incorrectly updated to default_project_key value

### DIFF
--- a/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.tsx
+++ b/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.tsx
@@ -95,7 +95,7 @@ export default class JiraInstanceAndProjectSelector extends React.PureComponent<
             fetchingProjectMetadata: false,
         });
 
-        if (projectMetadata.default_project_key) {
+        if (projectMetadata.default_project_key && !this.props.selectedProjectID) {
             this.props.onProjectChange(projectMetadata.default_project_key);
         }
     }


### PR DESCRIPTION
#### Summary
Thsi ticket resolves the case where a saved subscription is edited.  Previously, the `default_project_key` was getting set when the edit subscription modal would open. This resulted in opening a saved subscription with a different project that the saved default project would get changed to the default project key.  

The resolution is to check if the selectedProjectID exists, which is the saved subscription project ID.

#### Ticket Link
#663