### PR TITLE
[GH-745] Check status of the Jira instance before trying to install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dghubble/oauth1 v0.5.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/uuid v1.2.0
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/mattermost/mattermost-plugin-api v0.0.16
 	github.com/mattermost/mattermost-plugin-autolink v1.2.2-0.20210709183311-c8fa30db649f
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210621071817-df224571d8a1

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,8 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jamiealquiza/envy v1.1.0/go.mod h1:MP36BriGCLwEHhi1OU8E9569JNZrjWfCvzG7RsPnHus=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/server/command.go
+++ b/server/command.go
@@ -784,6 +784,15 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
+
+	jiraIsAccessible, err := utils.IsJiraAccessible(jiraURL)
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
+	if !jiraIsAccessible {
+		return p.responsef(header, "It looks like we couldn't validate the connection to your Jira server. Please make sure the URL was entered correctly. This could also be because of existing firewall or proxy rules. If you intend to have a one way integration from Jira to Mattermost this is not an issue.")
+	}
+
 	if strings.Contains(jiraURL, "http:") {
 		jiraURL = strings.ReplaceAll(jiraURL, "http:", "https:")
 		return p.responsef(header, "`/jira install cloud` requires a secure connection (HTTPS). Please run the following command:\n```\n/jira install cloud %s\n```", jiraURL)
@@ -831,6 +840,14 @@ func executeInstanceInstallServer(p *Plugin, c *plugin.Context, header *model.Co
 	}
 	if isJiraCloudURL {
 		return p.responsef(header, "The Jira URL you provided looks like a Jira Cloud URL - install it with:\n```\n/jira install cloud %s\n```", jiraURL)
+	}
+
+	jiraIsAccessible, err := utils.IsJiraAccessible(jiraURL)
+	if err != nil {
+		return p.responsef(header, err.Error())
+	}
+	if !jiraIsAccessible {
+		return p.responsef(header, "It looks like we couldn't validate the connection to your Jira server. Please make sure the URL was entered correctly. This could also be because of existing firewall or proxy rules. If you intend to have a one way integration from Jira to Mattermost this is not an issue.")
 	}
 
 	instance := newServerInstance(p, jiraURL)

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -90,7 +90,7 @@ func IsJiraAccessible(jiraURL string) (bool, error) {
 		return false, nil
 	}
 	if r.StatusCode != http.StatusOK {
-		return false, nil
+		return false, errors.Errorf("Jira server returned http status code %q when checking for availability: %q", r.Status, jiraURL)
 	}
 
 	resBody, err := ioutil.ReadAll(r.Body)
@@ -103,6 +103,9 @@ func IsJiraAccessible(jiraURL string) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
+	if j.State != "RUNNING" {
+		return false, errors.Errorf("Jira server is not in correct state, it should be up and running: %q", jiraURL)
+	}
 
-	return j.State == "RUNNING", nil
+	return true, nil
 }

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -78,7 +78,7 @@ type JiraStatus struct {
 func IsJiraAccessible(jiraURL string) (bool, error) {
 	u, err := url.Parse(jiraURL)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	if u.Host == "" {
 		return false, errors.Errorf("Invalid URL, no hostname: %q", jiraURL)
@@ -87,7 +87,7 @@ func IsJiraAccessible(jiraURL string) (bool, error) {
 	jURL := strings.TrimSuffix(u.String(), "/")
 	r, err := http.Get(jURL + "/status")
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	if r.StatusCode != http.StatusOK {
 		return false, nil

--- a/server/utils/utils_test.go
+++ b/server/utils/utils_test.go
@@ -154,7 +154,7 @@ func TestIsJiraCloudURL(t *testing.T) {
 func TestIsJiraAccessible(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
-	dummyUrl := "https://dummy-url.com"
+	dummyURL := "https://dummy-url.com"
 
 	tests := map[string]struct {
 		status     int
@@ -168,10 +168,10 @@ func TestIsJiraAccessible(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			httpmock.RegisterResponder("GET", dummyUrl+"/status",
+			httpmock.RegisterResponder("GET", dummyURL+"/status",
 				httpmock.NewStringResponder(tt.status, tt.resBody))
 
-			jiraIsAccessible, _ := IsJiraAccessible(dummyUrl)
+			jiraIsAccessible, _ := IsJiraAccessible(dummyURL)
 			assert.Equal(t, tt.accessible, jiraIsAccessible)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Soner Eker <sonereker@gmail.com>

#### Summary
Before trying to install Jira instance (cloud or server), do a `GET` request to instance `/status`
 endpoint which basically provides state information of the Jira instance. If instance is in `RUNNING` state, it means instance is accessible and it's OK to continue with installation.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-jira/issues/745

#### Verification Video:

https://drive.google.com/file/d/1SDyHiRCy5ryKxCnKU98xvokVH5cD677R/view?usp=sharing