### PR TITLE
Don't log unsupported webhook events as errors

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -21,7 +21,7 @@ const (
 	commentUpdated = "comment_updated"
 	commentCreated = "comment_created"
 
-	worklogUpdatd = "jira:worklog_updated"
+	worklogUpdated = "jira:worklog_updated"
 )
 
 type Webhook interface {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -20,6 +20,8 @@ const (
 	commentDeleted = "comment_deleted"
 	commentUpdated = "comment_updated"
 	commentCreated = "comment_created"
+
+	worklogUpdatd = "jira:worklog_updated"
 )
 
 type Webhook interface {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -17,6 +17,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
+var errWebhookeventUnsupported = errors.New("Unsupported webhook event")
+
 var webhookWrapperFunc func(wh Webhook) Webhook
 
 func ParseWebhook(bb []byte) (wh Webhook, err error) {
@@ -76,14 +78,16 @@ func ParseWebhook(bb []byte) (wh Webhook, err error) {
 		wh, err = parseWebhookCommentUpdated(jwh)
 	case commentDeleted:
 		wh, err = parseWebhookCommentDeleted(jwh)
+	case worklogUpdatd:
+		// not supported
 	default:
-		err = errors.Errorf("Unsupported webhook event: %v", jwh.WebhookEvent)
+		err = errors.Wrapf(errWebhookeventUnsupported, "event: %v", jwh.WebhookEvent)
 	}
 	if err != nil {
 		return nil, err
 	}
 	if wh == nil {
-		return nil, errors.Errorf("Unsupported webhook data: %v", jwh.WebhookEvent)
+		return nil, errors.Wrapf(errWebhookeventUnsupported, "event: %v", jwh.WebhookEvent)
 	}
 
 	// For HTTP testing, so we can capture the output of the interface

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -78,7 +78,7 @@ func ParseWebhook(bb []byte) (wh Webhook, err error) {
 		wh, err = parseWebhookCommentUpdated(jwh)
 	case commentDeleted:
 		wh, err = parseWebhookCommentDeleted(jwh)
-	case worklogUpdatd:
+	case worklogUpdated:
 		// not supported
 	default:
 		err = errors.Wrapf(errWebhookeventUnsupported, "event: %v", jwh.WebhookEvent)

--- a/server/webhook_worker.go
+++ b/server/webhook_worker.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
@@ -22,7 +24,11 @@ func (ww webhookWorker) work() {
 	for msg := range ww.workQueue {
 		err := ww.process(msg)
 		if err != nil {
-			ww.p.errorf("WebhookWorker id: %d, error processing, err: %v", ww.id, err)
+			if errors.Is(err, errWebhookeventUnsupported) {
+				ww.p.debugf("WebhookWorker id: %d, error processing, err: %v", ww.id, err)
+			} else {
+				ww.p.errorf("WebhookWorker id: %d, error processing, err: %v", ww.id, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Unsupported events are not an error and should not be logged as such.

#### Ticket Link
Found while debugging https://community.mattermost.com/core/pl/iu8bucepfpgy5c6xjoqx5m4goa