### PR TITLE
Don't log error for rest/applinks calls

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -75,6 +75,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	status, err := p.serveHTTP(c, w, r)
 	if err != nil {
 		p.API.LogError("ERROR: ", "Status", strconv.Itoa(status), "Error", err.Error(), "Host", r.Host, "RequestURI", r.RequestURI, "Method", r.Method, "query", r.URL.Query().Encode())
+		return
 	}
 	p.API.LogDebug("OK: ", "Status", strconv.Itoa(status), "Host", r.Host, "RequestURI", r.RequestURI, "Method", r.Method, "query", r.URL.Query().Encode())
 }
@@ -195,11 +196,8 @@ func (p *Plugin) serveHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		return p.httpChannelSubscriptions(w, r)
 	}
 
-	if strings.HasPrefix(path, "/rest/applinks") {
-		return http.StatusNotFound, nil
-	}
-
-	return respondErr(w, http.StatusNotFound, errors.New("not found"))
+	w.Write([]byte("not found"))
+	return http.StatusNotFound, nil
 }
 
 func (p *Plugin) loadTemplates(dir string) (map[string]*template.Template, error) {

--- a/server/http.go
+++ b/server/http.go
@@ -196,7 +196,7 @@ func (p *Plugin) serveHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		return p.httpChannelSubscriptions(w, r)
 	}
 
-	w.Write([]byte("not found"))
+	http.Error(w, "not found", http.StatusNotFound)
 	return http.StatusNotFound, nil
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -195,6 +195,10 @@ func (p *Plugin) serveHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		return p.httpChannelSubscriptions(w, r)
 	}
 
+	if strings.HasPrefix(path, "/rest/applinks") {
+		return http.StatusNotFound, nil
+	}
+
 	return respondErr(w, http.StatusNotFound, errors.New("not found"))
 }
 


### PR DESCRIPTION
#### Summary

There are some polling mechanisms Jira Server uses to query our plugin for health checks etc. Instead of logging each of these requests as errors, we should instead just return a 404 without logging an error.

Error messages:

```
{"level":"error","ts":1629292283.469139,"caller":"mlog/sugar.go:25","msg":"ERROR: ","plugin_id":"jira","Status":"404","Error":"not found","Host":"*","RequestURI":"/plugins/jira/rest/applinks/latest/capabilities/STATUS_API","Method":"GET","query":""}
{"level":"error","ts":1629292283.4739969,"caller":"mlog/sugar.go:25","msg":"ERROR: ","plugin_id":"jira","Status":"404","Error":"not found","Host":"*","RequestURI":"/plugins/jira/rest/applinks/latest/manifest","Method":"GET","query":""}
```

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/801