### PR TITLE
Improve error handling in `OnSendDailyTelemetry`

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -535,7 +535,7 @@ func (p *Plugin) OnSendDailyTelemetry() {
 		if cloud > 0 {
 			args["cloud_instance_count"] = cloud
 		}
-		
+
 		// Subscriptions
 		numSubscriptions := 0
 		var subs *Subscriptions
@@ -546,7 +546,7 @@ func (p *Plugin) OnSendDailyTelemetry() {
 			}
 			numSubscriptions += len(subs.Channel.ByID)
 		}
-	
+
 		args["subscriptions"] = numSubscriptions
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -538,16 +538,17 @@ func (p *Plugin) OnSendDailyTelemetry() {
 		
 		
 		// Subscriptions
-		subscriptions := 0
+		numSubscriptions := 0
+		var subs *Subscriptions
 		for _, id := range instances.IDs() {
-			subs, err := p.getSubscriptions(id)
+			subs, err = p.getSubscriptions(id)
 			if err != nil {
 				p.API.LogWarn("Failed to get subscriptions for telemetry", "error", err)
 			}
-			subscriptions += len(subs.Channel.ByID)
+			numSubscriptions += len(subs.Channel.ByID)
 		}
 	
-		args["subscriptions"] = subscriptions
+		args["subscriptions"] = numSubscriptions
 	}
 
 	// Connected users

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -519,40 +519,44 @@ func (p *Plugin) OnSendDailyTelemetry() {
 	instances, err := p.instanceStore.LoadInstances()
 	if err != nil {
 		p.API.LogWarn("Failed to get instances for telemetry", "error", err)
-	}
-	for _, id := range instances.IDs() {
-		switch instances.Get(id).Type {
-		case ServerInstanceType:
-			server++
-		case CloudInstanceType:
-			cloud++
+	} else {
+		for _, id := range instances.IDs() {
+			switch instances.Get(id).Type {
+			case ServerInstanceType:
+				server++
+			case CloudInstanceType:
+				cloud++
+			}
 		}
-	}
-	args["instance_count"] = server + cloud
-	if server > 0 {
-		args["server_instance_count"] = server
-	}
-	if cloud > 0 {
-		args["cloud_instance_count"] = cloud
+		args["instance_count"] = server + cloud
+		if server > 0 {
+			args["server_instance_count"] = server
+		}
+		if cloud > 0 {
+			args["cloud_instance_count"] = cloud
+		}
+		
+		
+		// Subscriptions
+		subscriptions := 0
+		for _, id := range instances.IDs() {
+			subs, err := p.getSubscriptions(id)
+			if err != nil {
+				p.API.LogWarn("Failed to get subscriptions for telemetry", "error", err)
+			}
+			subscriptions += len(subs.Channel.ByID)
+		}
+	
+		args["subscriptions"] = subscriptions
 	}
 
 	// Connected users
 	connected, err := p.userStore.CountUsers()
 	if err != nil {
 		p.API.LogWarn("Failed to get the number of connected users for telemetry", "error", err)
+	} else {
+		args["connected_user_count"] = connected
 	}
-	args["connected_user_count"] = connected
-
-	// Subscriptions
-	subscriptions := 0
-	for _, id := range instances.IDs() {
-		subs, err := p.getSubscriptions(id)
-		if err != nil {
-			p.API.LogWarn("Failed to get subscriptions for telemetry", "error", err)
-		}
-		subscriptions += len(subs.Channel.ByID)
-	}
-	args["subscriptions"] = subscriptions
 
 	_ = p.tracker.TrackEvent("stats", args)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -536,7 +536,6 @@ func (p *Plugin) OnSendDailyTelemetry() {
 			args["cloud_instance_count"] = cloud
 		}
 		
-		
 		// Subscriptions
 		numSubscriptions := 0
 		var subs *Subscriptions


### PR DESCRIPTION
#### Summary

There are blocks in the `OnSendDailyTelemetry` function that check for an error, and log the error, but doesn't actually handle the error afterwards. This PR makes it so we don't attempt to access the invalid return value used in the error'd function calls.

https://github.com/mattermost/mattermost-plugin-jira/blob/e4f60983998d0f474172df79f76b5d9b087e3838/server/plugin.go#L519-L531

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

