### PR TITLE
[GH-708] Fix check for autolink plug-in errors

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -313,7 +313,7 @@ func (p *Plugin) OnActivate() error {
 				continue
 			}
 			if status.State != model.PluginStateRunning {
-				p.API.LogWarn("OnActivate: Autolink plugin unavailable. Plug-in is not running", "status", status)
+				p.API.LogWarn("OnActivate: Autolink plugin unavailable. Plugin is not running", "status", status)
 				continue
 			}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -308,8 +308,12 @@ func (p *Plugin) OnActivate() error {
 			}
 
 			status, apiErr := p.API.GetPluginStatus(autolinkPluginId)
-			if apiErr != nil || status.State != model.PluginStateRunning {
-				p.API.LogWarn("OnActivate: Autolink plugin is unavailable", "error", err.Error(), "status", status)
+			if apiErr != nil {
+				p.API.LogWarn("OnActivate: Autolink plugin unavailable. API returned error", "error", apiErr.Error())
+				continue
+			}
+			if status.State != model.PluginStateRunning {
+				p.API.LogWarn("OnActivate: Autolink plugin unavailable. Plug-in is not running", "status", status)
 				continue
 			}
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug I stumbled upon when I was trying to reproduce #676 against the current `master`. That bug was causing the plug-in to crash due to the wrong error object being called during the warning log of autolink plug-in checks. Here I'm only making sure that the correct error object is used and only if it is not `nil`. More details can be found on the issue itself.

Thanks @mickmister for helping me with the troubleshooting.

#### Ticket Link
Fixes #708 

