### PR TITLE
[GH-589] Change log level for autolink when no cloud instance

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -303,7 +303,7 @@ func (p *Plugin) OnActivate() error {
 
 			ci, ok := instance.(*cloudInstance)
 			if !ok {
-				p.API.LogWarn("only cloud instances supported for autolink", "err", err)
+				p.API.LogInfo("only cloud instances supported for autolink", "err", err)
 				continue
 			}
 


### PR DESCRIPTION
#### Summary
Change log level for autolink when no cloud instance. From WARN to INFO.

#### Ticket Link
Fixes #589 

