### PR TITLE
[GH-678] when using --instance, show alias if available else show the instanceID

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -231,7 +231,7 @@ func createConnectCommand() *model.AutocompleteData {
 func createAliasCommand() *model.AutocompleteData {
 	alias := model.NewAutocompleteData(
 		"alias", "", "Create an alias to your Jira instance")
-	alias.AddDynamicListArgument("Jira URL", routeAutocompleteInstalledInstance, false)
+	alias.AddDynamicListArgument("Jira URL", routeAutocompleteInstalledInstanceWithAlias, false)
 	return alias
 }
 
@@ -313,7 +313,7 @@ func createSubscribeCommand(optInstance bool) *model.AutocompleteData {
 
 	list := model.NewAutocompleteData(
 		"list", "", "List the Jira notifications sent to this channel")
-	withFlagInstance(list, optInstance, routeAutocompleteInstalledInstance)
+	withFlagInstance(list, optInstance, routeAutocompleteInstalledInstanceWithAlias)
 	subscribe.AddCommand(list)
 	return subscribe
 }
@@ -322,7 +322,7 @@ func createWebhookCommand(optInstance bool) *model.AutocompleteData {
 	webhook := model.NewAutocompleteData(
 		"webhook", "[Jira URL]", "Display the webhook URLs to set up on Jira")
 	webhook.RoleID = model.SYSTEM_ADMIN_ROLE_ID
-	withFlagInstance(webhook, optInstance, routeAutocompleteInstalledInstance)
+	withFlagInstance(webhook, optInstance, routeAutocompleteInstalledInstanceWithAlias)
 	return webhook
 }
 
@@ -482,6 +482,12 @@ func executeInstanceAlias(p *Plugin, c *plugin.Context, header *model.CommandArg
 	if err != nil {
 		return p.responsef(header, "Failed to load instances. Error: %v.", err)
 	}
+
+	instanceFound := instances.getByAlias(string(instanceID))
+	if instanceFound != nil {
+		instanceID = instanceFound.InstanceID
+	}
+
 	isUnique, id := instances.isAliasUnique(instanceID, alias)
 	if !isUnique {
 		return p.responsef(header, "Alias `%v` already exists on InstanceID: %v.", alias, id)

--- a/server/instances.go
+++ b/server/instances.go
@@ -402,16 +402,13 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 
 	instances, err := p.instanceStore.LoadInstances()
 	for _, instanceID := range info.Instances.IDs() {
-		alias := instances.getAlias(instanceID)
-		if alias != "" {
-			out = append(out, model.AutocompleteListItem{
-				Item: alias,
-			})
-		} else {
-			out = append(out, model.AutocompleteListItem{
-				Item: string(instanceID),
-			})
+		item := instances.getAlias(instanceID)
+		if item != "" {
+			item = string(instanceID)
 		}
+		out = append(out, model.AutocompleteListItem{
+			Item: item,
+		})
 	}
 	return respondJSON(w, out)
 }

--- a/server/instances.go
+++ b/server/instances.go
@@ -407,6 +407,10 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 			out = append(out, model.AutocompleteListItem{
 				Item: alias,
 			})
+		} else {
+			out = append(out, model.AutocompleteListItem{
+				Item: string(instanceID),
+			})
 		}
 	}
 	return respondJSON(w, out)

--- a/server/instances.go
+++ b/server/instances.go
@@ -403,7 +403,7 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 	instances, err := p.instanceStore.LoadInstances()
 	for _, instanceID := range info.Instances.IDs() {
 		item := instances.getAlias(instanceID)
-		if item != "" {
+		if item == "" {
 			item = string(instanceID)
 		}
 		out = append(out, model.AutocompleteListItem{


### PR DESCRIPTION
#### Summary
When showing the list of available `--instance` options, show the aliases if available, else show the `instanceID`.

I tested this with 
`/jira issue view JTP-1`
`/jira issue view jstp-1 --instance server-alias`
`/jira issue view jtp-1 --instance https://mmtest.atlassian.net`

`/jira assign jstp-1 jfrerich --instance server-alias `
/jira assign jtp-1 jfrerich --instance https://mmtest.atlassian.net 

#### Ticket Link
Fixes #678 