### PR TITLE
Relocate dev docs to GitBook

### DIFF
--- a/docs/admininstrator-guide/notification-management.md
+++ b/docs/admininstrator-guide/notification-management.md
@@ -18,7 +18,7 @@ The notifications and metadata shown in a channel are not protected by Jira perm
 
 ## What is a notification subscription?
 
-Mattermost users can set up rules that define when a particular event with certain criteria are met in Jira that trigger a notification is sent to a particular channel. These subscription rules can specify the `Jira Project`, `Event Type`, `Issue Type`, and can filter out issues with certain values. 
+Mattermost users can set up rules that define when a particular event with certain criteria are met in Jira that trigger a notification is sent to a particular channel. These subscription rules can specify the `Jira Project`, `Event Type`, `Issue Type`, and can filter out issues with certain values.
 
 When a user is setting up a notification subscription they will only see the projects and issue types they have access to within Jira. If they can't see a project in Jira it won't be displayed as an option for that particular user when they are trying to setup a subscription in Mattermost.
 
@@ -34,9 +34,9 @@ Then, you can specify which Jira groups they also need to be a member of, in ord
 
 ![](../.gitbook/assets/image%20%283%29.png)
 
-## How can I see all the notification subscriptions that are set up in Mattermost? 
+## How can I see all the notification subscriptions that are set up in Mattermost?
 
-While logged in as a System Admin type `/jira list` in a Mattermost channel.
+While logged in as a System Admin type `/jira subscribe list` in a Mattermost channel.
 
 ## How can I set up Mattermost notifications directly within Jira?
 

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -4,6 +4,8 @@
 
 To contribute to the project see https://www.mattermost.org/contribute-to-mattermost
 
+Join the [Jira plugin channel](https://community.mattermost.com/core/channels/jira-plugin) on our community server to discuss any questions.
+
 Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
 
 This plugin supports both Jira Server (self-hosted) and Jira Cloud instances. There can be slight differences in behavior between the two systems, so it's best to test with both systems individually when introducing new webhook logic, or adding a new Jira API call.

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -2,6 +2,8 @@
 
 ## Development
 
+To contribute to the project see https://www.mattermost.org/contribute-to-mattermost
+
 Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
 
 This plugin supports both Jira Server (self-hosted) and Jira Cloud instances. There can be slight differences in behavior between the two systems, so it's best to test with both systems individually when introducing new webhook logic, or adding a new Jira API call.

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -2,11 +2,10 @@
 
 ## Development
 
-This plugin contains both a server and web app portion.
+Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
 
-Use `make dist` to build distributions of the plugin that you can upload to a Mattermost server. Use `make check-style` to check the style. Use `make deploy` to deploy the plugin to your local server.
+This plugin supports both Jira Server (self-hosted) and Jira Cloud instances. There can be slight differences in behavior between the two systems, so it's best to test with both systems individually when introducing new webhook logic, or adding a new Jira API call.
 
-For additional information on developing plugins, refer to [our plugin developer documentation](https://developers.mattermost.com/extend/plugins/).
+To test your changes against a local instance of Jira Server, you need [Docker](https://docs.docker.com/install) installed, then you can use the `docker-compose.yml` file in this repository to create a Jira instance. Simply run `docker-compose up` in the directory of the repository, and a new Jira server should start up and be available at http://localhost:8080. It can take a few minutes to start up due to Jira Server's startup processes. If the container fails to start with `exit code 443`, you may need to increase the amount of RAM you are allowing docker to use.
 
-To test your changes against Jira locally, we recommend starting a 14-day trial for Jira Software Cloud, if you don't have a Jira project to test against. More information can be found here: [https://www.atlassian.com/software/jira/try](https://www.atlassian.com/software/jira/try).
-
+To test your changes against a Jira Cloud instance, we recommend starting a 14-day trial, if you don't have a Jira project to test against. More information can be found here: https://www.atlassian.com/software/jira/try.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This plugin supports a two-way integration between Mattermost and Jira. Jira Cor
 
 From v3.0 of this plugin, support for multiple Jira instances is offered.
 
-Visit our [Jira Plugin Documentation](https://mattermost.gitbook.io/jira-plugin/) for guidance on installation, configuration, and usage. 
+Visit our [Jira Plugin Documentation](https://mattermost.gitbook.io/jira-plugin/) for guidance on installation, configuration, and usage.
 
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-jira/master)](https://circleci.com/gh/mattermost/mattermost-plugin-jira)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-jira/master)](https://codecov.io/gh/mattermost/mattermost-plugin-jira)
@@ -20,4 +20,4 @@ This repository is licensed under the Apache 2.0 License, except for the [server
 
 ## Development
 
-This plugin contains both a server and web app portion. Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
+Please read the Jira plugin's [developer docs](https://mattermost.gitbook.io/plugin-jira/development/environment) to learn more about contributing to the project.


### PR DESCRIPTION
#### Summary

Some development docs that were in the README got lost when switching over to GitBook. This PR brings those docs to GitBook, and links to them from the README.
