### PR TITLE
switched away from deprecated GetCreateIssueMeta to get the list of p…

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -54,7 +55,7 @@ type UserService interface {
 // ProjectService is the interface for project-related APIs.
 type ProjectService interface {
 	GetProject(key string) (*jira.Project, error)
-	GetAllProjectKeys() ([]string, error)
+	ListProjects(query string, limit int) (jira.ProjectList, error)
 }
 
 // SearchService is the interface for search-related APIs.
@@ -165,20 +166,6 @@ func (client JiraClient) RESTPostAttachment(issueID string, data []byte, name st
 	}
 
 	return attachments[0], nil
-}
-
-func (client JiraClient) GetAllProjectKeys() ([]string, error) {
-	projectlist, resp, err := client.Jira.Project.GetList()
-	if err != nil {
-		return nil, userFriendlyJiraError(resp, err)
-	}
-
-	keys := make([]string, 0, len(*projectlist))
-	for _, project := range *projectlist {
-		keys = append(keys, project.Key)
-	}
-
-	return keys, nil
 }
 
 // GetProject returns a Project by key.
@@ -405,7 +392,7 @@ func endpointURL(endpoint string) (string, error) {
 	}
 	if parsedURL.Scheme == "" {
 		// relative path
-		endpoint = fmt.Sprintf("/rest/api/%s", endpoint)
+		endpoint = path.Join("/rest/api", endpoint)
 	}
 	return endpoint, nil
 }

--- a/server/client_cloud.go
+++ b/server/client_cloud.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -65,4 +66,51 @@ func (client jiraCloudClient) GetUserGroups(connection *Connection) ([]*jira.Use
 		return nil, err
 	}
 	return groups, nil
+}
+
+func (client jiraCloudClient) ListProjects(query string, limit int) (jira.ProjectList, error) {
+	type searchResult struct {
+		Values     jira.ProjectList `json:"values"`
+		StartAt    int              `json:"startAt"`
+		MaxResults int              `json:"maxResults"`
+		Total      int              `json:"total"`
+		IsLast     bool             `json:"isLast"`
+	}
+
+	remaining := 50
+	fetchAll := false
+	if limit > 0 {
+		remaining = limit
+	}
+	if limit < 0 {
+		fetchAll = true
+	}
+
+	var out jira.ProjectList
+	for {
+		opts := map[string]string{
+			"startAt":    strconv.Itoa(len(out)),
+			"maxResults": strconv.Itoa(remaining),
+			"expand":     "issueTypes",
+		}
+		var result searchResult
+		err := client.RESTGet("/3/project/search", opts, &result)
+		if err != nil {
+			return nil, err
+		}
+		if len(result.Values) > remaining {
+			result.Values = result.Values[:remaining]
+		}
+		out = append(out, result.Values...)
+		remaining -= len(result.Values)
+
+		if !fetchAll && remaining == 0 {
+			// Got enough.
+			return out, nil
+		}
+		if len(result.Values) == 0 || result.IsLast {
+			// Ran out of results.
+			return out, nil
+		}
+	}
 }

--- a/server/client_server.go
+++ b/server/client_server.go
@@ -62,3 +62,18 @@ func (client jiraServerClient) GetUserGroups(connection *Connection) ([]*jira.Us
 	}
 	return result.Groups.Items, nil
 }
+
+func (client jiraServerClient) ListProjects(query string, limit int) (jira.ProjectList, error) {
+	plist, resp, err := client.Jira.Project.GetList()
+	if err != nil {
+		return nil, userFriendlyJiraError(resp, err)
+	}
+	if plist == nil {
+		return jira.ProjectList{}, nil
+	}
+	result := *plist
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}

--- a/server/issue.go
+++ b/server/issue.go
@@ -502,13 +502,13 @@ func (p *Plugin) httpGetJiraProjectMetadata(w http.ResponseWriter, r *http.Reque
 
 	instanceID := r.FormValue("instance_id")
 
-	cimd, connection, err := p.GetJiraProjectMetadata(types.ID(instanceID), types.ID(mattermostUserID))
+	plist, connection, err := p.ListJiraProjects(types.ID(instanceID), types.ID(mattermostUserID))
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError,
 			errors.WithMessage(err, "failed to GetProjectMetadata"))
 	}
 
-	if len(cimd.Projects) == 0 {
+	if len(plist) == 0 {
 		_, err = respondJSON(w, map[string]interface{}{
 			"error": "You do not have permission to create issues in any projects. Please contact your Jira admin.",
 		})
@@ -518,21 +518,20 @@ func (p *Plugin) httpGetJiraProjectMetadata(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	type option = utils.ReactSelectOption
-	projects := make([]option, 0, len(cimd.Projects))
-	issues := make(map[string][]option, len(cimd.Projects))
-	for _, prj := range cimd.Projects {
-		projects = append(projects, option{
+	projects := []utils.ReactSelectOption{}
+	issues := map[string][]utils.ReactSelectOption{}
+	for _, prj := range plist {
+		projects = append(projects, utils.ReactSelectOption{
 			Value: prj.Key,
 			Label: prj.Name,
 		})
-		issueTypes := make([]option, 0, len(prj.IssueTypes))
+		issueTypes := []utils.ReactSelectOption{}
 		for _, issue := range prj.IssueTypes {
-			if issue.Subtasks {
+			if issue.Subtask {
 				continue
 			}
-			issueTypes = append(issueTypes, option{
-				Value: issue.Id,
+			issueTypes = append(issueTypes, utils.ReactSelectOption{
+				Value: issue.ID,
 				Label: issue.Name,
 			})
 		}
@@ -546,16 +545,16 @@ func (p *Plugin) httpGetJiraProjectMetadata(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-func (p *Plugin) GetJiraProjectMetadata(instanceID, mattermostUserID types.ID) (*jira.CreateMetaInfo, *Connection, error) {
+func (p *Plugin) ListJiraProjects(instanceID, mattermostUserID types.ID) (jira.ProjectList, *Connection, error) {
 	client, _, connection, err := p.getClient(instanceID, mattermostUserID)
 	if err != nil {
 		return nil, nil, err
 	}
-	metainfo, err := client.GetCreateMeta(nil)
+	plist, err := client.ListProjects("", -1)
 	if err != nil {
 		return nil, nil, err
 	}
-	return metainfo, connection, nil
+	return plist, connection, nil
 }
 
 var reJiraIssueKey = regexp.MustCompile(`^([[:alnum:]]+)-([[:digit:]]+)$`)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -351,12 +351,13 @@ func (p *Plugin) AddAutolinksForCloudInstance(ci *cloudInstance) error {
 		return fmt.Errorf("unable to get jira client for server: %w", err)
 	}
 
-	keys, err := JiraClient{Jira: client}.GetAllProjectKeys()
+	plist, err := jiraCloudClient{JiraClient{Jira: client}}.ListProjects("", -1)
 	if err != nil {
 		return fmt.Errorf("unable to get project keys: %w", err)
 	}
 
-	for _, key := range keys {
+	for _, proj := range plist {
+		key := proj.Key
 		err = p.AddAutolinks(key, ci.BaseURL)
 	}
 	if err != nil {


### PR DESCRIPTION
There was a customer report that not all projects were showing in the project list ("edit subscription")

This PR switches away from using the `GetCreateIssueMeta` which is deprecated, in favor of cloud|server-specific APIs to get the list of all projects.

cc @hanzei 