### PR TITLE
Remove /jira settings command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -48,7 +48,6 @@ var jiraCommandHandler = CommandHandler{
 		"issue/transition":             executeTransition,
 		"issue/unassign":               executeUnassign,
 		"issue/view":                   executeView,
-		"settings":                     executeSettings,
 		"subscribe/list":               executeSubscribeList,
 		"transition":                   executeTransition,
 		"unassign":                     executeUnassign,
@@ -381,10 +380,10 @@ func (p *Plugin) help(args *model.CommandArgs) *model.CommandResponse {
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	err := p.CheckSiteURL()
-	if err != nil {
-		return p.responsef(commandArgs, err.Error()), nil
-	}
+	// err := p.CheckSiteURL()
+	// if err != nil {
+	// 	return p.responsef(commandArgs, err.Error()), nil
+	// }
 	args := strings.Fields(commandArgs.Command)
 	if len(args) == 0 || args[0] != "/jira" {
 		return p.help(commandArgs), nil

--- a/server/command.go
+++ b/server/command.go
@@ -380,10 +380,10 @@ func (p *Plugin) help(args *model.CommandArgs) *model.CommandResponse {
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	// err := p.CheckSiteURL()
-	// if err != nil {
-	// 	return p.responsef(commandArgs, err.Error()), nil
-	// }
+	err := p.CheckSiteURL()
+	if err != nil {
+		return p.responsef(commandArgs, err.Error()), nil
+	}
 	args := strings.Fields(commandArgs.Command)
 	if len(args) == 0 || args[0] != "/jira" {
 		return p.help(commandArgs), nil


### PR DESCRIPTION
#### Summary

- Removed `/jira settings` from slash commands as the actual command for settings is `/jira instance settings [setting] [value]` as stated in the help command

#### Ticket Link
Fixes #1037 
