### PR TITLE
[GH-855] Save user's last used field values

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -1035,8 +1035,8 @@ func executeMe(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...
 
 			resp += connectionBullet(info.User.ConnectedInstances.Get(instanceID), connection, info.User.DefaultInstanceID == instanceID)
 			resp += fmt.Sprintf("   * %s\n", connection.Settings)
-			if connection.DefaultProjectKey != "" {
-				resp += fmt.Sprintf("   * Default project: `%s`\n", connection.DefaultProjectKey)
+			if connection.SavedFieldValues != nil && connection.SavedFieldValues.ProjectKey != "" {
+				resp += fmt.Sprintf("   * Default project: `%s`\n", connection.SavedFieldValues.ProjectKey)
 			}
 		}
 	}

--- a/server/issue.go
+++ b/server/issue.go
@@ -321,7 +321,6 @@ func (p *Plugin) CreateIssue(in *InCreateIssue) (*jira.Issue, error) {
 	p.UpdateUserDefaults(in.mattermostUserID, in.InstanceID, &SavedFieldValues{
 		ProjectKey: project.Key,
 		IssueType:  issue.Fields.Type.ID,
-		Components: issue.Fields.Components,
 	})
 
 	// Create a public post for all the channel members

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -819,7 +819,9 @@ func (p *Plugin) httpChannelCreateSubscription(w http.ResponseWriter, r *http.Re
 	if subscription.Filters.Projects.Len() == 1 {
 		projectKey = subscription.Filters.Projects.Elems()[0]
 	}
-	p.UpdateUserDefaults(types.ID(mattermostUserID), subscription.InstanceID, projectKey)
+	p.UpdateUserDefaults(types.ID(mattermostUserID), subscription.InstanceID, &SavedFieldValues{
+		ProjectKey: projectKey,
+	})
 
 	code, err := respondJSON(w, &subscription)
 	if err != nil {
@@ -879,7 +881,9 @@ func (p *Plugin) httpChannelEditSubscription(w http.ResponseWriter, r *http.Requ
 	if subscription.Filters.Projects.Len() == 1 {
 		projectKey = subscription.Filters.Projects.Elems()[0]
 	}
-	p.UpdateUserDefaults(types.ID(mattermostUserID), subscription.InstanceID, projectKey)
+	p.UpdateUserDefaults(types.ID(mattermostUserID), subscription.InstanceID, &SavedFieldValues{
+		ProjectKey: projectKey,
+	})
 
 	code, err := respondJSON(w, &subscription)
 	if err != nil {

--- a/server/user.go
+++ b/server/user.go
@@ -38,9 +38,8 @@ type Connection struct {
 }
 
 type SavedFieldValues struct {
-	ProjectKey string            `json:"project_key,omitempty"`
-	IssueType  string            `json:"issue_type,omitempty"`
-	Components []*jira.Component `json:"components,omitempty"`
+	ProjectKey string `json:"project_key,omitempty"`
+	IssueType  string `json:"issue_type,omitempty"`
 }
 
 func (c *Connection) JiraAccountID() types.ID {

--- a/server/user.go
+++ b/server/user.go
@@ -33,8 +33,14 @@ type Connection struct {
 	Oauth1AccessSecret string        `json:",omitempty"`
 	OAuth2Token        *oauth2.Token `json:",omitempty"`
 	Settings           *ConnectionSettings
-	DefaultProjectKey  string   `json:"default_project_key,omitempty"`
-	MattermostUserID   types.ID `json:"mattermost_user_id"`
+	SavedFieldValues   *SavedFieldValues `json:"saved_field_values,omitempty"`
+	MattermostUserID   types.ID          `json:"mattermost_user_id"`
+}
+
+type SavedFieldValues struct {
+	ProjectKey string            `json:"project_key,omitempty"`
+	IssueType  string            `json:"issue_type,omitempty"`
+	Components []*jira.Component `json:"components,omitempty"`
 }
 
 func (c *Connection) JiraAccountID() types.ID {
@@ -153,7 +159,7 @@ func (user *User) AsConfigMap() map[string]interface{} {
 	}
 }
 
-func (p *Plugin) UpdateUserDefaults(mattermostUserID, instanceID types.ID, projectKey string) {
+func (p *Plugin) UpdateUserDefaults(mattermostUserID, instanceID types.ID, savedValues *SavedFieldValues) {
 	user, err := p.userStore.LoadUser(mattermostUserID)
 	if err != nil {
 		return
@@ -174,8 +180,8 @@ func (p *Plugin) UpdateUserDefaults(mattermostUserID, instanceID types.ID, proje
 		}
 	}
 
-	if projectKey != "" && projectKey != connection.DefaultProjectKey {
-		connection.DefaultProjectKey = projectKey
+	if savedValues != nil {
+		connection.SavedFieldValues = savedValues
 		err = p.userStore.StoreConnection(instanceID, user.MattermostUserID, connection)
 		if err != nil {
 			return

--- a/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.test.tsx
+++ b/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.test.tsx
@@ -26,7 +26,9 @@ describe('components/JiraInstanceAndProjectSelector', () => {
         connectedInstances: [{instance_id: 'instance1', type: InstanceType.CLOUD}, {instance_id: 'instance2', type: InstanceType.SERVER}],
         defaultUserInstanceID: '',
         fetchJiraProjectMetadata: jest.fn().mockResolvedValue({data: {
-            default_project_key: 'TEST',
+            saved_field_values: {
+                project_key: 'TEST',
+            },
             projects: [
                 {value: 'TEST', label: 'Test Project'},
                 {value: 'AA', label: 'Apples Arrangement'},
@@ -120,7 +122,7 @@ describe('components/JiraInstanceAndProjectSelector', () => {
         expect(props.onInstanceChange).not.toBeCalled();
     });
 
-    test('should use default project key after fetch', async () => {
+    test('should use default field values after fetch', async () => {
         const props = {
             ...baseProps,
             defaultUserInstanceID: 'instance2',
@@ -133,7 +135,9 @@ describe('components/JiraInstanceAndProjectSelector', () => {
         expect(wrapper.state().fetchingProjectMetadata).toBe(true);
 
         await props.fetchJiraProjectMetadata('');
-        expect(props.onProjectChange).toBeCalledWith('TEST');
+        expect(props.onProjectChange).toBeCalledWith({
+            project_key: 'TEST',
+        });
     });
 
     test('should pass error on failed fetch', async () => {

--- a/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.tsx
+++ b/webapp/src/components/jira_instance_and_project_selector/jira_instance_and_project_selector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {Theme} from 'mattermost-redux/types/preferences';
 
-import {Instance, ProjectMetadata, ReactSelectOption, APIResponse, GetConnectedResponse} from 'types/model';
+import {Instance, ProjectMetadata, ReactSelectOption, APIResponse, GetConnectedResponse, SavedFieldValues} from 'types/model';
 import ReactSelectSetting from 'components/react_select_setting';
 import {getProjectValues} from 'utils/jira_issue_metadata';
 
@@ -10,7 +10,7 @@ export type Props = {
     selectedInstanceID: string | null;
     selectedProjectID: string | null;
     onInstanceChange: (instanceID: string) => void;
-    onProjectChange: (projectID: string) => void;
+    onProjectChange: (fieldValues: SavedFieldValues) => void;
     onError: (err: string) => void;
 
     theme: Theme;
@@ -95,8 +95,8 @@ export default class JiraInstanceAndProjectSelector extends React.PureComponent<
             fetchingProjectMetadata: false,
         });
 
-        if (projectMetadata.default_project_key && !this.props.selectedProjectID) {
-            this.props.onProjectChange(projectMetadata.default_project_key);
+        if (projectMetadata.saved_field_values && projectMetadata.saved_field_values.project_key && !this.props.selectedProjectID) {
+            this.props.onProjectChange(projectMetadata.saved_field_values);
         }
     }
 
@@ -112,7 +112,9 @@ export default class JiraInstanceAndProjectSelector extends React.PureComponent<
     }
 
     handleProjectChange = (_: string, projectID: string) => {
-        this.props.onProjectChange(projectID);
+        this.props.onProjectChange({
+            project_key: projectID,
+        });
     }
 
     render() {

--- a/webapp/src/components/modals/attach_comment_modal/attach_comment_form.tsx
+++ b/webapp/src/components/modals/attach_comment_modal/attach_comment_form.tsx
@@ -8,7 +8,7 @@ import {Post} from 'mattermost-redux/types/posts';
 import {Team} from 'mattermost-redux/types/teams';
 import {Theme} from 'mattermost-redux/types/preferences';
 
-import {APIResponse, AttachCommentRequest} from 'types/model';
+import {APIResponse, AttachCommentRequest, SavedFieldValues} from 'types/model';
 
 import {getModalStyles} from 'utils/styles';
 
@@ -94,7 +94,7 @@ export default class AttachCommentToIssueForm extends PureComponent<Props, State
                 selectedProjectID={''}
                 hideProjectSelector={true}
                 onInstanceChange={(instanceID: string) => this.setState({instanceID})}
-                onProjectChange={(projectKey: string) => {}}
+                onProjectChange={(savedValues: SavedFieldValues) => {}}
                 theme={this.props.theme}
                 addValidate={this.validator.addComponent}
                 removeValidate={this.validator.removeComponent}

--- a/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.test.tsx
+++ b/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.test.tsx
@@ -138,7 +138,9 @@ describe('components/EditChannelSubscription', () => {
             <EditChannelSubscription {...props}/>
         );
         wrapper.setState(baseState);
-        wrapper.instance().handleProjectChange('TES');
+        wrapper.instance().handleProjectChange({
+            project_key: 'TES',
+        });
         expect(wrapper.state().filters.projects).toEqual(['TES']);
         expect(wrapper.state().fetchingIssueMetadata).toBe(true);
         expect(fetchJiraIssueMetadataForProjects).toHaveBeenCalled();
@@ -150,7 +152,9 @@ describe('components/EditChannelSubscription', () => {
         fetchJiraIssueMetadataForProjects = jest.fn().mockResolvedValue({error: {message: 'Failure'}});
         wrapper.setProps({fetchJiraIssueMetadataForProjects});
 
-        wrapper.instance().handleProjectChange('KT');
+        wrapper.instance().handleProjectChange({
+            project_key: 'KT',
+        });
         expect(wrapper.state().filters.projects).toEqual(['KT']);
         expect(fetchJiraIssueMetadataForProjects).toHaveBeenCalled();
         expect(wrapper.state().fetchingIssueMetadata).toBe(true);

--- a/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.tsx
@@ -22,7 +22,7 @@ import {
     filterValueIsSecurityField,
 } from 'utils/jira_issue_metadata';
 
-import {ChannelSubscription, ChannelSubscriptionFilters as ChannelSubscriptionFiltersModel, ReactSelectOption, FilterValue, IssueMetadata} from 'types/model';
+import {ChannelSubscription, ChannelSubscriptionFilters as ChannelSubscriptionFiltersModel, ReactSelectOption, FilterValue, IssueMetadata, SavedFieldValues} from 'types/model';
 
 import ChannelSubscriptionFilters from './channel_subscription_filters';
 import {SharedProps} from './shared_props';
@@ -244,10 +244,11 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
         }
 
         this.setState({instanceID, error: null});
-        this.handleProjectChange('');
+        this.handleProjectChange({});
     }
 
-    handleProjectChange = (projectID: string) => {
+    handleProjectChange = (fieldValues: SavedFieldValues) => {
+        const projectID = fieldValues.project_key ? fieldValues.project_key : '';
         this.clearConflictingErrorMessage();
 
         let projects: string[];

--- a/webapp/src/components/modals/create_issue/create_issue_form.tsx
+++ b/webapp/src/components/modals/create_issue/create_issue_form.tsx
@@ -133,7 +133,7 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
             this.setState(state);
         });
 
-        let fields = {
+        const fields = {
             summary: this.state.fields.summary,
             description: this.state.fields.description,
             project: {key: projectKey},
@@ -151,7 +151,6 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
             };
         }
 
-        fields = {...fields};
         if (fieldValues) {
             fields.components = fieldValues.components as JiraField;
         }

--- a/webapp/src/components/modals/create_issue/create_issue_form.tsx
+++ b/webapp/src/components/modals/create_issue/create_issue_form.tsx
@@ -8,7 +8,7 @@ import {Theme} from 'mattermost-redux/types/preferences';
 import {Post} from 'mattermost-redux/types/posts';
 import {Team} from 'mattermost-redux/types/teams';
 
-import {APIResponse, IssueMetadata, CreateIssueRequest, JiraFieldTypeEnums, JiraFieldCustomTypeEnums, CreateIssueFields, JiraField} from 'types/model';
+import {APIResponse, IssueMetadata, CreateIssueRequest, JiraFieldTypeEnums, JiraFieldCustomTypeEnums, CreateIssueFields, JiraField, SavedFieldValues} from 'types/model';
 
 import {getFields, getIssueTypes} from 'utils/jira_issue_metadata';
 import {getModalStyles} from 'utils/styles';
@@ -115,7 +115,8 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
         this.setState({instanceID, projectKey: '', error: null});
     }
 
-    handleProjectChange = (projectKey: string) => {
+    handleProjectChange = (fieldValues: SavedFieldValues) => {
+        const projectKey = fieldValues.project_key ? fieldValues.project_key : '';
         this.setState({projectKey, fetchingIssueMetadata: true, error: null});
 
         this.props.fetchJiraIssueMetadataForProjects([projectKey], this.state.instanceID as string).then(({data, error}) => {
@@ -132,21 +133,32 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
             this.setState(state);
         });
 
-        const fields = {
+        let fields = {
             summary: this.state.fields.summary,
             description: this.state.fields.description,
             project: {key: projectKey},
         } as CreateIssueFields;
 
-        const issueTypes = getIssueTypes(this.state.jiraIssueMetadata, projectKey);
-        const issueType = issueTypes.length ? issueTypes[0].id : '';
-        fields.issuetype = {
-            id: issueType,
-        };
+        if (fieldValues.issue_type) {
+            fields.issuetype = {
+                id: fieldValues.issue_type,
+            };
+        } else {
+            const issueTypes = getIssueTypes(this.state.jiraIssueMetadata, projectKey);
+            const issueType = issueTypes.length ? issueTypes[0].id : '';
+            fields.issuetype = {
+                id: issueType,
+            };
+        }
+
+        fields = {...fields};
+        if (fieldValues) {
+            fields.components = fieldValues.components as JiraField;
+        }
 
         this.setState({
             projectKey,
-            issueType,
+            issueType: fieldValues.issue_type ? fieldValues.issue_type : '',
             fields,
         });
     }

--- a/webapp/src/components/modals/create_issue/create_issue_form.tsx
+++ b/webapp/src/components/modals/create_issue/create_issue_form.tsx
@@ -151,10 +151,6 @@ export default class CreateIssueForm extends React.PureComponent<Props, State> {
             };
         }
 
-        if (fieldValues) {
-            fields.components = fieldValues.components as JiraField;
-        }
-
         this.setState({
             projectKey,
             issueType: fieldValues.issue_type ? fieldValues.issue_type : '',

--- a/webapp/src/types/model.ts
+++ b/webapp/src/types/model.ts
@@ -72,7 +72,13 @@ export type IssueMetadata = {
 export type ProjectMetadata = {
     projects: ReactSelectOption[];
     issues_per_project: {[key: string]: ReactSelectOption[]};
-    default_project_key?: string;
+    saved_field_values?: SavedFieldValues;
+}
+
+export type SavedFieldValues = {
+    project_key?: string;
+    issue_type?: string;
+    components?: JiraField;
 }
 
 export enum JiraFieldTypeEnums {

--- a/webapp/src/types/model.ts
+++ b/webapp/src/types/model.ts
@@ -78,7 +78,6 @@ export type ProjectMetadata = {
 export type SavedFieldValues = {
     project_key?: string;
     issue_type?: string;
-    components?: JiraField;
 }
 
 export enum JiraFieldTypeEnums {


### PR DESCRIPTION
#### Summary
Updated logic to store the last used issue type value while creating the issue and prefill the modal with those values the next time the user creates an issue.

##### What should be tested?
1. The specified fields are getting pre-filled properly.
2. A new issue is getting created successfully.
3. The prefilled value does not exist on Jira anymore.

#### Ticket Link
Fixes #855 