### PR TITLE
[GH-1018] Fix text overflow in the ticket link tooltip description

### DIFF
--- a/webapp/src/components/jira_ticket_tooltip/ticketStyle.scss
+++ b/webapp/src/components/jira_ticket_tooltip/ticketStyle.scss
@@ -111,6 +111,7 @@
         line-height: 1.5;
         width: 300px;
         text-overflow: ellipsis;
+        word-break: break-word;
     }
 
     .popover-body__description>p {


### PR DESCRIPTION
#### Summary
- Fix text overflow in the ticket link tooltip description

#### Screenshot
![tooltip_wrap](https://github.com/mattermost/mattermost-plugin-jira/assets/55234496/55a998be-f98a-4948-b80c-2b1e31d617d6)

#### What to test?
- Tooltip content is not overflowing in case there is a very long word in the description/title.

###### Steps to reproduce:
1. Connect your Jira account.
2. Create a ticket on Jira with very long words in the description/title.
3. Paste the ticket link in a channel.
4. Hover over the link.

#### Ticket Link
Fixes #1018 
