### PR TITLE
[MM-1108]: Handled the truncation of issue summary while making it a link for message

### DIFF
--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -16,12 +16,14 @@ import (
 
 var jiraLinkWithTextRegex = regexp.MustCompile(`\[([^\[]+)\|([^\]]+)\]`)
 
+const issueSummaryMaxLength = 80
+
 func parseJiraLinksToMarkdown(text string) string {
 	return jiraLinkWithTextRegex.ReplaceAllString(text, "[${1}](${2})")
 }
 
 func mdKeySummaryLink(issue *jira.Issue, instance Instance) string {
-	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, truncate(issue.Fields.Summary, 80), issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
+	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, truncate(issue.Fields.Summary, issueSummaryMaxLength), issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
 }
 
 func reporterSummary(reporter *jira.User) string {

--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -21,7 +21,7 @@ func parseJiraLinksToMarkdown(text string) string {
 }
 
 func mdKeySummaryLink(issue *jira.Issue, instance Instance) string {
-	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, issue.Fields.Summary, issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
+	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, truncate(issue.Fields.Summary, 80), issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
 }
 
 func reporterSummary(reporter *jira.User) string {

--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -23,7 +23,7 @@ func parseJiraLinksToMarkdown(text string) string {
 }
 
 func mdKeySummaryLink(issue *jira.Issue, instance Instance) string {
-	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, truncate(issue.Fields.Summary, issueSummaryMaxLength), issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
+	return fmt.Sprintf("[%s: %s (%s)](%s%s)", issue.Key, truncate(issue.Fields.Summary, maxIssueSummaryLength), issue.Fields.Status.Name, instance.GetJiraBaseURL(), "/browse/"+issue.Key)
 }
 
 func reporterSummary(reporter *jira.User) string {

--- a/server/issue_parser.go
+++ b/server/issue_parser.go
@@ -16,7 +16,7 @@ import (
 
 var jiraLinkWithTextRegex = regexp.MustCompile(`\[([^\[]+)\|([^\]]+)\]`)
 
-const issueSummaryMaxLength = 80
+const maxIssueSummaryLength = 80
 
 func parseJiraLinksToMarkdown(text string) string {
 	return jiraLinkWithTextRegex.ReplaceAllString(text, "[${1}](${2})")


### PR DESCRIPTION
### Summary
Handled the truncation of the issue summary while making it a link for the message

### Issue link
 Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1108

### Screenshots
#### Existing
![Screenshot from 2024-09-19 16-14-19](https://github.com/user-attachments/assets/3a5b07ab-844d-463c-be47-480e5d6634ff)
#### Updated
![Screenshot from 2024-09-19 16-02-02](https://github.com/user-attachments/assets/6b5aa954-4828-41ce-9620-f0afaae8e030)

### Testing steps
- Connect your JIra to mattermost
- Subscribe to Jira project
- Create a Jira issue with in the same project with a very long summary
- Check the subscription post in mattermost