### PR TITLE
[GH-1007]: Updated the instruction in the setup flow for the cloud Oauth2.0

### DIFF
--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -323,7 +323,9 @@ func (p *Plugin) stepCloudOAuthConfigure() flow.Step {
 			"       {{.OAuthCompleteURL}}\n"+
 			"8. Select **Settings** in the left menu.\n"+
 			"9. Copy the **Client ID** and **Secret** and keep it handy.\n"+
-			"10. Click on the **Configure** button below, enter these details and then **Continue**.", JiraScopes)).
+			"10. By default the app will be listed as private. If you wish to make it public means other users can use it too then Select the **Distribution** in the left menu.\n"+
+			"11. Click on the **Sharing** radio button, fill the form with the relevant data and click on **Save changes**.\n"+
+			"12. Click on the **Configure** button below, enter these details and then **Continue**.", JiraScopes)).
 		WithButton(flow.Button{
 			Name:  "Configure",
 			Color: flow.ColorPrimary,

--- a/server/setup_flow.go
+++ b/server/setup_flow.go
@@ -323,7 +323,7 @@ func (p *Plugin) stepCloudOAuthConfigure() flow.Step {
 			"       {{.OAuthCompleteURL}}\n"+
 			"8. Select **Settings** in the left menu.\n"+
 			"9. Copy the **Client ID** and **Secret** and keep it handy.\n"+
-			"10. By default the app will be listed as private. If you wish to make it public means other users can use it too then Select the **Distribution** in the left menu.\n"+
+			"10. By default the app will be created as private. In order to share it with your organization, select the **Distribution** in the left menu.\n"+
 			"11. Click on the **Sharing** radio button, fill the form with the relevant data and click on **Save changes**.\n"+
 			"12. Click on the **Configure** button below, enter these details and then **Continue**.", JiraScopes)).
 		WithButton(flow.Button{


### PR DESCRIPTION
#### Summary
1) Updated the step to include the sharing of the app to make it public and usable to other users in the setup command for cloud Oauth2.0.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-jira/issues/1007

#### Steps To Test
1) Run the slash command /jira setup and select cloud Oauth2.0. In the step 1: Creation of the App, You can find an additional step to make the app public. 
