### PR TITLE
[GH-526] make server install help text more clear to the user.

### DIFF
--- a/assets/templates/command/install_server.md
+++ b/assets/templates/command/install_server.md
@@ -10,8 +10,10 @@
 4. In **Link Applications** screen, set the following values:
   - **Application Name**: Mattermost
   - **Application Type**: Generic Application
-5. **IMPORTANT**: Check the **Create incoming link** value, then click **Continue**.
-6. In the following **Link Applications** screen, set the following values:
+  - Check the **Create incoming link** value.
+      **(Important)**
+  - Click **Continue**
+5. In the following **Link Applications** screen, set the following values:
   - **Consumer Key**: `{{ .MattermostKey }}`
   - **Consumer Name**: `Mattermost`
   - **Public Key**:
@@ -20,7 +22,7 @@
 	```
   - **Consumer Callback URL**: _leave blank_
   - **Allow 2-legged OAuth**: _leave unchecked_
-  7. Click **Continue**.
+  - Click **Continue**
 6. Use the "/jira connect" command to connect your Mattermost account with your
    Jira account.
 7. Click the "More Actions" (...) option of any message in the channel


### PR DESCRIPTION
#### Summary
We have had several customers have this issue.  The solution is actually simple and doesn't require any code changes. Please see this comment in the issue for an understanding of what caused the issue.

As a solution, I have changed the output of the `/jira instance install server example.com` command.  

To help clarify what must be done for each jira input form, I have consolidated the previous bullet 5 into bullet 4.  Now each numbered bullet, 3, 4, and 5 list the instructions for each input form.  I also think the previous bullet 5 with the **IMPORTANT** text is overkill and was causing extra distraction.

### Before
![image](https://user-images.githubusercontent.com/7575921/94222300-9b381880-feb2-11ea-952f-1941e0df9009.png)

### After
![image](https://user-images.githubusercontent.com/7575921/94222250-7ba0f000-feb2-11ea-8ae3-a52ab7fde2bc.png)


#### Ticket Link
#526 