### PR TITLE
[MM-1121]: Fix epic selector not displaying options if field is renamed in Jira

### DIFF
--- a/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
+++ b/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
@@ -54,9 +54,6 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
                     break;
                 }
             }
-            if (epicNameTypeId) {
-                break;
-            }
         }
 
         if (!epicNameTypeId || !epicNameTypeName) {
@@ -85,9 +82,6 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
                     projectKey = project.key;
                     break;
                 }
-            }
-            if (epicNameTypeId) {
-                break;
             }
         }
 

--- a/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
+++ b/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
@@ -45,7 +45,7 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
     searchIssues = async (userInput: string): Promise<ReactSelectOption[]> => {
         let epicNameTypeId: string | undefined;
         let epicNameTypeName: string | undefined;
-    
+
         for (const project of this.props.issueMetadata.projects) {
             for (const issueType of project.issuetypes) {
                 epicNameTypeId = Object.keys(issueType.fields).find((key) => isEpicNameField(issueType.fields[key]));
@@ -58,7 +58,7 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
                 break;
             }
         }
-    
+
         if (!epicNameTypeId || !epicNameTypeName) {
             return [];
         }
@@ -76,7 +76,7 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
         let epicIssueTypeId: string | undefined;
         let epicNameTypeId: string | undefined;
         let projectKey: string | undefined;
-    
+
         for (const project of this.props.issueMetadata.projects) {
             for (const issueType of project.issuetypes) {
                 epicNameTypeId = Object.keys(issueType.fields).find((key) => isEpicNameField(issueType.fields[key]));

--- a/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
+++ b/webapp/src/components/data_selectors/jira_epic_selector/jira_epic_selector.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import {isEpicIssueType, isEpicNameField} from 'utils/jira_issue_metadata';
+import {isEpicNameField} from 'utils/jira_issue_metadata';
 import {IssueMetadata, JiraIssue, ReactSelectOption} from 'types/model';
 
 import BackendSelector, {Props as BackendSelectorProps} from '../backend_selector';
@@ -43,17 +43,25 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
     };
 
     searchIssues = async (userInput: string): Promise<ReactSelectOption[]> => {
-        const epicIssueType = this.props.issueMetadata.projects[0].issuetypes.find(isEpicIssueType);
-        if (!epicIssueType) {
+        let epicNameTypeId: string | undefined;
+        let epicNameTypeName: string | undefined;
+    
+        for (const project of this.props.issueMetadata.projects) {
+            for (const issueType of project.issuetypes) {
+                epicNameTypeId = Object.keys(issueType.fields).find((key) => isEpicNameField(issueType.fields[key]));
+                if (epicNameTypeId) {
+                    epicNameTypeName = issueType.fields[epicNameTypeId].name;
+                    break;
+                }
+            }
+            if (epicNameTypeId) {
+                break;
+            }
+        }
+    
+        if (!epicNameTypeId || !epicNameTypeName) {
             return [];
         }
-
-        const epicNameTypeId = Object.keys(epicIssueType.fields).find((key) => isEpicNameField(epicIssueType.fields[key]));
-        if (!epicNameTypeId) {
-            return [];
-        }
-
-        const epicNameTypeName = epicIssueType.fields[epicNameTypeId].name;
 
         let searchStr = '';
         if (userInput) {
@@ -65,18 +73,29 @@ export default class JiraEpicSelector extends React.PureComponent<Props> {
     };
 
     fetchEpicsFromJql = async (jqlSearch: string, userInput: string): Promise<ReactSelectOption[]> => {
-        const epicIssueType = this.props.issueMetadata.projects[0].issuetypes.find(isEpicIssueType);
-        if (!epicIssueType) {
+        let epicIssueTypeId: string | undefined;
+        let epicNameTypeId: string | undefined;
+        let projectKey: string | undefined;
+    
+        for (const project of this.props.issueMetadata.projects) {
+            for (const issueType of project.issuetypes) {
+                epicNameTypeId = Object.keys(issueType.fields).find((key) => isEpicNameField(issueType.fields[key]));
+                if (epicNameTypeId) {
+                    epicIssueTypeId = issueType.id;
+                    projectKey = project.key;
+                    break;
+                }
+            }
+            if (epicNameTypeId) {
+                break;
+            }
+        }
+
+        if (!epicNameTypeId || !projectKey || !epicIssueTypeId) {
             return [];
         }
 
-        const epicNameTypeId = Object.keys(epicIssueType.fields).find((key) => isEpicNameField(epicIssueType.fields[key]));
-        if (!epicNameTypeId) {
-            return [];
-        }
-
-        const projectKey = this.props.issueMetadata.projects[0].key;
-        const fullJql = `project=${projectKey} and issuetype=${epicIssueType.id} ${jqlSearch} ${searchDefaults}`;
+        const fullJql = `project=${projectKey} and issuetype=${epicIssueTypeId} ${jqlSearch} ${searchDefaults}`;
 
         const params = {
             jql: fullJql,


### PR DESCRIPTION
#### Summary
- The `Create Issue` modal had a bug: if the `Epic` field in a Jira project was renamed to anything other than `Epic`, the dropdown for selecting Jira epics displayed no options.
- The existing logic iterates over each field in the Jira project, filtering for fields named `Epic`, and then checks if the filtered field matches the Epic field schema before fetching all epics from the project.
- The bug occurred because the code depended solely on finding a field named `Epic`. This PR removes the name-based check and instead relies exclusively on the field schema to identify the Epic field.

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1121
  
  #### What to test
 - Create different fields of [epic](https://community.atlassian.com/t5/Jira-questions/How-do-I-create-an-Epic-on-a-JIRA-software-project/qaq-p/756275) type in a Jira project
 - Look for the Epic link field in the Create Issue modal 
 
![Screenshot from 2024-11-05 13-54-22](https://github.com/user-attachments/assets/2902c30d-ab3f-45a9-87de-02ec92971824)

