### PR TITLE
Bump min server version to v5.26.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v2.4.0",
   "icon_path": "assets/icon.svg",
   "version": "3.0.0-beta2.1",
-  "min_server_version": "5.26.2",
+  "min_server_version": "5.26.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v2.4.0",
   "icon_path": "assets/icon.svg",
   "version": "3.0.0-beta2.1",
-  "min_server_version": "5.24.0",
+  "min_server_version": "5.26.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v2.4.0",
   "icon_path": "assets/icon.svg",
   "version": "3.0.0-beta2.1",
-  "min_server_version": "5.26.0",
+  "min_server_version": "5.26.2",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
Upgrading min_server_version to 5.26.0 so that autocomplete functions correctly.  Dylan found an issue with 5.24 where `/jira connect` gets replicated by the number of instances installed.

#### Ticket Link
N/A