### PR TITLE
GG-720

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -686,7 +686,7 @@ func executeInstanceList(p *Plugin, c *plugin.Context, header *model.CommandArgs
 
 	instances, err := p.instanceStore.LoadInstances()
 	if err != nil {
-		return p.responsef(header, "Failed to load known Jira instances: %v", err)
+		return p.responsef(header, "No Jira instances have been installed")
 	}
 	if instances.IsEmpty() {
 		return p.responsef(header, "(none installed)\n")


### PR DESCRIPTION
Ugly error message for `/jira instance list` when there are no instances installed.

#### Summary
Changed text to "No Jira instances have been installed" from "Failed to load known Jira instances: "

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/720


