### PR TITLE
[GH-1080] Update truncation logic for strings

### DIFF
--- a/server/webhook_jira.go
+++ b/server/webhook_jira.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -191,11 +192,12 @@ func mdUser(user *jira.User) string {
 }
 
 func truncate(s string, max int) string {
-	if len(s) <= max || max < 0 {
+	if utf8.RuneCountInString(s) <= max || max < 0 {
 		return s
 	}
+	runes := []rune(s)
 	if max > 3 {
-		return s[:max-3] + "..."
+		return string(runes[:max-3]) + "..."
 	}
-	return s[:max]
+	return string(runes[:max])
 }


### PR DESCRIPTION
#### Summary
In the existing implementation, truncation was occurring at the byte level, which could lead to incorrect handling of multi-byte characters, such as UTF-8 characters.

Changes:
- Changes have been made to the logic of string truncation to account for multi-byte characters.
- The usage of the unicode/utf8 package has been added to accurately count characters in the string.
- String truncation now occurs at the character level, ensuring proper behavior when dealing with multi-byte characters.

Screenshots:
Assumption: Max char length is 30

Earlier:
![image](https://github.com/user-attachments/assets/37fa1bdc-5031-4be8-87f4-42afcd4b26a4)

Now: 
![image](https://github.com/user-attachments/assets/db9d1579-45fc-4798-a382-7c1f0fa68ed0)

#### Ticket Link
Fixes #1080


