### PR TITLE
Update help-and-support.md

### DIFF
--- a/docs/development/help-and-support.md
+++ b/docs/development/help-and-support.md
@@ -1,10 +1,5 @@
 # Help and Support
 
-For Mattermost customers - please open a [support case](https://mattermost.zendesk.com/hc/en-us/requests/new) to ensure your issue is tracked properly.
-
-For Questions, Suggestions and Help - please find us on our forum at [https://forum.mattermost.org/c/plugins](https://forum.mattermost.org/c/plugins)
-
-Alternatively, join our pubic Mattermost server and join the Integrations and Apps channel here: [https://community-daily.mattermost.com/core/channels/integrations](https://community-daily.mattermost.com/core/channels/integrations)
-
-To Contribute to the Mattermost project see [https://www.mattermost.org/contribute-to-mattermost/](https://www.mattermost.org/contribute-to-mattermost/)
-
+- For Mattermost customers - Please open a support case.
+- For questions, suggestions, and help, visit the [Jira Plugin channel](https://community.mattermost.com/core/channels/jira-plugin) on our Community server.
+- To report a bug, please [open an issue](https://github.com/mattermost/mattermost-plugin-jira/issues).


### PR DESCRIPTION
Updates the help and support section of the docs. Applies to all versions of the docs. 

@hanzei, from what I understand, once this is merged I can cherry-pick it to all the docs branches? I should probably add that this PR https://github.com/mattermost/mattermost-plugin-jira/pull/702 was merged a while back but I don't see its changes reflected, hence this PR. 