### PR TITLE
Fix assignee comment notification for Jira Cloud

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -292,7 +292,8 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	// Don't send a notification to the assignee if they don't exist, or if are also the author.
 	// Also, if the assignee was mentioned above, avoid sending a duplicate notification here.
 	// Jira Server uses name field, Jira Cloud uses the AccountID field.
-	if assigneeMentioned || jwh.Issue.Fields.Assignee == nil || jwh.Issue.Fields.Assignee.Name == jwh.User.Name ||
+	if assigneeMentioned || jwh.Issue.Fields.Assignee == nil ||
+		(jwh.Issue.Fields.Assignee.Name != "" && jwh.Issue.Fields.Assignee.Name == jwh.User.Name) ||
 		(jwh.Issue.Fields.Assignee.AccountID != "" && jwh.Issue.Fields.Assignee.AccountID == jwh.Comment.UpdateAuthor.AccountID) {
 		return
 	}


### PR DESCRIPTION
#### Summary

This PR fixes an issue where Jira Cloud users are not receiving DM notifications for being the assignee of an issue.

The issue was that we were first checking if the `Name` of the assignee matched the comment author, but we were not checking if these values were empty. On Jira Cloud, both values are always empty, so they were always equal, so the condition was always true.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/479

Note that the assignee will only receive notifications for *comments* on the issue. There is no functionality in the plugin that makes it so the assignee gets a notification for updating the epic for instance.