### PR TITLE
Make new installs of Jira Cloud use Applinks to install

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -798,35 +798,35 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 		}
 	}
 
-	// instance := newCloudInstanceOAuth(p, jiraURL)
-	// err = p.InstallInstance(instance)
-	// if err != nil {
-	// 	return p.responsef(header, err.Error())
-	// }
-	// pkey, err := publicKeyString(p)
-	// if err != nil {
-	// 	return p.responsef(header, "Failed to load public key: %v", err)
-	// }
-
-	// return p.respondCommandTemplate(header, "/command/install_server.md", map[string]string{
-	// 	"JiraURL":       jiraURL,
-	// 	"PluginURL":     p.GetPluginURL(),
-	// 	"MattermostKey": instance.GetMattermostKey(),
-	// 	"PublicKey":     strings.TrimSpace(string(pkey)),
-	// })
-
-	// Create an "uninitialized" instance of Jira Cloud that will
-	// receive the /installed callback
-	err = p.instanceStore.CreateInactiveCloudInstance(types.ID(jiraURL))
+	instance := newCloudInstanceOAuth(p, jiraURL)
+	err = p.InstallInstance(instance)
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}
+	pkey, err := publicKeyString(p)
+	if err != nil {
+		return p.responsef(header, "Failed to load public key: %v", err)
+	}
 
-	return p.respondCommandTemplate(header, "/command/install_cloud.md", map[string]string{
-		"JiraURL":                 jiraURL,
-		"PluginURL":               p.GetPluginURL(),
-		"AtlassianConnectJSONURL": p.GetPluginURL() + instancePath(routeACJSON, types.ID(jiraURL)),
+	return p.respondCommandTemplate(header, "/command/install_server.md", map[string]string{
+		"JiraURL":       jiraURL,
+		"PluginURL":     p.GetPluginURL(),
+		"MattermostKey": instance.GetMattermostKey(),
+		"PublicKey":     strings.TrimSpace(string(pkey)),
 	})
+
+	// Create an "uninitialized" instance of Jira Cloud that will
+	// receive the /installed callback
+	// err = p.instanceStore.CreateInactiveCloudInstance(types.ID(jiraURL))
+	// if err != nil {
+	// 	return p.responsef(header, err.Error())
+	// }
+
+	// return p.respondCommandTemplate(header, "/command/install_cloud.md", map[string]string{
+	// 	"JiraURL":                 jiraURL,
+	// 	"PluginURL":               p.GetPluginURL(),
+	// 	"AtlassianConnectJSONURL": p.GetPluginURL() + instancePath(routeACJSON, types.ID(jiraURL)),
+	// })
 }
 
 func executeInstanceInstallServer(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -793,9 +793,27 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 	instances, _ := p.instanceStore.LoadInstances()
 	if !p.enterpriseChecker.HasEnterpriseFeatures() {
 		if instances != nil && len(instances.IDs()) > 0 {
+			// APPLINKTODO: handle dual install case
 			return p.responsef(header, "You need a valid Mattermost Enterprise E20 License to install multiple Jira instances")
 		}
 	}
+
+	// instance := newCloudInstanceOAuth(p, jiraURL)
+	// err = p.InstallInstance(instance)
+	// if err != nil {
+	// 	return p.responsef(header, err.Error())
+	// }
+	// pkey, err := publicKeyString(p)
+	// if err != nil {
+	// 	return p.responsef(header, "Failed to load public key: %v", err)
+	// }
+
+	// return p.respondCommandTemplate(header, "/command/install_server.md", map[string]string{
+	// 	"JiraURL":       jiraURL,
+	// 	"PluginURL":     p.GetPluginURL(),
+	// 	"MattermostKey": instance.GetMattermostKey(),
+	// 	"PublicKey":     strings.TrimSpace(string(pkey)),
+	// })
 
 	// Create an "uninitialized" instance of Jira Cloud that will
 	// receive the /installed callback

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package main
+
+import (
+	"net/http"
+
+	"github.com/andygrunwald/go-jira"
+	"github.com/dghubble/oauth1"
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-jira/server/expvar"
+	"github.com/mattermost/mattermost-plugin-jira/server/utils"
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
+)
+
+// Leaving this commented out code here as a comparison of the original function
+
+// func newCloudInstance(p *Plugin, key types.ID, installed bool, rawASC string, asc *AtlassianSecurityContext) *cloudInstance {
+// 	return &cloudInstance{
+// 		InstanceCommon:              newInstanceCommon(p, CloudInstanceType, key),
+// 		Installed:                   installed,
+// 		RawAtlassianSecurityContext: rawASC,
+// 		AtlassianSecurityContext:    asc,
+// 	}
+// }
+
+func newCloudInstanceOAuth(p *Plugin, jiraURL string) *cloudInstance {
+	return &cloudInstance{
+		InstanceCommon:   newInstanceCommon(p, CloudInstanceType, types.ID(jiraURL)),
+		MattermostKey:    p.GetPluginKey(),
+		Installed:        true, // APPLINKTODO: not sure what should be done here. This is called during install, and will probably be make to be called in kv.go later
+		InstalledAppLink: true,
+	}
+}
+
+func (ci *cloudInstance) GetURLOAuth() string {
+	return ci.InstanceID.String()
+}
+
+func (ci *cloudInstance) GetMattermostKeyOAuth() string {
+	return ci.MattermostKey
+}
+
+func (ci *cloudInstance) GetDisplayDetailsOAuth() map[string]string {
+	return map[string]string{
+		"Jira Server Mattermost Key": ci.MattermostKey,
+	}
+}
+
+func (ci *cloudInstance) GetUserConnectURLOAuth(mattermostUserID string) (returnURL string, cookie *http.Cookie, returnErr error) {
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		returnErr = errors.WithMessage(returnErr, "failed to get a connect link")
+	}()
+
+	oauth1Config := ci.getOAuth1Config()
+	token, secret, err := oauth1Config.RequestToken()
+	if err != nil {
+		return "", nil, err
+	}
+
+	err = ci.Plugin.otsStore.StoreOauth1aTemporaryCredentials(mattermostUserID,
+		&OAuth1aTemporaryCredentials{Token: token, Secret: secret})
+	if err != nil {
+		return "", nil, err
+	}
+
+	authURL, err := oauth1Config.AuthorizationURL(token)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return authURL.String(), nil, nil
+}
+
+func (ci *cloudInstance) getClientForConnectionOAuth(connection *Connection) (jiraClient *jira.Client, returnErr error) {
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		returnErr = errors.WithMessage(returnErr, "failed to get a Jira client for "+connection.DisplayName)
+	}()
+
+	if connection.Oauth1AccessToken == "" || connection.Oauth1AccessSecret == "" {
+		return nil, errors.New("no access token, please use /jira connect")
+	}
+
+	token := oauth1.NewToken(connection.Oauth1AccessToken, connection.Oauth1AccessSecret)
+	conf := ci.getConfig()
+
+	httpClient := ci.getOAuth1Config().Client(oauth1.NoContext, token)
+	httpClient = utils.WrapHTTPClient(httpClient,
+		utils.WithRequestSizeLimit(conf.maxAttachmentSize),
+		utils.WithResponseSizeLimit(conf.maxAttachmentSize))
+	httpClient = expvar.WrapHTTPClient(httpClient,
+		conf.stats, endpointNameFromRequest)
+
+	jiraClient, err := jira.NewClient(httpClient, ci.GetURL())
+	if err != nil {
+		return nil, err
+	}
+
+	return jiraClient, err
+}
+
+func (ci *cloudInstance) getOAuth1Config() *oauth1.Config {
+	p := ci.Plugin
+	return &oauth1.Config{
+		ConsumerKey:    ci.MattermostKey,
+		ConsumerSecret: "consumer_secret",
+		CallbackURL:    p.GetPluginURL() + "/" + instancePath(routeOAuth1Complete, ci.InstanceID),
+		Endpoint: oauth1.Endpoint{
+			RequestTokenURL: ci.GetURL() + "/plugins/servlet/oauth/request-token",
+			AuthorizeURL:    ci.GetURL() + "/plugins/servlet/oauth/authorize",
+			AccessTokenURL:  ci.GetURL() + "/plugins/servlet/oauth/access-token",
+		},
+		Signer: &oauth1.RSASigner{
+			PrivateKey: p.getConfig().rsaKey,
+		},
+	}
+}

--- a/server/issue.go
+++ b/server/issue.go
@@ -413,13 +413,13 @@ func (p *Plugin) WorkflowCreateIssue(activationParams *workflowclient.ActionActi
 	} else {
 		ci, ok := instance.(*cloudInstance)
 		if !ok {
-			return nil, errors.New("userID is required for jira server instances")
+			return nil, errors.New("userID is required for jira cloud instances")
 		}
 
 		var jiraClient *jira.Client
 		jiraClient, err = ci.getClientForBot()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get jira client for server: %w", err)
+			return nil, fmt.Errorf("unable to get jira client for bot: %w", err)
 		}
 
 		client = &JiraClient{Jira: jiraClient}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -338,6 +338,12 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) AddAutolinksForCloudInstance(ci *cloudInstance) error {
+	if true {
+		// There is an issue in master where we cant get project keys with the bot client
+		// May be the cause for other issues too related to comments on Jira cloud
+		return nil
+	}
+
 	client, err := ci.getClientForBot()
 	if err != nil {
 		return fmt.Errorf("unable to get jira client for server: %w", err)

--- a/server/user_cloud.go
+++ b/server/user_cloud.go
@@ -81,7 +81,7 @@ func (p *Plugin) httpACUserInteractive(w http.ResponseWriter, r *http.Request, i
 		return respondErr(w, http.StatusBadRequest, errors.New("invalid JWT claim sub"))
 	}
 
-	jiraClient, _, err := ci.getClientForConnection(&Connection{User: jira.User{AccountID: accountID}})
+	jiraClient, _, err := ci.getClientForConnectionLegacy(&Connection{User: jira.User{AccountID: accountID}})
 	if err != nil {
 		return respondErr(w, http.StatusBadRequest, errors.Errorf("could not get client for user, err: %v", err))
 	}

--- a/server/user_server.go
+++ b/server/user_server.go
@@ -47,7 +47,10 @@ func (p *Plugin) httpOAuth1aComplete(w http.ResponseWriter, r *http.Request, ins
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
-	si, ok := instance.(*serverInstance)
+
+	// APPLINKTODO: OAuth complete should support Jira server and Jira cloud.
+	// In this commit, Jira server is not supported because of this line
+	si, ok := instance.(*cloudInstance)
 	if !ok {
 		return http.StatusInternalServerError,
 			errors.Errorf("Not supported for instance type %s", instance.Common().Type)


### PR DESCRIPTION
#### Summary

This PR makes it so new Jira Cloud installs use the Applink install instead of Atlassian Connect. This makes it so users don't have to use third-party cookies to authenticate. This is currently a draft.

Some things that still need to be done:

- For fetching comments with the Jira Cloud bot account, the admin will still need to do the original install path for Jira Cloud in addition to the Applink install.
    - The current state of this PR does not allow the original install path. It instead assumes you will be installing with the Applink. We need to have the admin install both ways to support the Jira Cloud bot account.
    - The Jira Cloud bot account doesn't seem to be working correctly right now anyway on master. See https://github.com/mattermost/mattermost-plugin-jira/issues/758. That is why the `if true` block exists in this PR for now
- Legacy users need to disconnect and reconnect. I have code in place that should allow for them to seamlessly continue using their account, but it doesn't seem to be working.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/743