### PR TITLE
Let Jira cloud install finish when autolink fails

### DIFF
--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -84,7 +84,7 @@ func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request) (int, e
 	// Setup autolink
 	err = p.AddAutolinksForCloudInstance(newInstance)
 	if err != nil {
-		return respondErr(w, http.StatusInternalServerError, err)
+		p.API.LogInfo("could not install autolinks for cloud instance", "instance", ci.BaseURL, "err", err)
 	}
 
 	return respondJSON(w, []string{"OK"})

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -322,7 +322,7 @@ func (p *Plugin) OnActivate() error {
 			}
 
 			if err = p.AddAutolinksForCloudInstance(ci); err != nil {
-				p.API.LogWarn("could not install autolinks for cloud instance", "instance", ci.BaseURL, "err", err)
+				p.API.LogInfo("could not install autolinks for cloud instance", "instance", ci.BaseURL, "err", err)
 				continue
 			}
 		}


### PR DESCRIPTION
#### Summary

This PR makes it so the Jira Cloud instance install does not fail when the autolinks register fails. It's still unknown why the Jira Cloud bot account cannot fetch the project keys, but this is at least a fix for the bug of stopping the instance install when that happens.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/758