### PR TITLE
[GH-773]: Fixed Issue Jira's autolink should support issue links that contain a comment link in the URL

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
+	jira "github.com/andygrunwald/go-jira"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	"github.com/mattermost/mattermost-plugin-api/experimental/flow"
 	"github.com/mattermost/mattermost-plugin-api/experimental/telemetry"
@@ -356,30 +357,35 @@ func (p *Plugin) AddAutolinksForCloudInstance(ci *cloudInstance) error {
 		return fmt.Errorf("unable to get project keys: %w", err)
 	}
 
-	for _, proj := range plist {
-		key := proj.Key
-		err = p.AddAutolinks(key, ci.BaseURL)
-	}
-	if err != nil {
+	if err = p.AddAutolinks(plist, ci.BaseURL); err != nil {
 		return fmt.Errorf("some keys were not installed: %w", err)
 	}
 
 	return nil
 }
 
-func (p *Plugin) AddAutolinks(key, baseURL string) error {
+func (p *Plugin) AddAutolinks(projectList jira.ProjectList, baseURL string) error {
 	baseURL = strings.TrimRight(baseURL, "/")
 	installList := []autolink.Autolink{
 		{
+			Name:     "Jump to comment for " + baseURL,
+			Pattern:  `(` + strings.ReplaceAll(baseURL, ".", `\.`) + `/browse/)(?P<project_id>\w+)(-)(?P<jira_id>\d+)[?](focusedCommentId)(=)(?P<comment_id>\d+)`,
+			Template: `[${project_id}-${jira_id} (comment)](` + baseURL + `/browse/${project_id}-${jira_id}?focusedCommentId=${comment_id})`,
+		},
+		{
+			Name:     "Link to key for " + baseURL,
+			Pattern:  `(` + strings.ReplaceAll(baseURL, ".", `\.`) + `/browse/)(?P<project_id>\w+)(-)(?P<jira_id>\d+)`,
+			Template: `[${project_id}-${jira_id}](` + baseURL + `/browse/${project_id}-${jira_id})`,
+		},
+	}
+
+	for _, project := range projectList {
+		key := project.Key
+		installList = append(installList, autolink.Autolink{
 			Name:     key + " key to link for " + baseURL,
 			Pattern:  `(` + key + `)(-)(?P<jira_id>\d+)`,
 			Template: `[` + key + `-${jira_id}](` + baseURL + `/browse/` + key + `-${jira_id})`,
-		},
-		{
-			Name:     key + " link to key for " + baseURL,
-			Pattern:  `(` + strings.ReplaceAll(baseURL, ".", `\.`) + `/browse/)(` + key + `)(-)(?P<jira_id>\d+)`,
-			Template: `[` + key + `-${jira_id}](` + baseURL + `/browse/` + key + `-${jira_id})`,
-		},
+		})
 	}
 
 	client := autolinkclient.NewClientPlugin(p.API)


### PR DESCRIPTION
**Summary** 

- Currently the autolink config used by this plugin converts issue links to shorthand links, but it does not work when the originally posted URL has a comment link at the end of the posted URL. Fixed this issue updated the pattern for focusedCommentId as well.
- This PR contains all the changes from [Pr #839](https://github.com/mattermost/mattermost-plugin-jira/pull/839). So this PR alone is enough to fix this issue so we can close [Pr #839](https://github.com/mattermost/mattermost-plugin-jira/pull/839) afterward.

**Issue** 

- [Issue #773](https://github.com/mattermost/mattermost-plugin-jira/issues/773) 
- [Pr #839](https://github.com/mattermost/mattermost-plugin-jira/pull/839)
