### PR TITLE
Bump version to 3.0.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v3.0.0",
   "icon_path": "assets/icon.svg",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "min_server_version": "5.26.0",
   "server": {
     "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "jira",
-	Version: "3.0.0",
+	Version: "3.0.1",
 }

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -1,2 +1,2 @@
 export const id = 'jira';
-export const version = '3.0.0';
+export const version = '3.0.1';


### PR DESCRIPTION
#### Summary

This release contains the following PRs on top of 3.0:

- https://github.com/mattermost/mattermost-plugin-jira/pull/660
- https://github.com/mattermost/mattermost-plugin-jira/pull/723

See https://github.com/mattermost/mattermost-plugin-jira/pull/735

