### PR TITLE
Fix for issue #748 Mattermost Attach to Jira Issue

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -366,7 +366,7 @@ func endpointURL(endpoint string) (string, error) {
 	return endpoint, nil
 }
 
-var keyOrIDRegex = regexp.MustCompile("(^[[:alpha:]]+-)?[[:digit:]]+$")
+var keyOrIDRegex = regexp.MustCompile("(^[[:alnum:]]+-)?[[:digit:]]+$")
 
 func endpointNameFromRequest(r *http.Request) string {
 	_, path := splitInstancePath(r.URL.Path)

--- a/server/issue.go
+++ b/server/issue.go
@@ -639,7 +639,7 @@ func (p *Plugin) GetJiraProjectMetadata(instanceID, mattermostUserID types.ID) (
 	return metainfo, connection, nil
 }
 
-var reJiraIssueKey = regexp.MustCompile(`^([[:alpha:]]+)-([[:digit:]]+)$`)
+var reJiraIssueKey = regexp.MustCompile(`^([[:alnum:]]+)-([[:digit:]]+)$`)
 
 func (p *Plugin) httpAttachCommentToIssue(w http.ResponseWriter, r *http.Request) (int, error) {
 	if r.Method != http.MethodPost {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This is fix for problem with finding issues on Jira side when Jira issues are using alphanumeric keys (like GEN2-3080). This problem makes impossible to attach message as a Jira issue comment for such issues by using issue number.



  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/748


