### PR TITLE
[GH-982]: Added support for webhook of plugin version v2.x.x

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -134,8 +134,9 @@ func (p *Plugin) initializeRouter() {
 	// Firehose webhook setup for channel subscriptions
 	instanceRouter.HandleFunc(makeAPIRoute(routeAPISubscribeWebhook), p.handleResponseWithCallbackInstance(p.httpSubscribeWebhook)).Methods(http.MethodPost)
 
-	// To support Plugin v2.x webhook URL
+	// To support Plugin v2.x webhook URLs
 	apiRouter.HandleFunc(routeAPISubscribeWebhook, p.handleResponseWithCallbackInstance(p.httpSubscribeWebhook)).Methods(http.MethodPost)
+	instanceRouter.HandleFunc(routeIncomingWebhook, p.handleResponseWithCallbackInstance(p.httpWebhook)).Methods(http.MethodPost)
 
 	// Channel Subscriptions
 	apiRouter.HandleFunc(routeAPISubscriptionsChannelWithID, p.checkAuth(p.handleResponse(p.httpChannelGetSubscriptions))).Methods(http.MethodGet)

--- a/server/http.go
+++ b/server/http.go
@@ -134,6 +134,9 @@ func (p *Plugin) initializeRouter() {
 	// Firehose webhook setup for channel subscriptions
 	instanceRouter.HandleFunc(makeAPIRoute(routeAPISubscribeWebhook), p.handleResponseWithCallbackInstance(p.httpSubscribeWebhook)).Methods(http.MethodPost)
 
+	// To support Plugin v2.x webhook URL
+	apiRouter.HandleFunc(routeAPISubscribeWebhook, p.handleResponseWithCallbackInstance(p.httpSubscribeWebhook)).Methods(http.MethodPost)
+
 	// Channel Subscriptions
 	apiRouter.HandleFunc(routeAPISubscriptionsChannelWithID, p.checkAuth(p.handleResponse(p.httpChannelGetSubscriptions))).Methods(http.MethodGet)
 	apiRouter.HandleFunc(routeAPISubscriptionsChannel, p.checkAuth(p.handleResponse(p.httpChannelCreateSubscription))).Methods(http.MethodPost)


### PR DESCRIPTION
### Summary
- Added the endpoint to support the webhooks created for plugin version v2.x.x

### Issue link
#982 

### What to test
-The webhook created for jira plugin version 2. x.x should be supported and working fine.
### How to test
- Create a webhook using the readme from https://github.com/mattermost/mattermost-plugin-jira/tree/v2.4.0#step-2-configure-webhooks-in-jira. 
- Create the subscription
- Change notifications should come from the jira side. 