### PR TITLE
[GH-974] Return error if SiteURL is not set on plugin activation

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -248,7 +248,7 @@ func (p *Plugin) OnActivate() error {
 	if ptr != nil {
 		mattermostSiteURL = *ptr
 	} else {
-		return errors.New("failed to read SiteURL configuration")
+		return errors.New("please configure the Mattermost server's SiteURL, then restart the plugin.")
 	}
 
 	err = p.setDefaultConfiguration()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -247,6 +247,8 @@ func (p *Plugin) OnActivate() error {
 	ptr := p.client.Configuration.GetConfig().ServiceSettings.SiteURL
 	if ptr != nil {
 		mattermostSiteURL = *ptr
+	} else {
+		return errors.New("failed to read SiteURL configuration")
 	}
 
 	err = p.setDefaultConfiguration()


### PR DESCRIPTION
#### Summary
This PR fixes a crash occuring when no SiteURL has been configured. Specifically, the PR adds a corresponding check in OnActivate that returns an error and failure.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/974