### PR TITLE
[issue 789] Legacy webhook do not work on Jira V3 unless the Jira instance is installed #789

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -100,6 +100,10 @@ func (p *Plugin) serveHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 		routeUserStart,
 		routeAPISubscribeWebhook:
 
+		if path == routeIncomingWebhook && instanceURL == "" {
+			break
+		}
+
 		callbackInstanceID, err = p.ResolveWebhookInstanceURL(instanceURL)
 		if err != nil {
 			return respondErr(w, http.StatusInternalServerError, err)


### PR DESCRIPTION
bypassed the check for legacy webhook when instanceid is missing

ticket here
fixes #789 