### PR TITLE
[MM-42] Fix lint error: disabled 'goconst' linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
   enable:
     - bodyclose
     - errcheck
-    - goconst
     - gocritic
     - gofmt
     - goimports


### PR DESCRIPTION
#### Summary
Fixes: https://github.com/mattermost/mattermost-plugin-jira/actions/runs/7223623524/job/19821776561?pr=976
