### PR TITLE
Replaced legacy GitBook URLs with PL links

### DIFF
--- a/assets/templates/command/install_cloud.md
+++ b/assets/templates/command/install_cloud.md
@@ -9,4 +9,4 @@
 6. Use the "/jira connect" command to connect your Mattermost account with your Jira account.
 7. Click the "More Actions" (...) option of any message in the channel (available when you hover over a message).
 
-If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://mattermost.gitbook.io/plugin-jira) for troubleshooting help.
+If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme) for troubleshooting help.

--- a/assets/templates/command/install_cloud.md
+++ b/assets/templates/command/install_cloud.md
@@ -9,4 +9,4 @@
 6. Use the "/jira connect" command to connect your Mattermost account with your Jira account.
 7. Click the "More Actions" (...) option of any message in the channel (available when you hover over a message).
 
-If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme) for troubleshooting help.
+If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://mattermost.com/pl/mattermost-plugin-jira) for troubleshooting help.

--- a/assets/templates/command/install_server.md
+++ b/assets/templates/command/install_server.md
@@ -29,4 +29,4 @@
 7. Click the "More Actions" (...) option of any message in the channel
    (available when you hover over a message).
 
-If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://mattermost.gitbook.io/plugin-jira) for troubleshooting help.
+If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme) for troubleshooting help.

--- a/assets/templates/command/install_server.md
+++ b/assets/templates/command/install_server.md
@@ -29,4 +29,4 @@
 7. Click the "More Actions" (...) option of any message in the channel
    (available when you hover over a message).
 
-If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme) for troubleshooting help.
+If you see an option to create a Jira issue, you're all set! If not, refer to our [documentation](https://mattermost.com/pl/mattermost-plugin-jira) for troubleshooting help.

--- a/plugin.json
+++ b/plugin.json
@@ -23,7 +23,7 @@
     },
     "settings_schema": {
         "header": "Please refer to the `/jira` command [**documentation**](https://mattermost.com/pl/mattermost-plugin-jira) to further configure the Jira plugin.",
-        "footer": "Please refer to the `/jira` command [**documentation**](https://github.com/mattermost/mattermost-plugin-jira/#administrator-slash-commands) to further configure the Jira plugin. Specifically, [`/jira instance [un-]install`](https://github.com/mattermost/mattermost-plugin-jira/#uninstall-jira-instances) and [`/jira webhook`](https://github.com/mattermost/mattermost-plugin-jira/#step-3-configure-webhooks-on-the-jira-server).",
+        "footer": "Please refer to the `/jira` command [**documentation**](https://mattermost.com/pl/mattermost-plugin-jira) to further configure the Jira plugin. Specifically, `/jira instance [un-]install` and `/jira webhook`.",
         "settings": [
             {
                 "key": "EnableJiraUI",

--- a/plugin.json
+++ b/plugin.json
@@ -22,7 +22,7 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "Please refer to the `/jira` command [**documentation**](https://github.com/mattermost/mattermost-plugin-jira/#administrator-slash-commands) to further configure the Jira plugin.",
+        "header": "Please refer to the `/jira` command [**documentation**](https://mattermost.com/pl/mattermost-plugin-jira) to further configure the Jira plugin.",
         "footer": "Please refer to the `/jira` command [**documentation**](https://github.com/mattermost/mattermost-plugin-jira/#administrator-slash-commands) to further configure the Jira plugin. Specifically, [`/jira instance [un-]install`](https://github.com/mattermost/mattermost-plugin-jira/#uninstall-jira-instances) and [`/jira webhook`](https://github.com/mattermost/mattermost-plugin-jira/#step-3-configure-webhooks-on-the-jira-server).",
         "settings": [
             {

--- a/plugin.json
+++ b/plugin.json
@@ -22,8 +22,8 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "Please refer to the `/jira` command [**documentation**](https://mattermost.gitbook.io/plugin-jira/setup/installation#step-2-install-app-on-jira-server) to further configure the Jira plugin.",
-        "footer": "Please refer to the `/jira` command [**documentation**](https://mattermost.gitbook.io/plugin-jira/setup/installation#step-2-install-app-on-jira-server) to further configure the Jira plugin. Specifically, [`/jira instance [un-]install`](https://mattermost.gitbook.io/plugin-jira/setup/installation#step-2-install-app-on-jira-server) and [`/jira webhook`](https://mattermost.gitbook.io/plugin-jira/setup/configuration#step-4-required-setup-webhooks-from-jira).",
+        "header": "Please refer to the `/jira` command [**documentation**](https://github.com/mattermost/mattermost-plugin-jira/#administrator-slash-commands) to further configure the Jira plugin.",
+        "footer": "Please refer to the `/jira` command [**documentation**](https://github.com/mattermost/mattermost-plugin-jira/#administrator-slash-commands) to further configure the Jira plugin. Specifically, [`/jira instance [un-]install`](https://github.com/mattermost/mattermost-plugin-jira/#uninstall-jira-instances) and [`/jira webhook`](https://github.com/mattermost/mattermost-plugin-jira/#step-3-configure-webhooks-on-the-jira-server).",
         "settings": [
             {
                 "key": "EnableJiraUI",

--- a/server/command.go
+++ b/server/command.go
@@ -1126,7 +1126,7 @@ func executeWebhookURL(p *Plugin, c *plugin.Context, header *model.CommandArgs, 
 			"Legacy webhook needs to be set up for each channel. For this channel:\n"+
 			"   - `%s`\n"+
 			"   - right-click on [link](%s) and \"Copy Link Address\" to copy\n"+
-			" Visit the [Legacy Webhooks](https://github.com/mattermost/mattermost-plugin-jira/#legacy-webhooks) page to learn more about this feature.\n"+
+			" Visit the [Legacy Webhooks](https://mattermost.com/pl/mattermost-plugin-jira) page to learn more about this feature.\n"+
 			"",
 		instanceID, instance.GetManageWebhooksURL(), subWebhookURL, subWebhookURL, legacyWebhookURL, legacyWebhookURL)
 }

--- a/server/command.go
+++ b/server/command.go
@@ -1126,7 +1126,7 @@ func executeWebhookURL(p *Plugin, c *plugin.Context, header *model.CommandArgs, 
 			"Legacy webhook needs to be set up for each channel. For this channel:\n"+
 			"   - `%s`\n"+
 			"   - right-click on [link](%s) and \"Copy Link Address\" to copy\n"+
-			" Visit the [Legacy Webhooks](https://mattermost.gitbook.io/plugin-jira/administrator-guide/notification-management#legacy-webhooks) page to learn more about this feature.\n"+
+			" Visit the [Legacy Webhooks](https://github.com/mattermost/mattermost-plugin-jira/#legacy-webhooks) page to learn more about this feature.\n"+
 			"",
 		instanceID, instance.GetManageWebhooksURL(), subWebhookURL, subWebhookURL, legacyWebhookURL, legacyWebhookURL)
 }

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -467,7 +467,7 @@ func (p *Plugin) stepAnnouncementQuestion() flow.Step {
 							"We've added an integration that connects Jira and Mattermost. You can get notified when you are mentioned in Jira comments, " +
 							"or quickly change a message in Mattermost into a ticket in Jira. It's easy to get started, run the `/jira connect` slash " +
 							"command from any channel within Mattermost to connect your user account. See the " +
-							"[documentation](https://github.com/mattermost/mattermost-plugin-jira/#getting-started) for details on using the Jira plugin.",
+							"[documentation](https://mattermost.com/pl/mattermost-plugin-jira) for details on using the Jira plugin.",
 						HelpText: "You can edit this message before sending it.",
 					},
 				},

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -134,7 +134,7 @@ func (p *Plugin) stepWelcome() flow.Step {
 			"4. Connect your user account.\n" +
 			"\n" +
 			"You can **Cancel** setup at any time, and use `/jira` command to complete the configuration later. " +
-			"See the [documentation](https://mattermost.gitbook.io/plugin-jira/setting-up/configuration) for details.").
+			"See the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#configuration) for details.").
 		OnRender(func(f *flow.Flow) {
 			p.trackSetupWizard("setup_wizard_start", map[string]interface{}{
 				"from_invite": f.GetState().GetString(keyDelegatedFromUserID) != "",
@@ -199,7 +199,7 @@ func (p *Plugin) stepChooseEdition() flow.Step {
 		WithPretext("##### :white_check_mark: Step 1: Which Jira edition do you use?").
 		WithTitle("Cloud (OAuth 2.0) or Server (on-premise).").
 		WithText("Choose whether you're using Jira Cloud (OAuth 2.0) or Jira Server (on-premise/Data Center) edition. " +
-			"To integrate with more than one Jira instance, see the [documentation](https://mattermost.gitbook.io/plugin-jira/)").
+			"To integrate with more than one Jira instance, see the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme)").
 		WithButton(
 			flow.Button{
 				Name:  "Jira Cloud (OAuth 2.0)",
@@ -467,7 +467,7 @@ func (p *Plugin) stepAnnouncementQuestion() flow.Step {
 							"We've added an integration that connects Jira and Mattermost. You can get notified when you are mentioned in Jira comments, " +
 							"or quickly change a message in Mattermost into a ticket in Jira. It's easy to get started, run the `/jira connect` slash " +
 							"command from any channel within Mattermost to connect your user account. See the " +
-							"[documentation](https://mattermost.gitbook.io/plugin-jira/end-user-guide/getting-started) for details on using the Jira plugin.",
+							"[documentation](https://github.com/mattermost/mattermost-plugin-jira/#getting-started) for details on using the Jira plugin.",
 						HelpText: "You can edit this message before sending it.",
 					},
 				},
@@ -533,7 +533,7 @@ func (p *Plugin) stepCancel() flow.Step {
 		WithColor(flow.ColorDanger).
 		// WithPretext("##### :no_entry_sign: Canceled").
 		WithText("Jira integration set up has been canceled. Run it again later using the `/jira setup` command, " +
-			"or refer to the [documentation](https://mattermost.gitbook.io/plugin-jira/setting-up) " +
+			"or refer to the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#configuration) " +
 			"to configure it manually.\n").
 		OnRender(p.trackSetupWizard("setup_wizard_canceled", nil))
 }

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -533,7 +533,7 @@ func (p *Plugin) stepCancel() flow.Step {
 		WithColor(flow.ColorDanger).
 		// WithPretext("##### :no_entry_sign: Canceled").
 		WithText("Jira integration set up has been canceled. Run it again later using the `/jira setup` command, " +
-			"or refer to the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#configuration) " +
+			"or refer to the [documentation](https://mattermost.com/pl/mattermost-plugin-jira) " +
 			"to configure it manually.\n").
 		OnRender(p.trackSetupWizard("setup_wizard_canceled", nil))
 }

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -134,7 +134,7 @@ func (p *Plugin) stepWelcome() flow.Step {
 			"4. Connect your user account.\n" +
 			"\n" +
 			"You can **Cancel** setup at any time, and use `/jira` command to complete the configuration later. " +
-			"See the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#configuration) for details.").
+			"See the [documentation](https://mattermost.com/pl/mattermost-plugin-jira) for details.").
 		OnRender(func(f *flow.Flow) {
 			p.trackSetupWizard("setup_wizard_start", map[string]interface{}{
 				"from_invite": f.GetState().GetString(keyDelegatedFromUserID) != "",

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -199,7 +199,7 @@ func (p *Plugin) stepChooseEdition() flow.Step {
 		WithPretext("##### :white_check_mark: Step 1: Which Jira edition do you use?").
 		WithTitle("Cloud (OAuth 2.0) or Server (on-premise).").
 		WithText("Choose whether you're using Jira Cloud (OAuth 2.0) or Jira Server (on-premise/Data Center) edition. " +
-			"To integrate with more than one Jira instance, see the [documentation](https://github.com/mattermost/mattermost-plugin-jira/#readme)").
+			"To integrate with more than one Jira instance, see the [documentation](https://mattermost.com/pl/mattermost-plugin-jira)").
 		WithButton(
 			flow.Button{
 				Name:  "Jira Cloud (OAuth 2.0)",


### PR DESCRIPTION
Replaced legacy/broken GitBook links with permalinks [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436