### PR TITLE
[GH-772] - allow `/subscribe list` command to continue if channel has been deleted.

### DIFF
--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -466,7 +466,7 @@ func (p *Plugin) getSortedSubscriptions(instanceID types.ID) ([]SubsGroupedByTea
 
 			channel, appErr := p.API.GetChannel(channelID)
 			if appErr != nil {
-				p.API.LogWarn("getSortedSubscriptions: failed to get channel.", "channelID", channelID, "error", appErr)
+				p.API.LogDebug("getSortedSubscriptions: failed to get channel.", "channelID", channelID, "error", appErr)
 				continue
 			}
 

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -466,7 +466,8 @@ func (p *Plugin) getSortedSubscriptions(instanceID types.ID) ([]SubsGroupedByTea
 
 			channel, appErr := p.API.GetChannel(channelID)
 			if appErr != nil {
-				return nil, errors.New("failed to get channel")
+				p.API.LogWarn("getSortedSubscriptions: failed to get channel.", "channelID", channelID, "error", appErr)
+				continue
 			}
 
 			if subsMap[channel.TeamId] == nil {


### PR DESCRIPTION
#### Summary
Do not return an error if a subscription points to a channel that was deleted from the database. Instead, log the error and move on so the `list` command is still functional.

**QA Testing**
`/jira subscribe list`
* created subscription to a channel
* verified the webhook sent a notification to the channel
* manually deleted channel from the Database
* `/jira subscribe list` still shows channel subscription
* `make restart-server` to pick up the DB change with channel deleted
* `/jira subscribe list` 
  * does not show subscription for the channel
  * does not respond with `failed to get channel`
  * sends logged message for deleted channel(s)
    * ![image](https://user-images.githubusercontent.com/7575921/124163736-7dad6600-da65-11eb-82a1-3992f75ffa17.png)

`Webhook Notifications`
When a channel that has subscriptions gets deleted from the database, the webhook will still get sent. The webhook logs the following message.
![image](https://user-images.githubusercontent.com/7575921/124164117-06c49d00-da66-11eb-92ee-1301b4ef664d.png)


#### Ticket Link
#772 