### PR TITLE
[MM-1106]: Updated the default value for maximum attachment size for Jira plugin

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -83,7 +83,7 @@ type externalConfig struct {
 	DisplaySubscriptionNameInNotifications bool
 }
 
-const defaultMaxAttachmentSize = utils.ByteSize(10 * 1024 * 1024) // 10Mb
+const defaultMaxAttachmentSize = utils.ByteSize(100 * 1024 * 1024) // 10Mb
 
 type config struct {
 	// externalConfig caches values from the plugin's settings in the server's config.json

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -83,7 +83,7 @@ type externalConfig struct {
 	DisplaySubscriptionNameInNotifications bool
 }
 
-const defaultMaxAttachmentSize = utils.ByteSize(100 * 1024 * 1024) // 10Mb
+const defaultMaxAttachmentSize = utils.ByteSize(100 * 1024 * 1024) // 100Mb
 
 type config struct {
 	// externalConfig caches values from the plugin's settings in the server's config.json


### PR DESCRIPTION
#### Summary
Updated the default value for maximum attachment size for Jira plugin

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1106

