### PR TITLE
[GH-1087] Add "updated_priority" event param for legacy webhooks

### DIFF
--- a/server/webhook_http.go
+++ b/server/webhook_http.go
@@ -28,7 +28,7 @@ var eventParamMasks = map[string]StringSet{
 	"updated_attachment":  NewStringSet(eventUpdatedAttachment),  // updated attachments
 	"updated_description": NewStringSet(eventUpdatedDescription), // issue description edited
 	"updated_labels":      NewStringSet(eventUpdatedLabels),      // updated labels
-	"updated_prioity":     NewStringSet(eventUpdatedPriority),    // changes in priority
+	"updated_prioity":     NewStringSet(eventUpdatedPriority),    // changes in priority (Leaving this event with incorrect spelling in place in order to maintain backward compatibility)
 	"updated_priority":    NewStringSet(eventUpdatedPriority),    // changes in priority
 	"updated_rank":        NewStringSet(eventUpdatedRank),        // ranked higher or lower
 	"updated_sprint":      NewStringSet(eventUpdatedSprint),      // assigned to a different sprint

--- a/server/webhook_http.go
+++ b/server/webhook_http.go
@@ -29,6 +29,7 @@ var eventParamMasks = map[string]StringSet{
 	"updated_description": NewStringSet(eventUpdatedDescription), // issue description edited
 	"updated_labels":      NewStringSet(eventUpdatedLabels),      // updated labels
 	"updated_prioity":     NewStringSet(eventUpdatedPriority),    // changes in priority
+	"updated_priority":    NewStringSet(eventUpdatedPriority),    // changes in priority
 	"updated_rank":        NewStringSet(eventUpdatedRank),        // ranked higher or lower
 	"updated_sprint":      NewStringSet(eventUpdatedSprint),      // assigned to a different sprint
 	"updated_status":      NewStringSet(eventUpdatedStatus),      // transitions like Done, In Progress


### PR DESCRIPTION
#### Summary
- The "updated_priority" event param for legacy webhooks was misspelled as "updated_prioity". We added the correct event param without changing the existing one, so that the functionality of existing users does not get affected.
Documentation update PR: https://github.com/mattermost/docs/pull/7238

#### What to test:
- Users are getting notified for priority change event in for both event params i.e. "updated_priority" and "updated_prioity"

#### How to test:
- Install a Jira instance on you MM
- Do not connect your account
- Setup a [legacy webhook](https://docs.mattermost.com/integrate/jira-interoperability.html#legacy-jira-webhooks)
- Update the priority of any ticket on Jira

#### Ticket Link
Fixes #1087 

