### PR TITLE
Allow the "@" character when parse jira usernames

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -112,7 +112,7 @@ func parseJIRAUsernamesFromText(text string) []string {
 	usernameMap := map[string]bool{}
 	usernames := []string{}
 
-	var re = regexp.MustCompile(`(?m)\[~([a-zA-Z0-9-_.:\+]+)\]`)
+	var re = regexp.MustCompile(`(?m)\[~([a-zA-Z0-9-_@.:\+]+)\]`)
 	for _, match := range re.FindAllString(text, -1) {
 		name := match[:len(match)-1]
 		name = name[2:]

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJIRAUsernamesFromText(t *testing.T) {
+	tcs := []struct {
+		Text     string
+		Expected []string
+	}{
+		{Text: "[~]", Expected: []string{}},
+		{Text: "[~j]", Expected: []string{"j"}},
+		{Text: "[~jira]", Expected: []string{"jira"}},
+		{Text: "[~jira.user]", Expected: []string{"jira.user"}},
+		{Text: "[~jira_user]", Expected: []string{"jira_user"}},
+		{Text: "[~jira-user]", Expected: []string{"jira-user"}},
+		{Text: "[~jira:user]", Expected: []string{"jira:user"}},
+		{Text: "[~jira_user_3]", Expected: []string{"jira_user_3"}},
+		{Text: "[~jira-user-4]", Expected: []string{"jira-user-4"}},
+		{Text: "[~JiraUser5]", Expected: []string{"JiraUser5"}},
+		{Text: "[~jira-user+6]", Expected: []string{"jira-user+6"}},
+		{Text: "[~2023]", Expected: []string{"2023"}},
+		{Text: "[~jira.user@company.com]", Expected: []string{"jira.user@company.com"}},
+		{Text: "[~jira_user@mattermost.com]", Expected: []string{"jira_user@mattermost.com"}},
+		{Text: "[~jira-unique-user@mattermost.com] [~jira-unique-user@mattermost.com] [~jira-unique-user@mattermost.com]", Expected: []string{"jira-unique-user@mattermost.com"}},
+		{Text: "[jira_incorrect_user]", Expected: []string{}},
+		{Text: "[~jira_user_reviewer], Hi! Can you review the PR from [~jira_user_contributor]? Thanks!", Expected: []string{"jira_user_reviewer", "jira_user_contributor"}},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.Expected, parseJIRAUsernamesFromText(tc.Text))
+	}
+}


### PR DESCRIPTION
Fixes #924.

I tested these changes using my personal build of the plugin.

P.S I can also add tests to it if needed.