### PR TITLE
[GH-149] Send ephemeral message after /jira connect flow succeeds

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -424,8 +424,8 @@ export function handleConnectChange(store) {
             return;
         }
 
-        if (msg.event === "custom_jira_connect") {
-            store.dispatch(sendEphemeralPost("You have successfully connected your Jira account."));
+        if (msg.event === 'custom_jira_connect') {
+            store.dispatch(sendEphemeralPost('You have successfully connected your Jira account.'));
         }
 
         store.dispatch({

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -425,7 +425,7 @@ export function handleConnectChange(store) {
         }
 
         if (msg.event === 'custom_jira_connect') {
-            store.dispatch(sendEphemeralPost('You have successfully connected your Jira account.'));
+            store.dispatch(sendEphemeralPost('You have successfully connected your Jira account. Type in /jira to get started. '));
         }
 
         store.dispatch({

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -424,6 +424,10 @@ export function handleConnectChange(store) {
             return;
         }
 
+        if (msg.event === "custom_jira_connect") {
+            store.dispatch(sendEphemeralPost("You have successfully connected your Jira account."));
+        }
+
         store.dispatch({
             type: ActionTypes.RECEIVED_CONNECTED,
             data: msg.data,


### PR DESCRIPTION
#### Summary
This PR sends an ephemeral message to the user after the `/jira connect` flow is completed. Please check [this comment](https://github.com/mattermost/mattermost-plugin-jira/issues/149#issuecomment-716924011) regarding this issue, as this PR does not address all the requirements.

#### Ticket Link
GH-149

