### PR TITLE
Changing Jira Server docker compose configuration

### DIFF
--- a/docker-compose-jiraserver.yml
+++ b/docker-compose-jiraserver.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+services:
+  jira:
+    depends_on:
+      - postgresql
+    image: mattermost/jira-software-arm64:${VERSION}
+    build:
+      context: .
+      dockerfile: ./jiraserver.Dockerfile
+    networks:
+      - jiranet
+    volumes:
+      - jiradata:/var/atlassian/jira
+    ports:
+      - '8080:8080'
+    logging:
+      # limit logs retained on host to 25MB
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "50"
+
+  postgresql:
+    image: postgres:9.5-alpine
+    networks:
+      - jiranet
+    volumes:
+      - postgresqldata:/var/lib/postgresql/data
+    environment:
+      - 'POSTGRES_USER=jira'
+      # CHANGE THE PASSWORD!
+      - 'POSTGRES_PASSWORD=Postgres_password'
+      - 'POSTGRES_DB=jiradb'
+      - 'POSTGRES_ENCODING=UNICODE'
+      - 'POSTGRES_COLLATE=C'
+      - 'POSTGRES_COLLATE_TYPE=C'
+    logging:
+      # limit logs retained on host to 25MB
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "50"
+
+volumes:
+  jiradata:
+    external: false
+  postgresqldata:
+    external: false
+
+networks:
+  jiranet:
+    driver: bridge

--- a/docker-compose-jiraserver.yml
+++ b/docker-compose-jiraserver.yml
@@ -1,5 +1,7 @@
 version: '3'
 
+# IMPORTANT! Check the instructions and recommendations @
+# https://mattermost.gitbook.io/plugin-jira/development/jira-server
 services:
   jira:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '3'
-services:
-  jira:
-    image: atlassian/jira-software:7 # It is recommended to test with version 7. Most, if not all, compatibility issues between Jira Server/Cloud exist in version 7.
-    # image: atlassian/jira-software:8 # Test with version 8 as well when adding new webhook handling logic, or introducing a new Jira API call.
-    ports:
-      - "8080:8080"

--- a/docs/development/jira-server.md
+++ b/docs/development/jira-server.md
@@ -4,6 +4,12 @@ If you want to test the plugin against JIRA Server, you can deploy one locally u
 
 Keep in mind this version is a configuration for development purposes only and will be dangerous to deploy in production.
 
+## Recommendations
+
+**It is recommended to test with version 7**. Most, if not all, compatibility issues between Jira Server/Cloud exist in version 7.
+
+**Test with version 8** as well when adding new webhook handling logic, or introducing a new Jira API call.
+
 ## Instructions
 
 ## Optional configuration
@@ -14,10 +20,10 @@ You might want to change the Postgres password before running it [here](https://
 
 First we build the image in the project root folder:
 
-The default version is 8.22.0, you can change it through the `VERSION ENVVAR`.
+The default version is 7.13.1, you can change it through the `VERSION ENVVAR`.
 
 Keep in mind the current Mattermost JIRA Plugin covers version 7 and 8 of JIRA Server now.
 
 ```bash
-VERSION=8.22.0 docker-compose -f docker-compose-jiraserver.yml up
+VERSION=7.13.1 docker-compose -f docker-compose-jiraserver.yml up
 ```

--- a/docs/development/jira-server.md
+++ b/docs/development/jira-server.md
@@ -1,0 +1,23 @@
+# JIRA Server
+
+If you want to test the plugin against JIRA Server, you can deploy one locally using `docker-compose`.
+
+Keep in mind this version is a configuration for development purposes only and will be dangerous to deploy in production.
+
+## Instructions
+
+## Optional configuration
+
+You might want to change the Postgres password before running it [here](https://github.com/mattermost/mattermost-plugin-jira/blob/master/docker-compose-jiraserver.yml#L33).
+
+## Installation
+
+First we build the image in the project root folder:
+
+The default version is 8.22.0, you can change it through the `VERSION ENVVAR`.
+
+Keep in mind the current Mattermost JIRA Plugin covers version 7 and 8 of JIRA Server now.
+
+```bash
+VERSION=8.22.0 docker-compose -f docker-compose-jiraserver.yml up
+```

--- a/docs/development/jira-server.md
+++ b/docs/development/jira-server.md
@@ -18,8 +18,6 @@ You might want to change the Postgres password before running it [here](https://
 
 ## Installation
 
-First we build the image in the project root folder:
-
 The default version is 7.13.1, you can change it through the `VERSION ENVVAR`. When using version 7, by default it's using `JDK_VERSION=8`.
 
 Keep in mind the current Mattermost JIRA Plugin covers version 7 and 8 of JIRA Server now.

--- a/docs/development/jira-server.md
+++ b/docs/development/jira-server.md
@@ -20,10 +20,21 @@ You might want to change the Postgres password before running it [here](https://
 
 First we build the image in the project root folder:
 
-The default version is 7.13.1, you can change it through the `VERSION ENVVAR`.
+The default version is 7.13.1, you can change it through the `VERSION ENVVAR`. When using version 7, by default it's using `JDK_VERSION=8`.
 
 Keep in mind the current Mattermost JIRA Plugin covers version 7 and 8 of JIRA Server now.
 
 ```bash
-VERSION=7.13.1 docker-compose -f docker-compose-jiraserver.yml up
+JDK_VERSION=8 VERSION=7.13.1 docker-compose -f docker-compose-jiraserver.yml up
+```
+
+If you want to run JIRA server version 8
+
+```bash
+# In case you have used if before to build 7, you need to rebuild it without the cache
+# to get the parameters
+export JDK_VERSION=11
+export VERSION=8.22.0
+docker-compose -f docker-compose-jiraserver.yml build --no-cache
+docker-compose -f docker-compose-jiraserver.yml up
 ```

--- a/jiraserver.Dockerfile
+++ b/jiraserver.Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+ARG VERSION=8.22.0
+WORKDIR /home
+RUN apt update
+RUN apt --assume-yes install openjdk-11-jdk curl
+RUN mkdir -p downloads
+RUN cd downloads
+RUN mkdir -p jirahome
+RUN curl https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-${VERSION}.tar.gz --output atlassian-jira-software.tar.gz
+RUN mkdir jira && tar xvf atlassian-jira-software.tar.gz -C jira --strip-components 1
+
+ENV JIRA_HOME=/home/downloads/jirahome
+CMD ["jira/bin/start-jira.sh", "-fg"]

--- a/jiraserver.Dockerfile
+++ b/jiraserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-ARG VERSION=8.22.0
+ARG VERSION=7.13.1
 WORKDIR /home
 RUN apt update
 RUN apt --assume-yes install openjdk-11-jdk curl

--- a/jiraserver.Dockerfile
+++ b/jiraserver.Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:latest
 ARG VERSION=7.13.1
+ARG JDK_VERSION=8
 WORKDIR /home
 RUN apt update
-RUN apt --assume-yes install openjdk-11-jdk curl
+RUN apt --assume-yes install openjdk-${JDK_VERSION}-jdk curl
 RUN mkdir -p downloads
 RUN cd downloads
 RUN mkdir -p jirahome


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The current Docker compose got stuck in my configuration (which might not be enough good reason to change this). I think this docker-compose is more complex because it also has an external database, but it's also more configurable with the `$VERSION` envvar.

The `$JDK_VERSION` has to be also configurable, since Jira 7 doesn't support `openjdk-11`, but `openjdk-8`.

Let me know what you think!

I'll be updating the plugin documentation too to explain how to use this.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

