### PR TITLE
Add *User param to GetUserInfo to avoid read replica issue

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -421,7 +421,7 @@ func executeConnect(p *Plugin, c *plugin.Context, header *model.CommandArgs, arg
 		jiraURL = instance.InstanceID.String()
 	}
 
-	info, err := p.GetUserInfo(types.ID(header.UserId))
+	info, err := p.GetUserInfo(types.ID(header.UserId), nil)
 	if err != nil {
 		return p.responsef(header, "Failed to connect: "+err.Error())
 	}
@@ -982,7 +982,7 @@ func executeInfo(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 		return ""
 	}
 
-	info, err := p.GetUserInfo(mattermostUserID)
+	info, err := p.GetUserInfo(mattermostUserID, nil)
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}

--- a/server/info.go
+++ b/server/info.go
@@ -32,7 +32,7 @@ func (p *Plugin) httpGetUserInfo(w http.ResponseWriter, r *http.Request) (int, e
 			errors.New("not authorized"))
 	}
 
-	info, err := p.GetUserInfo(types.ID(mattermostUserId))
+	info, err := p.GetUserInfo(types.ID(mattermostUserId), nil)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
@@ -40,15 +40,19 @@ func (p *Plugin) httpGetUserInfo(w http.ResponseWriter, r *http.Request) (int, e
 	return respondJSON(w, info.AsConfigMap())
 }
 
-func (p *Plugin) GetUserInfo(mattermostUserID types.ID) (*UserInfo, error) {
+func (p *Plugin) GetUserInfo(mattermostUserID types.ID, user *User) (*UserInfo, error) {
+	var err error
+
 	instances, err := p.instanceStore.LoadInstances()
 	if err != nil {
 		return nil, err
 	}
 
-	user, err := p.MigrateV2User(mattermostUserID)
-	if err != nil {
-		return nil, err
+	if user == nil {
+		user, err = p.MigrateV2User(mattermostUserID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	isConnected := !user.ConnectedInstances.IsEmpty()

--- a/server/instances.go
+++ b/server/instances.go
@@ -324,7 +324,7 @@ func (p *Plugin) httpAutocompleteConnect(w http.ResponseWriter, r *http.Request)
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
-	info, err := p.GetUserInfo(mattermostUserID)
+	info, err := p.GetUserInfo(mattermostUserID, nil)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
@@ -348,7 +348,7 @@ func (p *Plugin) httpAutocompleteUserInstance(w http.ResponseWriter, r *http.Req
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
-	info, err := p.GetUserInfo(mattermostUserID)
+	info, err := p.GetUserInfo(mattermostUserID, nil)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
@@ -390,7 +390,7 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
-	info, err := p.GetUserInfo(mattermostUserID)
+	info, err := p.GetUserInfo(mattermostUserID, nil)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
@@ -422,7 +422,7 @@ func (p *Plugin) httpAutocompleteInstalledInstance(w http.ResponseWriter, r *htt
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
-	info, err := p.GetUserInfo(mattermostUserID)
+	info, err := p.GetUserInfo(mattermostUserID, nil)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}

--- a/server/user.go
+++ b/server/user.go
@@ -198,7 +198,7 @@ func (p *Plugin) UpdateUserDefaults(mattermostUserID, instanceID types.ID, proje
 		}
 	}
 
-	info, err := p.GetUserInfo(types.ID(mattermostUserID))
+	info, err := p.GetUserInfo(types.ID(mattermostUserID), user)
 	if err != nil {
 		return
 	}
@@ -246,7 +246,7 @@ func (p *Plugin) connectUser(instance Instance, mattermostUserID types.ID, conne
 		return err
 	}
 
-	info, err := p.GetUserInfo(types.ID(mattermostUserID))
+	info, err := p.GetUserInfo(types.ID(mattermostUserID), user)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (p *Plugin) disconnectUser(instance Instance, user *User) (*Connection, err
 		return nil, err
 	}
 
-	info, err := p.GetUserInfo(types.ID(user.MattermostUserID))
+	info, err := p.GetUserInfo(types.ID(user.MattermostUserID), user)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Summary

There is an issue where we update user info in the kv store, and immediately try to read the info, resulting in a data inconsistency.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/694