### PR TITLE
[GH-939]: Updated the message for webhookURL in step 2 of plugin setup

### DIFF
--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -58,7 +58,7 @@ const (
 )
 
 const (
-	newline    = "\n"
+	lineBreak    = "\n"
 	webhookURL = "\n [{{.WebhookURL}}]({{.WebhookURL}})"
 )
 
@@ -405,7 +405,7 @@ func (p *Plugin) stepWebhook() flow.Step {
 			Color: flow.ColorPrimary,
 			Dialog: &model.Dialog{
 				Title:            "Jira Webhook URL",
-				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("%s %s", newline, webhookURL),
+				IntroductionText: fmt.Sprintf("Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. %s", lineBreak) + fmt.Sprintf("%s %s", lineBreak, webhookURL),
 				SubmitLabel:      "Continue",
 			},
 			OnDialogSubmit: flow.DialogGoto(stepWebhookDone),

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -58,8 +58,8 @@ const (
 )
 
 const (
-	lineBreak    = "\n"
-	webhookURL = "\n [{{.WebhookURL}}]({{.WebhookURL}})"
+	lineBreak  = "\n"
+	webhookURL = "[{{.WebhookURL}}]({{.WebhookURL}})"
 )
 
 func (p *Plugin) NewSetupFlow() *flow.Flow {

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -57,6 +57,11 @@ const (
 	NameURL          = "url"
 )
 
+const (
+	newline    = "\n"
+	webhookURL = "\n [{{.WebhookURL}}]({{.WebhookURL}})"
+)
+
 func (p *Plugin) NewSetupFlow() *flow.Flow {
 	pluginURL := *p.client.Configuration.GetConfig().ServiceSettings.SiteURL + "/" + "plugins" + "/" + Manifest.Id
 	conf := p.getConfig()
@@ -400,7 +405,7 @@ func (p *Plugin) stepWebhook() flow.Step {
 			Color: flow.ColorPrimary,
 			Dialog: &model.Dialog{
 				Title:            "Jira Webhook URL",
-				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("\n") + fmt.Sprintf("\n [{{.WebhookURL}}]({{.WebhookURL}})"),
+				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("%s %s", newline, webhookURL),
 				SubmitLabel:      "Continue",
 			},
 			OnDialogSubmit: flow.DialogGoto(stepWebhookDone),

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -400,7 +400,7 @@ func (p *Plugin) stepWebhook() flow.Step {
 			Color: flow.ColorPrimary,
 			Dialog: &model.Dialog{
 				Title:            "Jira Webhook URL",
-				IntroductionText: "Please scroll to select the entire URL if necessary.\n\n```{{.WebhookURL}}```\n\nOnce you have entered all options and the webhook URL, select **Create**",
+				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("\n")+  fmt.Sprintf("\n [{{.WebhookURL}}]({{.WebhookURL}})"),
 				SubmitLabel:      "Continue",
 			},
 			OnDialogSubmit: flow.DialogGoto(stepWebhookDone),

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -400,7 +400,7 @@ func (p *Plugin) stepWebhook() flow.Step {
 			Color: flow.ColorPrimary,
 			Dialog: &model.Dialog{
 				Title:            "Jira Webhook URL",
-				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("\n")+  fmt.Sprintf("\n [{{.WebhookURL}}]({{.WebhookURL}})"),
+				IntroductionText: "Please copy and use the link below as webhook URL. Once you have entered all options and the webhook URL, select **Create**. \n" + fmt.Sprintf("\n") + fmt.Sprintf("\n [{{.WebhookURL}}]({{.WebhookURL}})"),
 				SubmitLabel:      "Continue",
 			},
 			OnDialogSubmit: flow.DialogGoto(stepWebhookDone),


### PR DESCRIPTION
### Summary
- Updated the message in webhookURL modal in the second step of the plugin setup
### Screenshot
#### Old
![Screenshot from 2023-10-10 13-45-05](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/17fbfc9b-a461-4085-97ef-23676ae7795b)

#### New
![Screenshot from 2023-10-10 13-43-30](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/ef352668-9e21-4435-87df-bbb3eda66e75)

### Issue link
#939 

### What to test
- Content of the modal in step 2 of plugin setup(webhook URL step)
### How to test
- Install the plugin
- run `jira setup`
- open the JIRA bot dm
- Complete Step 1
- Modal to be tested will be visible at the end of step 2
![Screenshot from 2023-10-10 13-48-04](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/771c82ca-df80-465d-8449-a32eb7bb20a0)
