### PR TITLE
Fix CI timeouts using `npm install --verbose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/.npminstall:
 ifneq ($(HAS_WEBAPP),)
-	git config --global url."ssh://git@".insteadOf git://
+	git config url."ssh://git@".insteadOf git://
 	cd webapp && $(NPM) install
 	touch $@
 endif

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/.npminstall:
 ifneq ($(HAS_WEBAPP),)
+	git config --global url."ssh://git@".insteadOf git://
 	cd webapp && $(NPM) install
 	touch $@
 endif

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/.npminstall:
 ifneq ($(HAS_WEBAPP),)
-	git config url."ssh://git@".insteadOf git://
-	cd webapp && $(NPM) install
+	cd webapp && $(NPM) install --verbose
 	touch $@
 endif
 


### PR DESCRIPTION
#### Summary

Edit: I've changed the solution to use `--verbose`, as CI was still timing out with the git config changes.

Inspiration taken from https://community-daily.mattermost.com/core/pl/5kec7ujznpf79nx49n4bjctchw. This solution is an alternative to adding `--verbose` to the `npm install` command. This solution more directly addresses the timing out issue.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44776
