### PR TITLE
Remove registration of link tooltip component

### DIFF
--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -15,7 +15,6 @@ import ChannelSubscriptionsModal from 'components/modals/channel_subscriptions';
 import AttachCommentToIssuePostMenuAction from 'components/post_menu_actions/attach_comment_to_issue';
 import AttachCommentToIssueModal from 'components/modals/attach_comment_modal';
 import SetupUI from 'components/setup_ui';
-import LinkTooltip from 'components/jira_ticket_tooltip';
 
 import {id as PluginId} from './manifest';
 
@@ -38,7 +37,6 @@ const setupUILater = (registry: any, store: Store<object, Action<object>>): () =
             registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);
             registry.registerRootComponent(AttachCommentToIssueModal);
             registry.registerPostDropdownMenuComponent(AttachCommentToIssuePostMenuAction);
-            registry.registerLinkTooltipComponent(LinkTooltip);
         }
 
         registry.registerRootComponent(ChannelSubscriptionsModal);


### PR DESCRIPTION
#### Summary

The link tooltip feature is having some issues as noted in the ticket below. The feature is pretty complex, so it will take some time to fix the issue. This PR temporarily removes the feature so we unblock the [v4.1.0](https://github.com/mattermost/mattermost-plugin-jira/pull/997) release.

#### Ticket Link

Temporarily fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1015