### PR TITLE
[MM-933] Updated code to display proper errors on UI

### DIFF
--- a/server/autocomplete_search.go
+++ b/server/autocomplete_search.go
@@ -22,29 +22,27 @@ func (p *Plugin) httpGetAutoCompleteFields(w http.ResponseWriter, r *http.Reques
 
 	client, _, _, err := p.getClient(types.ID(instanceID), types.ID(mattermostUserID))
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return respondErr(w, http.StatusInternalServerError, err)
 	}
 
 	results, err := client.SearchAutoCompleteFields(params)
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return respondErr(w, http.StatusInternalServerError, err)
 	}
 
 	if results == nil {
-		return http.StatusInternalServerError, errors.New("failed to return any results")
+		return respondErr(w, http.StatusInternalServerError, errors.New("failed to return any results"))
 	}
 
 	bb, err := json.Marshal(results)
 	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to marshal response")
+		return respondErr(w, http.StatusInternalServerError, errors.WithMessage(err, "failed to marshal response"))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(bb)
 	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to write response")
+		return respondErr(w, http.StatusInternalServerError, errors.WithMessage(err, "failed to write response"))
 	}
 	return http.StatusOK, nil
 }
@@ -57,30 +55,28 @@ func (p *Plugin) httpGetSearchUsers(w http.ResponseWriter, r *http.Request) (int
 
 	client, _, _, err := p.getClient(types.ID(instanceID), types.ID(mattermostUserID))
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return respondErr(w, http.StatusInternalServerError, err)
 	}
 
 	// Get list of assignable users
 	jiraUsers, err := client.SearchUsersAssignableInProject(projectKey, userSearch, 10)
 	if StatusCode(err) == 401 {
-		return http.StatusInternalServerError, err
+		return respondErr(w, http.StatusInternalServerError, err)
 	}
 
 	if jiraUsers == nil {
-		return http.StatusInternalServerError, errors.New("failed to return any results")
+		return respondErr(w, http.StatusInternalServerError, errors.New("failed to return any results"))
 	}
 
 	bb, err := json.Marshal(jiraUsers)
 	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to marshal response")
+		return respondErr(w, http.StatusInternalServerError, errors.WithMessage(err, "failed to marshal response"))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(bb)
 	if err != nil {
-		return http.StatusInternalServerError,
-			errors.WithMessage(err, "failed to write response")
+		return http.StatusInternalServerError, errors.WithMessage(err, "failed to write response")
 	}
 	return http.StatusOK, nil
 }

--- a/webapp/src/components/data_selectors/jira_autocomplete_selector/jira_autocomplete_selector.tsx
+++ b/webapp/src/components/data_selectors/jira_autocomplete_selector/jira_autocomplete_selector.tsx
@@ -44,6 +44,8 @@ export default class JiraAutoCompleteSelector extends React.PureComponent<Props>
                 value: suggestion.value,
                 label: stripHTML(suggestion.displayName),
             }));
+        }).catch((e) => {
+            throw new Error('Error fetching data');
         });
     };
 

--- a/webapp/src/components/data_selectors/jira_user_selector/jira_user_selector.tsx
+++ b/webapp/src/components/data_selectors/jira_user_selector/jira_user_selector.tsx
@@ -53,6 +53,8 @@ export default class JiraUserSelector extends React.PureComponent<Props> {
                     label,
                 };
             });
+        }).catch((e) => {
+            throw new Error('Error fetching data');
         });
     };
 


### PR DESCRIPTION
#### Summary
- Updated the backend code to return proper errors instead of empty responses for the "get-search-autocomplete-fields" and "get-search-users" API.
- Updated UI code to display a generic error in case of "get-search-autocomplete-fields" and "get-search-users" API calls.

#### Screenshot
![error_fetching_Data](https://github.com/mattermost/mattermost-plugin-jira/assets/55234496/96db517f-9ed2-486f-a6b5-5d0f3907ff17)

#### Ticket Link
Fixes #933 
