### PR TITLE
Add back build info

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -4,6 +4,7 @@ ifndef MM_RUDDER_WRITE_KEY
 endif
 LDFLAGS += -X "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
 
+# Build info
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)
 BUILD_HASH_SHORT = $(shell git rev-parse --short HEAD)

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -3,3 +3,12 @@ ifndef MM_RUDDER_WRITE_KEY
 	MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
 endif
 LDFLAGS += -X "github.com/mattermost/mattermost-plugin-jira/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
+
+BUILD_DATE = $(shell date -u)
+BUILD_HASH = $(shell git rev-parse HEAD)
+BUILD_HASH_SHORT = $(shell git rev-parse --short HEAD)
+LDFLAGS += -X "main.BuildDate=$(BUILD_DATE)"
+LDFLAGS += -X "main.BuildHash=$(BUILD_HASH)"
+LDFLAGS += -X "main.BuildHashShort=$(BUILD_HASH_SHORT)"
+
+GO_BUILD_FLAGS = -ldflags '$(LDFLAGS)'


### PR DESCRIPTION
#### Summary
Add back build info for `/jira info`. This was broken in https://github.com/mattermost/mattermost-plugin-jira/pull/712.
![Screenshot from 2021-09-27 15-53-27](https://user-images.githubusercontent.com/16541325/134922953-d989eb29-a519-49ae-9039-4f38d47c0b25.png)


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/806