### PR TITLE
Fix full fetch logic (resolves #955)

### DIFF
--- a/server/client_cloud.go
+++ b/server/client_cloud.go
@@ -107,11 +107,12 @@ func (client jiraCloudClient) ListProjects(query string, limit int, expandIssueT
 			result.Values = result.Values[:remaining]
 		}
 		out = append(out, result.Values...)
-		remaining -= len(result.Values)
-
-		if !fetchAll && remaining == 0 {
-			// Got enough.
-			return out, nil
+		if !fetchAll {
+			remaining -= len(result.Values)
+			if remaining == 0 {
+				// Got enough.
+				return out, nil
+			}
 		}
 		if len(result.Values) == 0 || result.IsLast {
 			// Ran out of results.


### PR DESCRIPTION
#### Summary
Pagination is broken for flows such as the `jira subscribe edit` workflow. Only 50 projects are currently listed, with no way to retrieve additional projects.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/955

