### PR TITLE
Reporter receive notification when someone comments on their issue

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -592,6 +592,10 @@ func executeSettings(p *Plugin, c *plugin.Context, header *model.CommandArgs, ar
 		return p.responsef(header, "Current settings:\n%s", conn.Settings.String())
 	case "notifications":
 		return p.settingsNotifications(header, instance.GetID(), user.MattermostUserID, conn, args)
+	case "send_notifications_for_assigned":
+		return p.settingsSendNotificationsForAssigned(header, instance.GetID(), user.MattermostUserID, conn, args)
+	case "send_notifications_for_reporter":
+		return p.settingsSendNotificationsForReporter(header, instance.GetID(), user.MattermostUserID, conn, args)
 	default:
 		return p.responsef(header, "Unknown setting.")
 	}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -196,6 +196,46 @@ func TestPlugin_ExecuteCommand_Settings(t *testing.T) {
 			numInstances: 1,
 			expectedMsg:  "Settings updated. Notifications off.",
 		},
+		"set send_notifications_for_assigned without value": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_assigned", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "`/jira settings send_notifications_for_assigned [value]`\n* Invalid value. Accepted values are: `on` or `off`.",
+		},
+		"set send_notifications_for_assigned with unknown value": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_assigned test", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "`/jira settings send_notifications_for_assigned [value]`\n* Invalid value. Accepted values are: `on` or `off`.",
+		},
+		"enable send_notifications_for_assigned": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_assigned on", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "Settings updated. SendNotificationsForAssigned on.",
+		},
+		"disable send_notifications_for_assigned": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_assigned off", UserId: mockUserIDWithNotifications},
+			numInstances: 1,
+			expectedMsg:  "Settings updated. SendNotificationsForAssigned off.",
+		},
+		"set send_notifications_for_reporter without value": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_reporter", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "`/jira settings send_notifications_for_reporter [value]`\n* Invalid value. Accepted values are: `on` or `off`.",
+		},
+		"set send_notifications_for_reporter with unknown value": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_reporter test", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "`/jira settings send_notifications_for_reporter [value]`\n* Invalid value. Accepted values are: `on` or `off`.",
+		},
+		"enable send_notifications_for_reporter": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_reporter on", UserId: mockUserIDWithoutNotifications},
+			numInstances: 1,
+			expectedMsg:  "Settings updated. SendNotificationsForReporter on.",
+		},
+		"disable send_notifications_for_reporter": {
+			commandArgs:  &model.CommandArgs{Command: "/jira settings send_notifications_for_reporter off", UserId: mockUserIDWithNotifications},
+			numInstances: 1,
+			expectedMsg:  "Settings updated. SendNotificationsForReporter off.",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/server/settings.go
+++ b/server/settings.go
@@ -11,6 +11,8 @@ const (
 	settingOff = "off"
 )
 
+var onOffToBool = map[string]bool{settingOn: true, settingOff: false}
+
 func (p *Plugin) settingsNotifications(header *model.CommandArgs, instanceID, mattermostUserID types.ID, connection *Connection, args []string) *model.CommandResponse {
 	const helpText = "`/jira settings notifications [value]`\n* Invalid value. Accepted values are: `on` or `off`."
 
@@ -18,13 +20,8 @@ func (p *Plugin) settingsNotifications(header *model.CommandArgs, instanceID, ma
 		return p.responsef(header, helpText)
 	}
 
-	var value bool
-	switch args[1] {
-	case settingOn:
-		value = true
-	case settingOff:
-		value = false
-	default:
+	value, ok := onOffToBool[args[1]]
+	if !ok {
 		return p.responsef(header, helpText)
 	}
 
@@ -42,10 +39,86 @@ func (p *Plugin) settingsNotifications(header *model.CommandArgs, instanceID, ma
 	if err != nil {
 		return p.responsef(header, "Your username is not connected to Jira. Please type `jira connect`. %v", err)
 	}
-	notifications := settingOff
-	if updatedConnection.Settings.Notifications {
-		notifications = settingOn
+
+	return p.responsef(header, "Settings updated. Notifications %s.",
+		boolToOnOff(updatedConnection.Settings.Notifications))
+}
+
+func (p *Plugin) settingsSendNotificationsForAssigned(
+	header *model.CommandArgs,
+	instanceID, mattermostUserID types.ID,
+	connection *Connection,
+	args []string,
+) *model.CommandResponse {
+	const helpText = "`/jira settings send_notifications_for_assigned [value]`\n* Invalid value. Accepted values are: `on` or `off`."
+
+	if len(args) != 2 {
+		return p.responsef(header, helpText)
 	}
 
-	return p.responsef(header, "Settings updated. Notifications %s.", notifications)
+	value, ok := onOffToBool[args[1]]
+	if !ok {
+		return p.responsef(header, helpText)
+	}
+
+	if connection.Settings == nil {
+		connection.Settings = &ConnectionSettings{}
+	}
+	connection.Settings.SendNotificationsForAssigned = value
+	if err := p.userStore.StoreConnection(instanceID, mattermostUserID, connection); err != nil {
+		p.errorf("settingsSendNotificationsForAssigned, err: %v", err)
+		p.responsef(header, "Could not store new settings. Please contact your system administrator. error: %v", err)
+	}
+
+	// send back the actual value
+	updatedConnection, err := p.userStore.LoadConnection(instanceID, mattermostUserID)
+	if err != nil {
+		return p.responsef(header, "Your username is not connected to Jira. Please type `jira connect`. %v", err)
+	}
+
+	return p.responsef(header, "Settings updated. SendNotificationsForAssigned %s.",
+		boolToOnOff(updatedConnection.Settings.SendNotificationsForAssigned))
+}
+
+func (p *Plugin) settingsSendNotificationsForReporter(
+	header *model.CommandArgs,
+	instanceID, mattermostUserID types.ID,
+	connection *Connection,
+	args []string,
+) *model.CommandResponse {
+	const helpText = "`/jira settings send_notifications_for_reporter [value]`\n* Invalid value. Accepted values are: `on` or `off`."
+
+	if len(args) != 2 {
+		return p.responsef(header, helpText)
+	}
+
+	value, ok := onOffToBool[args[1]]
+	if !ok {
+		return p.responsef(header, helpText)
+	}
+
+	if connection.Settings == nil {
+		connection.Settings = &ConnectionSettings{}
+	}
+	connection.Settings.SendNotificationsForReporter = value
+	if err := p.userStore.StoreConnection(instanceID, mattermostUserID, connection); err != nil {
+		p.errorf("settingsSendNotificationsForReporter, err: %v", err)
+		p.responsef(header, "Could not store new settings. Please contact your system administrator. error: %v", err)
+	}
+
+	// send back the actual value
+	updatedConnection, err := p.userStore.LoadConnection(instanceID, mattermostUserID)
+	if err != nil {
+		return p.responsef(header, "Your username is not connected to Jira. Please type `jira connect`. %v", err)
+	}
+
+	return p.responsef(header, "Settings updated. SendNotificationsForReporter %s.",
+		boolToOnOff(updatedConnection.Settings.SendNotificationsForReporter))
+}
+
+func boolToOnOff(isOn bool) string {
+	if isOn {
+		return settingOn
+	}
+	return settingOff
 }

--- a/server/testdata/webhook-issue-comment-created-notify-assignee-and-reporter.json
+++ b/server/testdata/webhook-issue-comment-created-notify-assignee-and-reporter.json
@@ -1,0 +1,248 @@
+{
+  "timestamp": 1593218697100,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_commented",
+  "user": {
+    "self": "http://localhost:8082/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "sample@yahoo.com",
+    "avatarUrls": {
+      "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+      "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+      "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+      "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+    },
+    "displayName": "Test",
+    "active": true,
+    "timeZone": "GMT"
+  },
+  "issue": {
+    "id": "10101",
+    "self": "http://localhost:8082/rest/api/2/issue/10101",
+    "key": "TEST-4",
+    "fields": {
+      "issuetype": {
+        "self": "http://localhost:8082/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "http://localhost:8082/images/icons/issuetypes/story.svg",
+        "name": "Story",
+        "subtask": false
+      },
+      "components": [],
+      "timespent": null,
+      "timeoriginalestimate": null,
+      "description": "Creating an issue for unit testing",
+      "project": {
+        "self": "http://localhost:8082/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TEST",
+        "name": "Test",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/projectavatar?avatarId=10324",
+          "24x24": "http://localhost:8082/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "http://localhost:8082/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "http://localhost:8082/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "timetracking": {},
+      "customfield_10106": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "summary": "unit testing",
+      "lastViewed": "2020-06-27T00:44:24.621+0000",
+      "watches": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "creator": {
+        "self": "http://localhost:8082/rest/api/2/user?username=Test",
+        "name": "Test",
+        "key": "test",
+        "emailAddress": "sample@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "user",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "subtasks": [],
+      "created": "2020-06-27T00:43:53.099+0000",
+      "assignee": {
+        "self": "http://localhost:8082/rest/api/2/user?username=assignee",
+        "name": "assignee",
+        "accountID": "assignee123",
+        "key": "assignee",
+        "emailAddress": "assignee@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Assignee",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "reporter": {
+        "self": "http://localhost:8082/rest/api/2/user?username=reporter",
+        "name": "reporter",
+        "accountID": "reporter123",
+        "key": "reporter",
+        "emailAddress": "reporter@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Reporter",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "customfield_10000": "",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "priority": {
+        "self": "http://localhost:8082/rest/api/2/priority/3",
+        "iconUrl": "http://localhost:8082/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "customfield_10100": "0|i0000n:",
+      "customfield_10101": null,
+      "customfield_10102": null,
+      "labels": [],
+      "environment": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+            "id": "10503",
+            "author": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+            "updateAuthor": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "created": "2018-05-15T11:39:29.299+0000",
+            "updated": "2018-05-15T11:39:29.299+0000"
+          }
+        ],
+        "maxResults": 1,
+        "total": 1,
+        "startAt": 0
+      },
+      "issuelinks": [],
+      "votes": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      },
+      "updated": "2020-06-27T00:43:53.099+0000",
+      "status": {
+        "self": "http://localhost:8082/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "http://localhost:8082/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "http://localhost:8082/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "comment": {
+    "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+    "id": "10503",
+    "author": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "body": "[~test] creating a test comment\r\n\r\na second line for the test comment",
+    "updateAuthor": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "created": "2020-06-27T00:44:57.013+0000",
+    "updated": "2020-06-27T00:44:57.013+0000"
+  }
+}

--- a/server/testdata/webhook-issue-comment-created-notify-mentioned-users.json
+++ b/server/testdata/webhook-issue-comment-created-notify-mentioned-users.json
@@ -1,0 +1,248 @@
+{
+  "timestamp": 1593218697100,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_commented",
+  "user": {
+    "self": "http://localhost:8082/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "sample@yahoo.com",
+    "avatarUrls": {
+      "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+      "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+      "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+      "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+    },
+    "displayName": "Test",
+    "active": true,
+    "timeZone": "GMT"
+  },
+  "issue": {
+    "id": "10101",
+    "self": "http://localhost:8082/rest/api/2/issue/10101",
+    "key": "TEST-4",
+    "fields": {
+      "issuetype": {
+        "self": "http://localhost:8082/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "http://localhost:8082/images/icons/issuetypes/story.svg",
+        "name": "Story",
+        "subtask": false
+      },
+      "components": [],
+      "timespent": null,
+      "timeoriginalestimate": null,
+      "description": "Creating an issue for unit testing",
+      "project": {
+        "self": "http://localhost:8082/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TEST",
+        "name": "Test",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/projectavatar?avatarId=10324",
+          "24x24": "http://localhost:8082/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "http://localhost:8082/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "http://localhost:8082/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "timetracking": {},
+      "customfield_10106": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "summary": "unit testing",
+      "lastViewed": "2020-06-27T00:44:24.621+0000",
+      "watches": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "creator": {
+        "self": "http://localhost:8082/rest/api/2/user?username=Test",
+        "name": "Test",
+        "key": "test",
+        "emailAddress": "sample@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "user",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "subtasks": [],
+      "created": "2020-06-27T00:43:53.099+0000",
+      "assignee": {
+        "self": "http://localhost:8082/rest/api/2/user?username=assignee",
+        "name": "assignee",
+        "accountID": "assignee123",
+        "key": "assignee",
+        "emailAddress": "assignee@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Assignee",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "reporter": {
+        "self": "http://localhost:8082/rest/api/2/user?username=reporter",
+        "name": "reporter",
+        "accountID": "reporter123",
+        "key": "reporter",
+        "emailAddress": "reporter@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Reporter",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "customfield_10000": "",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "priority": {
+        "self": "http://localhost:8082/rest/api/2/priority/3",
+        "iconUrl": "http://localhost:8082/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "customfield_10100": "0|i0000n:",
+      "customfield_10101": null,
+      "customfield_10102": null,
+      "labels": [],
+      "environment": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+            "id": "10503",
+            "author": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+            "updateAuthor": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "created": "2018-05-15T11:39:29.299+0000",
+            "updated": "2018-05-15T11:39:29.299+0000"
+          }
+        ],
+        "maxResults": 1,
+        "total": 1,
+        "startAt": 0
+      },
+      "issuelinks": [],
+      "votes": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      },
+      "updated": "2020-06-27T00:43:53.099+0000",
+      "status": {
+        "self": "http://localhost:8082/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "http://localhost:8082/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "http://localhost:8082/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "comment": {
+    "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+    "id": "10503",
+    "author": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "body": "[~test] creating a test comment\r\n\r\na second line [~alice] for [~accountid:bob123] the [~assignee] [~reporter] test comment",
+    "updateAuthor": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "created": "2020-06-27T00:44:57.013+0000",
+    "updated": "2020-06-27T00:44:57.013+0000"
+  }
+}

--- a/server/testdata/webhook-issue-comment-edited-notify-assignee-and-reporter.json
+++ b/server/testdata/webhook-issue-comment-edited-notify-assignee-and-reporter.json
@@ -1,0 +1,248 @@
+{
+  "timestamp": 1593218697100,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_comment_edited",
+  "user": {
+    "self": "http://localhost:8082/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "sample@yahoo.com",
+    "avatarUrls": {
+      "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+      "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+      "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+      "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+    },
+    "displayName": "Test",
+    "active": true,
+    "timeZone": "GMT"
+  },
+  "issue": {
+    "id": "10101",
+    "self": "http://localhost:8082/rest/api/2/issue/10101",
+    "key": "TEST-4",
+    "fields": {
+      "issuetype": {
+        "self": "http://localhost:8082/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "http://localhost:8082/images/icons/issuetypes/story.svg",
+        "name": "Story",
+        "subtask": false
+      },
+      "components": [],
+      "timespent": null,
+      "timeoriginalestimate": null,
+      "description": "Creating an issue for unit testing",
+      "project": {
+        "self": "http://localhost:8082/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TEST",
+        "name": "Test",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/projectavatar?avatarId=10324",
+          "24x24": "http://localhost:8082/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "http://localhost:8082/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "http://localhost:8082/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "timetracking": {},
+      "customfield_10106": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "summary": "unit testing",
+      "lastViewed": "2020-06-27T00:44:24.621+0000",
+      "watches": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "creator": {
+        "self": "http://localhost:8082/rest/api/2/user?username=Test",
+        "name": "Test",
+        "key": "test",
+        "emailAddress": "sample@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "user",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "subtasks": [],
+      "created": "2020-06-27T00:43:53.099+0000",
+      "assignee": {
+        "self": "http://localhost:8082/rest/api/2/user?username=assignee",
+        "name": "assignee",
+        "accountID": "assignee123",
+        "key": "assignee",
+        "emailAddress": "assignee@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Assignee",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "reporter": {
+        "self": "http://localhost:8082/rest/api/2/user?username=reporter",
+        "name": "reporter",
+        "accountID": "reporter123",
+        "key": "reporter",
+        "emailAddress": "reporter@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Reporter",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "customfield_10000": "",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "priority": {
+        "self": "http://localhost:8082/rest/api/2/priority/3",
+        "iconUrl": "http://localhost:8082/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "customfield_10100": "0|i0000n:",
+      "customfield_10101": null,
+      "customfield_10102": null,
+      "labels": [],
+      "environment": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+            "id": "10503",
+            "author": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+            "updateAuthor": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "created": "2018-05-15T11:39:29.299+0000",
+            "updated": "2018-05-15T11:39:29.299+0000"
+          }
+        ],
+        "maxResults": 1,
+        "total": 1,
+        "startAt": 0
+      },
+      "issuelinks": [],
+      "votes": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      },
+      "updated": "2020-06-27T00:43:53.099+0000",
+      "status": {
+        "self": "http://localhost:8082/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "http://localhost:8082/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "http://localhost:8082/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "comment": {
+    "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+    "id": "10503",
+    "author": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "body": "[~test] creating a test comment\r\n\r\na second line for the test comment",
+    "updateAuthor": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "created": "2020-06-27T00:44:57.013+0000",
+    "updated": "2020-06-27T00:44:57.013+0000"
+  }
+}

--- a/server/testdata/webhook-issue-comment-edited-notify-mentioned-users.json
+++ b/server/testdata/webhook-issue-comment-edited-notify-mentioned-users.json
@@ -1,0 +1,248 @@
+{
+  "timestamp": 1593218697100,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_comment_edited",
+  "user": {
+    "self": "http://localhost:8082/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "sample@yahoo.com",
+    "avatarUrls": {
+      "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+      "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+      "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+      "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+    },
+    "displayName": "Test",
+    "active": true,
+    "timeZone": "GMT"
+  },
+  "issue": {
+    "id": "10101",
+    "self": "http://localhost:8082/rest/api/2/issue/10101",
+    "key": "TEST-4",
+    "fields": {
+      "issuetype": {
+        "self": "http://localhost:8082/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "http://localhost:8082/images/icons/issuetypes/story.svg",
+        "name": "Story",
+        "subtask": false
+      },
+      "components": [],
+      "timespent": null,
+      "timeoriginalestimate": null,
+      "description": "Creating an issue for unit testing",
+      "project": {
+        "self": "http://localhost:8082/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TEST",
+        "name": "Test",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/projectavatar?avatarId=10324",
+          "24x24": "http://localhost:8082/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "http://localhost:8082/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "http://localhost:8082/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "timetracking": {},
+      "customfield_10106": null,
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "summary": "unit testing",
+      "lastViewed": "2020-06-27T00:44:24.621+0000",
+      "watches": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "creator": {
+        "self": "http://localhost:8082/rest/api/2/user?username=Test",
+        "name": "Test",
+        "key": "test",
+        "emailAddress": "sample@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "user",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "subtasks": [],
+      "created": "2020-06-27T00:43:53.099+0000",
+      "assignee": {
+        "self": "http://localhost:8082/rest/api/2/user?username=assignee",
+        "name": "assignee",
+        "accountID": "assignee123",
+        "key": "assignee",
+        "emailAddress": "assignee@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Assignee",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "reporter": {
+        "self": "http://localhost:8082/rest/api/2/user?username=reporter",
+        "name": "reporter",
+        "accountID": "reporter123",
+        "key": "reporter",
+        "emailAddress": "reporter@gmail.com",
+        "avatarUrls": {
+          "48x48": "http://localhost:8082/secure/useravatar?avatarId=10349",
+          "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10349",
+          "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10349",
+          "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10349"
+        },
+        "displayName": "Reporter",
+        "active": true,
+        "timeZone": "GMT"
+      },
+      "customfield_10000": "",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "priority": {
+        "self": "http://localhost:8082/rest/api/2/priority/3",
+        "iconUrl": "http://localhost:8082/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "customfield_10100": "0|i0000n:",
+      "customfield_10101": null,
+      "customfield_10102": null,
+      "labels": [],
+      "environment": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/issue/10013/comment/10005",
+            "id": "10503",
+            "author": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "body": "Joined Sample Sprint 2 1 days 4 hours 10 minutes ago",
+            "updateAuthor": {
+              "self": "http://sales-jira.centralus.cloudapp.azure.com:8080/rest/api/2/user?username=craig",
+              "name": "craig",
+              "key": "craig",
+              "emailAddress": "craig@mattermost.com",
+              "avatarUrls": {
+                "48x48": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?avatarId=10341",
+                "24x24": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=small&avatarId=10341",
+                "16x16": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=xsmall&avatarId=10341",
+                "32x32": "http://sales-jira.centralus.cloudapp.azure.com:8080/secure/useravatar?size=medium&avatarId=10341"
+              },
+              "displayName": "Craig Vitter",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "created": "2018-05-15T11:39:29.299+0000",
+            "updated": "2018-05-15T11:39:29.299+0000"
+          }
+        ],
+        "maxResults": 1,
+        "total": 1,
+        "startAt": 0
+      },
+      "issuelinks": [],
+      "votes": {
+        "self": "http://localhost:8082/rest/api/2/issue/TEST-4/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      },
+      "updated": "2020-06-27T00:43:53.099+0000",
+      "status": {
+        "self": "http://localhost:8082/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "http://localhost:8082/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "http://localhost:8082/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "comment": {
+    "self": "http://localhost:8082/rest/api/2/issue/10101/comment/10503",
+    "id": "10503",
+    "author": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "body": "[~test] creating a test comment\r\n\r\na second line [~alice] for [~accountid:bob123] the [~assignee] [~reporter] test comment",
+    "updateAuthor": {
+      "self": "http://localhost:8082/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "sample@yahoo.com",
+      "avatarUrls": {
+        "48x48": "http://localhost:8082/secure/useravatar?avatarId=10337",
+        "24x24": "http://localhost:8082/secure/useravatar?size=small&avatarId=10337",
+        "16x16": "http://localhost:8082/secure/useravatar?size=xsmall&avatarId=10337",
+        "32x32": "http://localhost:8082/secure/useravatar?size=medium&avatarId=10337"
+      },
+      "displayName": "Test",
+      "active": true,
+      "timeZone": "GMT"
+    },
+    "created": "2020-06-27T00:44:57.013+0000",
+    "updated": "2020-06-27T00:44:57.013+0000"
+  }
+}

--- a/server/user.go
+++ b/server/user.go
@@ -44,6 +44,10 @@ func (c *Connection) JiraAccountID() types.ID {
 
 type ConnectionSettings struct {
 	Notifications bool `json:"notifications"`
+
+	// these will take effect if Notifications is true
+	SendNotificationsForAssigned bool `json:"send_notifications_for_assigned"`
+	SendNotificationsForReporter bool `json:"send_notifications_for_reporter"`
 }
 
 func (s *ConnectionSettings) String() string {

--- a/server/utils.go
+++ b/server/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
-func (p *Plugin) CreateBotDMPost(instanceID, mattermostUserID types.ID, message, postType string) (post *model.Post, returnErr error) {
+func (p *Plugin) CreateBotDMPost(instanceID, mattermostUserID types.ID, message, postType, recipientType string) (post *model.Post, returnErr error) {
 	defer func() {
 		if returnErr != nil {
 			returnErr = errors.WithMessage(returnErr,
@@ -30,6 +30,10 @@ func (p *Plugin) CreateBotDMPost(instanceID, mattermostUserID types.ID, message,
 		return nil, nil
 	}
 	if c.Settings == nil || !c.Settings.Notifications {
+		return nil, nil
+	}
+	if (recipientType == recipientTypeAssignee && !c.Settings.SendNotificationsForAssigned) ||
+		(recipientType == recipientTypeReporter && !c.Settings.SendNotificationsForReporter) {
 		return nil, nil
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -22,6 +22,11 @@ const (
 	commentCreated = "comment_created"
 )
 
+const (
+	recipientTypeAssignee = "assignee"
+	recipientTypeReporter = "reporter"
+)
+
 type Webhook interface {
 	Events() StringSet
 	PostToChannel(p *Plugin, instanceID types.ID, channelID, fromUserID string) (*model.Post, int, error)
@@ -51,6 +56,7 @@ type webhookUserNotification struct {
 	message       string
 	postType      string
 	commentSelf   string
+	recipientType string
 }
 
 func (wh *webhook) Events() StringSet {
@@ -149,7 +155,7 @@ func (wh *webhook) PostNotifications(p *Plugin, instanceID types.ID) ([]*model.P
 
 		notification.message = p.replaceJiraAccountIds(instance.GetID(), notification.message)
 
-		post, err := p.CreateBotDMPost(instance.GetID(), mattermostUserID, notification.message, notification.postType)
+		post, err := p.CreateBotDMPost(instance.GetID(), mattermostUserID, notification.message, notification.postType, notification.recipientType)
 		if err != nil {
 			p.errorf("PostNotifications: failed to create notification post, err: %v", err)
 			continue

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -306,6 +306,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 			message:       commentMessage,
 			postType:      PostTypeComment,
 			commentSelf:   jwh.Comment.Self,
+			recipientType: recipientTypeAssignee,
 		})
 	}
 	if !reporterMentioned && shouldSendNotification(jwh.Issue.Fields.Reporter, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
@@ -315,6 +316,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 			message:       commentMessage,
 			postType:      PostTypeComment,
 			commentSelf:   jwh.Comment.Self,
+			recipientType: recipientTypeReporter,
 		})
 	}
 }

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -299,7 +299,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	// Don't send a notification to the assignee or reporter if they don't exist, or if are also the author.
 	// Also, if the assignee or reporter was mentioned above, avoid sending a duplicate notification here.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
-	if !assigneeMentioned && canSendNotification(jwh.Issue.Fields.Assignee, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
+	if !assigneeMentioned && shouldSendNotification(jwh.Issue.Fields.Assignee, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
 		wh.notifications = append(wh.notifications, webhookUserNotification{
 			jiraUsername:  jwh.Issue.Fields.Assignee.Name,
 			jiraAccountID: jwh.Issue.Fields.Assignee.AccountID,
@@ -308,7 +308,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 			commentSelf:   jwh.Comment.Self,
 		})
 	}
-	if !reporterMentioned && canSendNotification(jwh.Issue.Fields.Reporter, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
+	if !reporterMentioned && shouldSendNotification(jwh.Issue.Fields.Reporter, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
 		wh.notifications = append(wh.notifications, webhookUserNotification{
 			jiraUsername:  jwh.Issue.Fields.Reporter.Name,
 			jiraAccountID: jwh.Issue.Fields.Reporter.AccountID,
@@ -319,7 +319,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	}
 }
 
-func canSendNotification(to *jira.User, fromName, fromAccountID string) bool {
+func shouldSendNotification(to *jira.User, fromName, fromAccountID string) bool {
 	return !(to == nil || to.Name == fromName || (to.AccountID != "" && to.AccountID == fromAccountID))
 }
 

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -296,8 +296,8 @@ func appendCommentNotifications(wh *webhook, verb string) {
 
 	commentMessage := fmt.Sprintf("%s **commented** on %s:\n>%s", commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body)
 
-	// Don't send a notification to the assignee if they don't exist, or if are also the author.
-	// Also, if the assignee was mentioned above, avoid sending a duplicate notification here.
+	// Don't send a notification to the assignee or reporter if they don't exist, or if are also the author.
+	// Also, if the assignee or reporter was mentioned above, avoid sending a duplicate notification here.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
 	if !assigneeMentioned && canSendNotification(jwh.Issue.Fields.Assignee, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {
 		wh.notifications = append(wh.notifications, webhookUserNotification{

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -296,7 +296,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 
 	commentMessage := fmt.Sprintf("%s **commented** on %s:\n>%s", commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body)
 
-	// Don't send a notification to the assignee or reporter if they don't exist, or if are also the author.
+	// Don't send a notification to the assignee or reporter if they don't exist, or if they are also the author.
 	// Also, if the assignee or reporter was mentioned above, avoid sending a duplicate notification here.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
 	if !assigneeMentioned && shouldSendNotification(jwh.Issue.Fields.Assignee, jwh.User.Name, jwh.Comment.UpdateAuthor.AccountID) {

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -149,11 +149,13 @@ func TestNotificationsIssueCommentCreatedEdited(t *testing.T) {
 					jiraUsername:  "assignee",
 					jiraAccountID: "assignee123",
 					postType:      PostTypeComment,
+					recipientType: recipientTypeAssignee,
 				},
 				{
 					jiraUsername:  "reporter",
 					jiraAccountID: "reporter123",
 					postType:      PostTypeComment,
+					recipientType: recipientTypeReporter,
 				},
 			},
 		},
@@ -185,11 +187,13 @@ func TestNotificationsIssueCommentCreatedEdited(t *testing.T) {
 					jiraUsername:  "assignee",
 					jiraAccountID: "assignee123",
 					postType:      PostTypeComment,
+					recipientType: recipientTypeAssignee,
 				},
 				{
 					jiraUsername:  "reporter",
 					jiraAccountID: "reporter123",
 					postType:      PostTypeComment,
+					recipientType: recipientTypeReporter,
 				},
 			},
 		},
@@ -234,6 +238,7 @@ func TestNotificationsIssueCommentCreatedEdited(t *testing.T) {
 				require.Equal(t, tc.expectedNotifs[i].jiraUsername, w.notifications[i].jiraUsername)
 				require.Equal(t, tc.expectedNotifs[i].jiraAccountID, w.notifications[i].jiraAccountID)
 				require.Equal(t, tc.expectedNotifs[i].postType, w.notifications[i].postType)
+				require.Equal(t, tc.expectedNotifs[i].recipientType, w.notifications[i].recipientType)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR modifies `appendCommentNotifications` so both Assignee and Reporter will get a notification when someone comments on their issue (previously, only Assignee gets the notification)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/699
