### PR TITLE
[MM-996]: removed jwt instance from setup autocomplete

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -84,11 +84,9 @@ const sysAdminHelpText = "\n###### For System Administrators:\n" +
 	"Install Jira instances:\n" +
 	"* `/jira instance install server [jiraURL]` - Connect Mattermost to a Jira Server or Data Center instance located at <jiraURL>\n" +
 	"* `/jira instance install cloud-oauth [jiraURL]` - Connect Mattermost to a Jira Cloud instance using OAuth 2.0 located at <jiraURL>\n" +
-	"* `/jira instance install cloud [jiraURL]` - Connect Mattermost to a Jira Cloud instance located at <jiraURL>. (Deprecated. Please use `cloud-oauth` instead.)\n" +
 	"Uninstall Jira instances:\n" +
 	"* `/jira instance uninstall server [jiraURL]` - Disconnect Mattermost from a Jira Server or Data Center instance located at <jiraURL>\n" +
 	"* `/jira instance uninstall cloud-oauth [jiraURL]` - Disconnect Mattermost from a Jira Cloud instance using OAuth 2.0 located at <jiraURL>\n" +
-	"* `/jira instance uninstall cloud [jiraURL]` - Disconnect Mattermost from a Jira Cloud instance located at <jiraURL>\n" +
 	"Manage channel subscriptions:\n" +
 	"* `/jira subscribe ` - Configure the Jira notifications sent to this channel\n" +
 	"* `/jira subscribe list` - Display all the the subscription rules setup across all the channels and teams on your Mattermost instance\n" +
@@ -179,13 +177,13 @@ func createInstanceCommand(optInstance bool) *model.AutocompleteData {
 	}
 
 	install := model.NewAutocompleteData(
-		"install", "[cloud|server|cloud-oauth] [URL]", "Connect Mattermost to a Jira instance")
+		"install", "[server|cloud-oauth] [URL]", "Connect Mattermost to a Jira instance")
 	install.AddStaticListArgument("Jira type: server, cloud or cloud-oauth", true, jiraTypes)
 	install.AddTextArgument("Jira URL", "Enter the Jira URL, e.g. https://mattermost.atlassian.net", "")
 	install.RoleID = model.SystemAdminRoleId
 
 	uninstall := model.NewAutocompleteData(
-		"uninstall", "[cloud|server|cloud-oauth] [URL]", "Disconnect Mattermost from a Jira instance")
+		"uninstall", "[server|cloud-oauth] [URL]", "Disconnect Mattermost from a Jira instance")
 	uninstall.AddStaticListArgument("Jira type: server, cloud or cloud-oauth", true, jiraTypes)
 	uninstall.AddDynamicListArgument("Jira instance", makeAutocompleteRoute(routeAutocompleteInstalledInstance), true)
 	uninstall.RoleID = model.SystemAdminRoleId

--- a/server/command.go
+++ b/server/command.go
@@ -176,7 +176,6 @@ func createInstanceCommand(optInstance bool) *model.AutocompleteData {
 	jiraTypes := []model.AutocompleteListItem{
 		{HelpText: "Jira Server or Datacenter", Item: "server"},
 		{HelpText: "Jira Cloud OAuth 2.0 (atlassian.net)", Item: "cloud-oauth"},
-		{HelpText: "Jira Cloud (atlassian.net) (Deprecated. Please use cloud-oauth instead.)", Item: "cloud"},
 	}
 
 	install := model.NewAutocompleteData(


### PR DESCRIPTION
#### Summary
Remove the "cloud" JWT instance type from install, uninstall paths & help text.

#### What to test
Check for JWT/Cloud instance type in any command/autocomplete, i.e. install, uninstall, help etc

##### Existing
![Screenshot from 2024-06-28 21-06-15](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/6979343e-5ae5-476d-9b78-ea502165bc91)
![help-text-old](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/c1b5d302-99c9-4623-8cf2-b275c5b5505e)
![instance-install-old](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/9716b846-7b0c-45ae-a7f0-bf82266558d6)

##### Updated
![Screenshot from 2024-06-28 20-58-42](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/e0a2cbbe-8633-4f13-ac61-439914df088d)
![help-text-new](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/716f63c7-2d36-47d4-93fb-55e846d59f27)
![instance-install-new](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/4dff74d1-b16d-45c4-be4a-fcf3d247cf68)

#### Issue
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/996

