### PR TITLE
[GH-867]:Clicking the x next to an array element in the JIRA create issue modal causes a Javascript error

### DIFF
--- a/webapp/src/components/jira_field.jsx
+++ b/webapp/src/components/jira_field.jsx
@@ -175,7 +175,7 @@ export default class JiraField extends React.Component {
                 }
 
                 const onChange = (id, val) => {
-                    const newValue = val.map((v) => ({id: v}));
+                    const newValue = val ? val.map((v) => ({id: v})) : [];
                     this.props.onChange(id, newValue);
                 };
 


### PR DESCRIPTION
**Summary** 

- Clicking the x next to an array element in the JIRA create issue modal causes a Javascript error to occur, though clicking the x to the right of the select box works correctly.

**Issue** 

- [Issue #867](https://github.com/mattermost/mattermost-plugin-jira/issues/867) 

