### PR TITLE
[MM-673]: Updated the instance connect autocomplete data to show alias and url both

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -188,7 +188,7 @@ func createInstanceCommand(optInstance bool) *model.AutocompleteData {
 	uninstall := model.NewAutocompleteData(
 		"uninstall", "[server|cloud-oauth] [URL]", "Disconnect Mattermost from a Jira instance")
 	uninstall.AddStaticListArgument("Jira type: server, cloud or cloud-oauth", true, jiraTypes)
-	uninstall.AddDynamicListArgument("Jira instance", makeAutocompleteRoute(routeAutocompleteInstalledInstance), true)
+	uninstall.AddDynamicListArgument("Jira instance", makeAutocompleteRoute(routeAutocompleteInstalledInstanceWithAlias), true)
 	uninstall.RoleID = model.SystemAdminRoleId
 
 	list := model.NewAutocompleteData(

--- a/server/command.go
+++ b/server/command.go
@@ -229,7 +229,7 @@ func withParamIssueKey(cmd *model.AutocompleteData) {
 func createConnectCommand() *model.AutocompleteData {
 	connect := model.NewAutocompleteData(
 		"connect", "", "Connect your Mattermost account to your Jira account")
-	connect.AddDynamicListArgument("Jira URL", makeAutocompleteRoute(routeAutocompleteConnect), false)
+	connect.AddDynamicListArgument("Jira URL", makeAutocompleteRoute(routeAutocompleteInstalledInstanceWithAlias), false)
 	return connect
 }
 

--- a/server/instances.go
+++ b/server/instances.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -417,7 +418,7 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 	}
 
 	for _, instanceID := range info.Instances.IDs() {
-		item := instances.getAlias(instanceID)
+		item := fmt.Sprintf("%s(%s)", instances.getAlias(instanceID), instanceID)
 		if item == "" {
 			item = string(instanceID)
 		}

--- a/server/instances.go
+++ b/server/instances.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -418,12 +417,15 @@ func (p *Plugin) httpAutocompleteInstalledInstanceWithAlias(w http.ResponseWrite
 	}
 
 	for _, instanceID := range info.Instances.IDs() {
-		item := fmt.Sprintf("%s(%s)", instances.getAlias(instanceID), instanceID)
+		item := instances.getAlias(instanceID)
+		helpText := string(instanceID)
 		if item == "" {
 			item = string(instanceID)
+			helpText = ""
 		}
 		out = append(out, model.AutocompleteListItem{
-			Item: item,
+			Item:     item,
+			HelpText: helpText,
 		})
 	}
 	return respondJSON(w, out)


### PR DESCRIPTION
#### Summary
Updated the instance connect autocomplete data to show alias and url both

#### Screenshots
##### Existing
![Screenshot from 2024-07-30 19-32-33](https://github.com/user-attachments/assets/fe894c18-ad2c-4099-8c10-dd04cf7f1a2c)

##### Updated
![Screenshot from 2024-07-30 21-40-48](https://github.com/user-attachments/assets/5c4bbd5c-9adb-4829-ba8a-fa8ba63ef090)

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/673


