### PR TITLE
Fix for #749 - problem with recognizing Jira issues with alphanumeric issue ID

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -366,7 +366,7 @@ func endpointURL(endpoint string) (string, error) {
 	return endpoint, nil
 }
 
-var keyOrIDRegex = regexp.MustCompile("(^[[:alpha:]]+-)?[[:digit:]]+$")
+var keyOrIDRegex = regexp.MustCompile("(^[[:alnum:]]+-)?[[:digit:]]+$")
 
 func endpointNameFromRequest(r *http.Request) string {
 	_, path := splitInstancePath(r.URL.Path)

--- a/server/issue.go
+++ b/server/issue.go
@@ -639,7 +639,7 @@ func (p *Plugin) GetJiraProjectMetadata(instanceID, mattermostUserID types.ID) (
 	return metainfo, connection, nil
 }
 
-var reJiraIssueKey = regexp.MustCompile(`^([[:alpha:]]+)-([[:digit:]]+)$`)
+var reJiraIssueKey = regexp.MustCompile(`^([[:alnum:]]+)-([[:digit:]]+)$`)
 
 func (p *Plugin) httpAttachCommentToIssue(w http.ResponseWriter, r *http.Request) (int, error) {
 	if r.Method != http.MethodPost {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

When JIRA issue has alphanumeric id (like GEN2-3080) it cannot be found when user is trying attach comment from the Mattermost chat to Jira


#### Ticket Link
fixes: https://github.com/mattermost/mattermost-plugin-jira/pull/749

