### PR TITLE
[MM-1096]: Fixed improper markdown for Jira comments received as a subscription in mattermost

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -337,7 +337,7 @@ func preProcessText(jiraMarkdownString string) string {
 	var counter int
 	var lastLineWasNumberedList bool
 	var result []string
-	lines := strings.Split(comment, "\n")
+	lines := strings.Split(jiraMarkdownString, "\n")
 	for _, line := range lines {
 		if numberedListRegex.MatchString(line) {
 			if !lastLineWasNumberedList {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -318,6 +318,11 @@ func quoteIssueComment(comment string) string {
 	return "> " + strings.ReplaceAll(comment, "\n", "\n> ")
 }
 
+// preProcessText processes the given comment string to apply various formatting transformations.
+// The purpose of the function is to convert the formatting provided by JIRA into the corresponding formatting supported by Mattermost.
+// This includes converting asterisks to bold, hyphens to strikethrough, JIRA-style headings to Markdown headings,
+// JIRA code blocks to inline code, numbered lists to Markdown lists, colored text to plain text, and JIRA links to Markdown links.
+// For more reference, please visit https://github.com/mattermost/mattermost-plugin-jira/issues/1096
 func preProcessText(comment string) string {
 	asteriskRegex := regexp.MustCompile(`\*(\w+)\*`)
 	hyphenRegex := regexp.MustCompile(`-(\w+)-`)
@@ -327,7 +332,7 @@ func preProcessText(comment string) string {
 	colouredTextRegex := regexp.MustCompile(`\{color:[^}]+\}(.*?)\{color\}`)
 	linkRegex := regexp.MustCompile(`\[(.*?)\|([^|\]]+)(?:\|([^|\]]+))?\]`)
 
-	// below code converts lines starting with "#" into a numbered list. It increments the counter if consecutive lines are numbered,
+	// the below code converts lines starting with "#" into a numbered list. It increments the counter if consecutive lines are numbered,
 	// otherwise resets it to 1. The "#" is replaced with the corresponding number and period. Non-numbered lines are added unchanged.
 	var counter int
 	var lastLineWasNumberedList bool
@@ -349,7 +354,7 @@ func preProcessText(comment string) string {
 	}
 	processedComment := strings.Join(result, "\n")
 
-	// below code converts links in the format "[text|url]" or "[text|url|optional]" to Markdown links. If the text is empty,
+	// the below code converts links in the format "[text|url]" or "[text|url|optional]" to Markdown links. If the text is empty,
 	// the URL is used for both the text and link. If the optional part is present, it's ignored. Unrecognized patterns remain unchanged.
 	processedComment = linkRegex.ReplaceAllStringFunc(processedComment, func(link string) string {
 		parts := linkRegex.FindStringSubmatch(link)

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -403,12 +403,6 @@ func preProcessText(jiraMarkdownString string) string {
 		return "> " + quotedText
 	})
 
-	fmt.Println("\n\n\n\n\n\n")
-	fmt.Println(jiraMarkdownString)
-	fmt.Println("\n\n\n\n\n\n")
-	fmt.Println(processedString)
-	fmt.Println("\n\n\n\n\n\n")
-
 	return processedString
 }
 

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -318,12 +318,12 @@ func quoteIssueComment(comment string) string {
 	return "> " + strings.ReplaceAll(comment, "\n", "\n> ")
 }
 
-// preProcessText processes the given comment string to apply various formatting transformations.
+// preProcessText processes the given string to apply various formatting transformations.
 // The purpose of the function is to convert the formatting provided by JIRA into the corresponding formatting supported by Mattermost.
 // This includes converting asterisks to bold, hyphens to strikethrough, JIRA-style headings to Markdown headings,
 // JIRA code blocks to inline code, numbered lists to Markdown lists, colored text to plain text, and JIRA links to Markdown links.
 // For more reference, please visit https://github.com/mattermost/mattermost-plugin-jira/issues/1096
-func preProcessText(comment string) string {
+func preProcessText(jiraMarkdownString string) string {
 	asteriskRegex := regexp.MustCompile(`\*(\w+)\*`)
 	hyphenRegex := regexp.MustCompile(`-(\w+)-`)
 	headingRegex := regexp.MustCompile(`(?m)^(h[1-6]\.)\s+`)

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -331,6 +331,7 @@ func preProcessText(jiraMarkdownString string) string {
 	numberedListRegex := regexp.MustCompile(`^#\s+`)
 	colouredTextRegex := regexp.MustCompile(`\{color:[^}]+\}(.*?)\{color\}`)
 	linkRegex := regexp.MustCompile(`\[(.*?)\|([^|\]]+)(?:\|([^|\]]+))?\]`)
+	quoteRegex := regexp.MustCompile(`\{quote\}(.*?)\{quote\}`)
 
 	// the below code converts lines starting with "#" into a numbered list. It increments the counter if consecutive lines are numbered,
 	// otherwise resets it to 1. The "#" is replaced with the corresponding number and period. Non-numbered lines are added unchanged.
@@ -390,6 +391,11 @@ func preProcessText(jiraMarkdownString string) string {
 	})
 
 	processedComment = colouredTextRegex.ReplaceAllString(processedComment, "$1")
+
+	processedComment = quoteRegex.ReplaceAllStringFunc(processedComment, func(quote string) string {
+		quotedText := quote[strings.Index(quote, "}")+1 : strings.LastIndex(quote, "{quote}")]
+		return "> " + quotedText
+	})
 
 	return processedComment
 }

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -487,7 +487,7 @@ func parseWebhookUpdatedDescription(jwh *JiraWebhook, from, to string) *webhook 
 	fromFmttd := "\n**From:** " + truncate(from, 500)
 	toFmttd := "\n**To:** " + truncate(to, 500)
 	wh.fieldInfo = webhookField{descriptionField, descriptionField, fromFmttd, toFmttd}
-	wh.text = jwh.mdIssueDescription()
+	wh.text = preProcessText(jwh.mdIssueDescription())
 	return wh
 }
 

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -200,6 +200,10 @@ h6. HEADING 6`,
 			input:          "[google|http://www.google.com]",
 			expectedOutput: "[google](http://www.google.com)",
 		},
+		"Quote formatting": {
+			input:          "{quote}This is a quote{quote}",
+			expectedOutput: "> This is a quote",
+		},
 	}
 
 	for name, tc := range tests {

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -136,3 +136,76 @@ func TestWebhookQuotedComment(t *testing.T) {
 		assert.True(t, strings.HasPrefix(w.text, ">"))
 	}
 }
+
+func TestPreProcessText(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedOutput string
+	}{
+		"BOLD formatting": {
+			input:          "*BOLD*",
+			expectedOutput: "**BOLD**",
+		},
+		"STRIKETHROUGH formatting": {
+			input:          "-STRIKETHROUGH-",
+			expectedOutput: "~~STRIKETHROUGH~~",
+		},
+		"Colored text formatting": {
+			input:          "{color:#ff5630}RED{color} {color:#4c9aff}BLUE{color} {color:#36b37e}GREEN{color}",
+			expectedOutput: "RED BLUE GREEN",
+		},
+		"Numbered list with mixed content formatting": {
+			input: `# NUMBERED LIST ROW 1
+# NUMBERED LIST ROW 2
+non-numbered list text
+# NUMBERED LIST ROW 1`,
+			expectedOutput: `1. NUMBERED LIST ROW 1
+2. NUMBERED LIST ROW 2
+non-numbered list text
+1. NUMBERED LIST ROW 1`,
+		},
+		"Code block formatting": {
+			input:          "{code:go}fruit := \"APPLE\"{code}",
+			expectedOutput: "`fruit := \"APPLE\"`",
+		},
+		"Bullet list formatting": {
+			input: `* BULLET LIST ROW 1
+* BULLET LIST ROW 2`,
+			expectedOutput: `* BULLET LIST ROW 1
+* BULLET LIST ROW 2`,
+		},
+		"Heading formatting": {
+			input: `h1. HEADING 1
+h2. HEADING 2
+h3. HEADING 3
+h4. HEADING 4
+h5. HEADING 5
+h6. HEADING 6`,
+			expectedOutput: `# HEADING 1
+## HEADING 2
+### HEADING 3
+#### HEADING 4
+##### HEADING 5
+###### HEADING 6`,
+		},
+		"Link formatting with text": {
+			input:          "[www.googlesd.com|http://www.googlesd.com]",
+			expectedOutput: "[www.googlesd.com](http://www.googlesd.com)",
+		},
+		"Link formatting with smart-link": {
+			input:          "[http://www.google.com|http://www.google.com|smart-link]",
+			expectedOutput: "[http://www.google.com](http://www.google.com)",
+		},
+		"Link formatting with title": {
+			input:          "[google|http://www.google.com]",
+			expectedOutput: "[google](http://www.google.com)",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualOutput := preProcessText(tc.input)
+			assert.Equal(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}


### PR DESCRIPTION
### Description
- Corrected Markdown formatting for Jira comments received as subscriptions in Mattermost.
- Note that Mattermost does not support colored text in Markdown; any colored text from Jira comments will be displayed as plain text in Mattermost.

**Important:** This PR employs regular expressions to identify and replace various Markdown elements. If these identifiers are present exactly as written in the comment, they will be interpreted as Markdown by Mattermost. However, the likelihood of this occurring is minimal.

### What to test
- Setup Jira plugin and create a subscription for issue comment/issue description
- Comment on an issue or update the description of a ticket
- Check the markdowns used in Jira and their equivalent markdown on Mattermost
#### Markedowns fixed in this PR
- Bold
- strikethrough
- color
- numbered list
- links
- code block
- quotes
### Ticket link
 Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1096
 Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/599

### Screenshots
#### Jira Comment
![jira text](https://github.com/user-attachments/assets/86925835-475c-458b-a6ff-95f2a95c05b8)
#### Previous Mattermost Subscription Notification
![old mattermost text](https://github.com/user-attachments/assets/261f1361-9db7-46f7-b79a-ae8d82288fb6)
![Screenshot from 2024-09-02 17-12-09](https://github.com/user-attachments/assets/cd77f088-a79f-47a6-acbc-5b46ec99db50)
#### Updated Mattermost Subscription Notification
![mattermost text](https://github.com/user-attachments/assets/d03f2c43-a439-48a7-8356-ce41f45f2367)
![Screenshot from 2024-09-02 17-12-32](https://github.com/user-attachments/assets/33c7c409-6724-4c50-93f2-0f9e0891324b)

