### PR TITLE
[GH-971] Support Jira migration to Oauth

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -817,7 +817,7 @@ func executeInstanceInstallCloudOAuth(p *Plugin, c *plugin.Context, header *mode
 		return p.help(header)
 	}
 
-	jiraURL, instance, err := p.installCloudOAuthInstance(args[0], "", "")
+	jiraURL, instance, err := p.installCloudOAuthInstance(args[0])
 	if err != nil {
 		return p.responsef(header, err.Error())
 	}

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -98,12 +98,12 @@ func (ci *cloudOAuthInstance) GetClient(connection *Connection) (Client, error) 
 func (ci *cloudOAuthInstance) getClientForConnection(connection *Connection) (*jira.Client, *http.Client, error) {
 	oauth2Conf := ci.GetOAuthConfig()
 	ctx := context.Background()
-	tokenSource := oauth2Conf.TokenSource(ctx, connection.OAuth2Token)
-	if ci.JWTInstance != nil && tokenSource == nil {
-		ci.Plugin.API.LogDebug("Returning a JWT token client in case the stored JWT instance is not nil and the user's oauth token is nil")
+	if ci.JWTInstance != nil && connection.OAuth2Token == nil {
+		ci.Plugin.API.LogDebug("Returning a JWT token client since the stored JWT instance is not nil and the user's oauth token is nil")
 		return ci.JWTInstance.getClientForConnection(connection)
 	}
 
+	tokenSource := oauth2Conf.TokenSource(ctx, connection.OAuth2Token)
 	client := oauth2.NewClient(ctx, tokenSource)
 
 	// Get a new token, if Access Token has expired

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils"
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/kvstore"
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
@@ -57,7 +58,7 @@ const (
 	PKCEByteArrayLength = 32
 )
 
-func (p *Plugin) installCloudOAuthInstance(rawURL, clientID, clientSecret string) (string, *cloudOAuthInstance, error) {
+func (p *Plugin) installCloudOAuthInstance(rawURL string) (string, *cloudOAuthInstance, error) {
 	jiraURL, err := utils.CheckJiraURL(p.GetSiteURL(), rawURL, false)
 	if err != nil {
 		return "", nil, err
@@ -71,20 +72,53 @@ func (p *Plugin) installCloudOAuthInstance(rawURL, clientID, clientSecret string
 		return "", nil, err
 	}
 
-	instance := &cloudOAuthInstance{
-		InstanceCommon:   newInstanceCommon(p, CloudOAuthInstanceType, types.ID(jiraURL)),
-		MattermostKey:    p.GetPluginKey(),
-		JiraClientID:     clientID,
-		JiraClientSecret: clientSecret,
-		JiraBaseURL:      rawURL,
-		CodeVerifier:     params.CodeVerifier,
-		CodeChallenge:    params.CodeChallenge,
-	}
-	if err = p.InstallInstance(instance); err != nil {
-		return "", nil, err
+	newInstance := &cloudOAuthInstance{
+		InstanceCommon: newInstanceCommon(p, CloudOAuthInstanceType, types.ID(jiraURL)),
+		MattermostKey:  p.GetPluginKey(),
+		JiraBaseURL:    rawURL,
+		CodeVerifier:   params.CodeVerifier,
+		CodeChallenge:  params.CodeChallenge,
 	}
 
-	return jiraURL, instance, err
+	existingInstance, err := p.instanceStore.LoadInstance(types.ID(jiraURL))
+	if err != nil && !errors.Is(err, kvstore.ErrNotFound) {
+		return "", nil, errors.Wrapf(err, "failed to load existing jira instance. ID: %s", jiraURL)
+	}
+
+	// Handle backwards compatibility with existing JWT instance
+	if existingInstance != nil {
+		if existingInstance.Common().Type == CloudOAuthInstanceType {
+			oauthInstance, ok := existingInstance.(*cloudOAuthInstance)
+			if !ok {
+				return "", nil, errors.Wrapf(err, "failed to assert existing cloud-oauth instance as cloudOAuthInstance. ID: %s", jiraURL)
+			}
+
+			newInstance.JWTInstance = oauthInstance.JWTInstance
+			if newInstance.JWTInstance != nil {
+				p.API.LogDebug("Installing cloud-oauth over existing cloud-oauth instance. Carrying over existing saved JWT instance.")
+			} else {
+				p.API.LogDebug("Installing cloud-oauth over existing cloud-oauth instance. There exists no previous JWT instance to carry over.")
+			}
+		}
+
+		if existingInstance.Common().Type == CloudInstanceType {
+			jwtInstance, ok := existingInstance.(*cloudInstance)
+			if !ok {
+				return "", nil, errors.Wrapf(err, "failed to assert existing cloud instance as cloudInstance. ID: %s", jiraURL)
+			}
+
+			newInstance.JWTInstance = jwtInstance
+			p.API.LogDebug("Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.")
+		}
+	} else {
+		p.API.LogDebug("Installing new cloud-oauth instance. There exists no previous JWT instance to carry over.")
+	}
+
+	if err = p.InstallInstance(newInstance); err != nil {
+		return "", nil, errors.Wrapf(err, "failed to install cloud-oauth instance. ID: %s", jiraURL)
+	}
+
+	return jiraURL, newInstance, nil
 }
 
 func (ci *cloudOAuthInstance) GetClient(connection *Connection) (Client, error) {

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -99,9 +99,7 @@ func (p *Plugin) installCloudOAuthInstance(rawURL string) (string, *cloudOAuthIn
 			} else {
 				p.API.LogDebug("Installing cloud-oauth over existing cloud-oauth instance. There exists no previous JWT instance to carry over.")
 			}
-		}
-
-		if existingInstance.Common().Type == CloudInstanceType {
+		} else if existingInstance.Common().Type == CloudInstanceType {
 			jwtInstance, ok := existingInstance.(*cloudInstance)
 			if !ok {
 				return "", nil, errors.Wrapf(err, "failed to assert existing cloud instance as cloudInstance. ID: %s", jiraURL)

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -98,6 +98,8 @@ func (ci *cloudOAuthInstance) GetClient(connection *Connection) (Client, error) 
 func (ci *cloudOAuthInstance) getClientForConnection(connection *Connection) (*jira.Client, *http.Client, error) {
 	oauth2Conf := ci.GetOAuthConfig()
 	ctx := context.Background()
+
+	// Checking if this user's connection is for a JWT instance
 	if ci.JWTInstance != nil && connection.OAuth2Token == nil {
 		ci.Plugin.API.LogDebug("Returning a JWT token client since the stored JWT instance is not nil and the user's oauth token is nil")
 		return ci.JWTInstance.getClientForConnection(connection)

--- a/server/instances.go
+++ b/server/instances.go
@@ -166,9 +166,17 @@ func (p *Plugin) InstallInstance(newInstance Instance) error {
 					// Storing the JWT instance data inside the OAuth instance data. We will use this to use the stored JWT token in case the user has not connected to OAuth yet.
 					p.API.LogDebug("Instance type stored in KV store", "ID", previousInstance.GetID(), "Type", previousInstance.Common().Type)
 					if previousInstance.Common().Type == CloudInstanceType {
-						oAuthInstance.JWTInstance = previousInstance.(*cloudInstance)
+						ci, ok := previousInstance.(*cloudInstance)
+						if !ok {
+							p.API.LogError("Instance type is `cloud` but failed to assert instance.(*cloudInstance).", "ID", newInstance.GetID())
+						}
+						oAuthInstance.JWTInstance = ci
 					} else if previousInstance.Common().Type == CloudOAuthInstanceType {
-						oAuthInstance.JWTInstance = previousInstance.(*cloudOAuthInstance).JWTInstance
+						ci, ok := previousInstance.(*cloudOAuthInstance)
+						if !ok {
+							p.API.LogError("Instance type is `cloud-oauth` but failed to assert instance.(*cloudOAuthInstance).", "ID", newInstance.GetID())
+						}
+						oAuthInstance.JWTInstance = ci.JWTInstance
 					}
 
 					if oAuthInstance.JWTInstance != nil {

--- a/server/instances.go
+++ b/server/instances.go
@@ -141,44 +141,49 @@ func (p *instancesArray) Resize(n int) {
 	*p = make(instancesArray, n)
 }
 
-func (p *Plugin) InstallInstance(instance Instance) error {
+func (p *Plugin) InstallInstance(newInstance Instance) error {
 	var updated *Instances
 	err := UpdateInstances(p.instanceStore,
 		func(instances *Instances) error {
 			if !p.enterpriseChecker.HasEnterpriseFeatures() {
-				if instances != nil && len(instances.IDs()) > 0 && !instances.checkIfExists(instance.GetID()) {
+				if instances != nil && len(instances.IDs()) > 0 && !instances.checkIfExists(newInstance.GetID()) {
 					return errors.Errorf(licenseErrorString)
 				}
 			}
 
-			if instance.Common().Type == CloudOAuthInstanceType && len(instances.IDs()) > 0 && instances.checkIfExists(instance.GetID()) {
-				p.API.LogDebug("Getting the stored JWT instance data to store it inside the OAuth instance data.")
-				jwtInstance, err := p.instanceStore.LoadInstance(instance.GetID())
-				if err != nil {
-					p.API.LogError("Error occurred while fetching the instance", "ID", instance.GetID(), "Error", err.Error())
-					return err
-				}
-
-				// Storing the JWT instance data inside the OAuth instance data. We will use this to use the stored JWT token in case the user has not connected to OAuth yet.
-				p.API.LogDebug("Instance type stored in KV store", "ID", jwtInstance.GetID(), "Type", jwtInstance.Common().Type)
-				if jwtInstance.Common().Type == CloudInstanceType {
-					instance.(*cloudOAuthInstance).JWTInstance = jwtInstance.(*cloudInstance)
-				} else if jwtInstance.Common().Type == CloudOAuthInstanceType {
-					instance.(*cloudOAuthInstance).JWTInstance = jwtInstance.(*cloudOAuthInstance).JWTInstance
-				}
-
-				if instance.(*cloudOAuthInstance).JWTInstance != nil {
-					p.API.LogDebug("JWT instance is successfully stored inside cloud OAuth instance data.", "JWTInstance", instance.(*cloudOAuthInstance).JWTInstance)
+			if newInstance.Common().Type == CloudOAuthInstanceType && len(instances.IDs()) > 0 && instances.checkIfExists(newInstance.GetID()) {
+				oAuthInstance, ok := newInstance.(*cloudOAuthInstance)
+				if !ok {
+					p.API.LogError("Instance type is `cloud-oauth` but failed to assert instance.(*cloudOAuthInstance).", "ID", newInstance.GetID())
 				} else {
-					p.API.LogDebug("Failed to store JWT instance inside cloud OAuth instance data or there was no JWT instance installed previously.", "JWTInstance", instance.(*cloudOAuthInstance).JWTInstance)
+					p.API.LogDebug("Getting the stored JWT instance data to store it inside the OAuth instance data.")
+					previousInstance, err := p.instanceStore.LoadInstance(newInstance.GetID())
+					if err != nil {
+						p.API.LogError("Error occurred while fetching the instance", "ID", newInstance.GetID(), "Error", err.Error())
+						return err
+					}
+
+					// Storing the JWT instance data inside the OAuth instance data. We will use this to use the stored JWT token in case the user has not connected to OAuth yet.
+					p.API.LogDebug("Instance type stored in KV store", "ID", previousInstance.GetID(), "Type", previousInstance.Common().Type)
+					if previousInstance.Common().Type == CloudInstanceType {
+						oAuthInstance.JWTInstance = previousInstance.(*cloudInstance)
+					} else if previousInstance.Common().Type == CloudOAuthInstanceType {
+						oAuthInstance.JWTInstance = previousInstance.(*cloudOAuthInstance).JWTInstance
+					}
+
+					if oAuthInstance.JWTInstance != nil {
+						p.API.LogDebug("JWT instance is successfully stored inside cloud OAuth instance data.", "JWTInstance", oAuthInstance.JWTInstance)
+					} else {
+						p.API.LogDebug("No JWT instance inside cloud OAuth instance data.", "JWTInstance", oAuthInstance.JWTInstance)
+					}
 				}
 			}
 
-			err := p.instanceStore.StoreInstance(instance)
+			err := p.instanceStore.StoreInstance(newInstance)
 			if err != nil {
 				return err
 			}
-			instances.Set(instance.Common())
+			instances.Set(newInstance.Common())
 			updated = instances
 			return nil
 		})

--- a/server/kv.go
+++ b/server/kv.go
@@ -157,8 +157,8 @@ func (store store) StoreConnection(instanceID, mattermostUserID types.ID, connec
 		return err
 	}
 
-	store.plugin.debugf("Stored: connection, keys:\n\t%s (%s): %+v\n\t%s (%s): %s",
-		keyWithInstanceID(instanceID, mattermostUserID), mattermostUserID, connection,
+	store.plugin.debugf("Stored: connection, keys:\n\t%s (%s): %s\n\t%s (%s): %s",
+		keyWithInstanceID(instanceID, mattermostUserID), mattermostUserID, connection.DisplayName,
 		keyWithInstanceID(instanceID, connection.JiraAccountID()), connection.JiraAccountID(), mattermostUserID)
 
 	return nil

--- a/server/webhook_jira.go
+++ b/server/webhook_jira.go
@@ -52,9 +52,20 @@ func (jwh *JiraWebhook) expandIssue(p *Plugin, instanceID types.ID) error {
 			}
 
 			jwh.Issue = *issue
-		} else if _, ok := instance.(*cloudOAuthInstance); ok {
+		} else if instance, ok := instance.(*cloudOAuthInstance); ok {
 			mmUserID, err := p.userStore.LoadMattermostUserID(instanceID, jwh.Comment.Author.AccountID)
 			if err != nil {
+				if instance.JWTInstance != nil {
+					var issue *jira.Issue
+					issue, err = p.getIssueDataForCloudWebhook(instance.JWTInstance, jwh.Issue.ID)
+					if err != nil {
+						return err
+					}
+
+					jwh.Issue = *issue
+					return nil
+				}
+
 				return errors.Wrap(err, "Cannot create subscription posts for this comment as the Jira comment author is not connected to Mattermost.")
 			}
 


### PR DESCRIPTION
#### Summary
- While installing the oauth instance we are storing the previously stored JWT instance data inside the new oauth instance data.
- While getting a client for making the API requests we are returning a JWT client in case the stored JWT instance is not nil and the user's oauth token is nil.
- We have added several debug statements to keep track of how the code is working as there was no way for us to test this change properly. (Since we don't have a server with a JWT (cloud instance) setup)

#### What to test?
- If an instance was previously connected to Jira using JWT (cloud instance) and the admin has installed a cloud-oauth instance then all the users who have not connected to oauth yet should be able to continue using the plugin.

#### Steps to reproduce:
- Install a cloud-oauth instance on a server that already has a JWT (cloud instance) setup and certain users have connected to it.

#### Ticket Link

Fixes #971 
