### PR TITLE
[GH-1021] Removed the project icon from ticket link tooltip

### DIFF
--- a/webapp/src/components/jira_ticket_tooltip/jira_ticket_tooltip.tsx
+++ b/webapp/src/components/jira_ticket_tooltip/jira_ticket_tooltip.tsx
@@ -185,20 +185,6 @@ export default class TicketPopover extends React.PureComponent<Props, State> {
                     <div className='popover-header__container'>
                         <a
                             href={this.props.href}
-                            title='Go to ticket'
-                            target='_blank'
-                            rel='noopener noreferrer'
-                        >
-                            <img
-                                src={ticketDetails.jiraIcon}
-                                width={14}
-                                height={14}
-                                alt='jira-avatar'
-                                className='popover-header__avatar'
-                            />
-                        </a>
-                        <a
-                            href={this.props.href}
                             className='popover-header__keyword'
                             target='_blank'
                             rel='noopener noreferrer'

--- a/webapp/src/components/jira_ticket_tooltip/ticketStyle.scss
+++ b/webapp/src/components/jira_ticket_tooltip/ticketStyle.scss
@@ -32,17 +32,6 @@
         align-items: center;
     }
 
-    .popover-header__avatar {
-        background-color: #282c34;
-        width: 20px;
-        position: absolute;
-        margin-left: 300px;
-        right: 24px;
-        top: 24px;
-        height: 20px;
-        border-radius: 50%;
-    }
-
     .popover-header__keyword {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
#### Summary
Removed the project icon from ticket link tooltip

#### Screenshot
![image](https://github.com/mattermost/mattermost-plugin-jira/assets/55234496/0c6498f3-70a9-4057-adb5-639ef8c62d76)


#### Ticket Link
Fixes #1021 

