### PR TITLE
[MM-1137]: Added Autolink support for cloud-oauth

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -126,7 +126,7 @@
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",
-                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira and setup autolink.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access.",
+                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira and setup autolink.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
                 "placeholder": "",
                 "secret": true,
                 "default": ""

--- a/plugin.json
+++ b/plugin.json
@@ -126,7 +126,7 @@
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",
-                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
+                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for projects that the user cannot access and autolink will not work.",
                 "placeholder": "",
                 "secret": true,
                 "default": ""
@@ -135,7 +135,7 @@
                 "key": "AdminEmail",
                 "display_name": "Admin Email",
                 "type": "text",
-                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin and to to get notified for comment and issue created events when the user triggering the event is not connected to Jira",
+                "help_text": "**Note** Admin email is necessary to setup autolink for the Jira plugin and to to get notified for comment and issue created events when the user triggering the event is not connected to Jira",
                 "placeholder": "",
                 "default": ""
             }

--- a/plugin.json
+++ b/plugin.json
@@ -119,7 +119,16 @@
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",
-                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access.",
+                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira and setup autolink.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access.",
+                "placeholder": "",
+                "secret": true,
+                "default": ""
+            },
+            {
+                "key": "AdminEmail",
+                "display_name": "Admin Email",
+                "type": "text",
+                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin",
                 "placeholder": "",
                 "default": ""
             }

--- a/plugin.json
+++ b/plugin.json
@@ -119,14 +119,14 @@
                 "key": "EncryptionKey",
                 "display_name": "At Rest Encryption Key:",
                 "type": "generated",
-                "help_text": "The AES encryption key used to encrypt stored api tokens.",
+                "help_text": "The encryption key used to encrypt stored api tokens.",
                 "secret": true
             },
             {
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",
-                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira and setup autolink.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
+                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
                 "placeholder": "",
                 "secret": true,
                 "default": ""
@@ -135,7 +135,7 @@
                 "key": "AdminEmail",
                 "display_name": "Admin Email",
                 "type": "text",
-                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin",
+                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin and to to get notified for comment and issue created events even if the user triggering the event is not connected to Jira",
                 "placeholder": "",
                 "default": ""
             }

--- a/plugin.json
+++ b/plugin.json
@@ -120,6 +120,8 @@
                 "display_name": "At Rest Encryption Key:",
                 "type": "generated",
                 "help_text": "The encryption key used to encrypt stored API tokens.",
+                "placeholder": "",
+                "default": null,
                 "secret": true
             },
             {

--- a/plugin.json
+++ b/plugin.json
@@ -119,14 +119,14 @@
                 "key": "EncryptionKey",
                 "display_name": "At Rest Encryption Key:",
                 "type": "generated",
-                "help_text": "The encryption key used to encrypt stored api tokens.",
+                "help_text": "The encryption key used to encrypt stored API tokens.",
                 "secret": true
             },
             {
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",
-                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events even if the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
+                "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for the project the user cannot access and autolink will not work.",
                 "placeholder": "",
                 "secret": true,
                 "default": ""
@@ -135,7 +135,7 @@
                 "key": "AdminEmail",
                 "display_name": "Admin Email",
                 "type": "text",
-                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin and to to get notified for comment and issue created events even if the user triggering the event is not connected to Jira",
+                "help_text": "**Note** Admin email is necessary to setup autolink for Jira plugin and to to get notified for comment and issue created events when the user triggering the event is not connected to Jira",
                 "placeholder": "",
                 "default": ""
             }

--- a/plugin.json
+++ b/plugin.json
@@ -116,6 +116,13 @@
                 "default": false
             },
             {
+                "key": "EncryptionKey",
+                "display_name": "At Rest Encryption Key:",
+                "type": "generated",
+                "help_text": "The AES encryption key used to encrypt stored api tokens.",
+                "secret": true
+            },
+            {
                 "key": "AdminAPIToken",
                 "display_name": "Admin API Token",
                 "type": "text",

--- a/server/issue.go
+++ b/server/issue.go
@@ -1104,7 +1104,18 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 		return nil, errors.Wrapf(err, "failed to create http request for fetching issue data. IssueID: %s", issueID)
 	}
 
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + p.getConfig().AdminAPIToken))
+	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
+	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	if err != nil {
+		return nil, err
+	}
+	var adminAPIToken string
+	err = json.Unmarshal(jsonBytes, &adminAPIToken)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
 	req.Header.Set("Authorization", "Basic "+encodedAuth)
 	req.Header.Set("Accept", "application/json")
 
@@ -1154,7 +1165,18 @@ func (p *Plugin) GetProjectListWithAPIToken(instanceID string) (*jira.ProjectLis
 		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching project list data. InstanceID: %s", instanceID)
 	}
 
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + p.getConfig().AdminAPIToken))
+	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
+	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	if err != nil {
+		return nil, err
+	}
+	var adminAPIToken string
+	err = json.Unmarshal(jsonBytes, &adminAPIToken)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
 	req.Header.Set("Authorization", "Basic "+encodedAuth)
 	req.Header.Set("Accept", "application/json")
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1104,20 +1103,10 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 		return nil, errors.Wrapf(err, "failed to create http request for fetching issue data. IssueID: %s", issueID)
 	}
 
-	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
-	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	err = p.SetAdminAPITokenRequestHeader(req)
 	if err != nil {
 		return nil, err
 	}
-	var adminAPIToken string
-	err = json.Unmarshal(jsonBytes, &adminAPIToken)
-	if err != nil {
-		return nil, err
-	}
-
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
-	req.Header.Set("Authorization", "Basic "+encodedAuth)
-	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -1165,20 +1154,10 @@ func (p *Plugin) GetProjectListWithAPIToken(instanceID string) (*jira.ProjectLis
 		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching project list data. InstanceID: %s", instanceID)
 	}
 
-	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
-	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	err = p.SetAdminAPITokenRequestHeader(req)
 	if err != nil {
 		return nil, err
 	}
-	var adminAPIToken string
-	err = json.Unmarshal(jsonBytes, &adminAPIToken)
-	if err != nil {
-		return nil, err
-	}
-
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
-	req.Header.Set("Authorization", "Basic "+encodedAuth)
-	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
@@ -98,26 +99,29 @@ func (store mockUserStore) MapUsers(func(*User) error) error {
 	return nil
 }
 
-type mockInstanceStore struct{}
+type mockInstanceStore struct {
+	mock.Mock
+}
 
-func (store mockInstanceStore) CreateInactiveCloudInstance(types.ID, string) error {
+func (store *mockInstanceStore) CreateInactiveCloudInstance(types.ID, string) error {
 	return nil
 }
-func (store mockInstanceStore) DeleteInstance(types.ID) error {
+func (store *mockInstanceStore) DeleteInstance(types.ID) error {
 	return nil
 }
-func (store mockInstanceStore) LoadInstance(types.ID) (Instance, error) {
+func (store *mockInstanceStore) LoadInstance(id types.ID) (Instance, error) {
+	args := store.Called(id)
+	return args.Get(0).(Instance), args.Error(1)
+}
+func (store *mockInstanceStore) LoadInstanceFullKey(string) (Instance, error) {
 	return &testInstance{}, nil
 }
-func (store mockInstanceStore) LoadInstanceFullKey(string) (Instance, error) {
-	return &testInstance{}, nil
-}
-func (store mockInstanceStore) LoadInstances() (*Instances, error) {
+func (store *mockInstanceStore) LoadInstances() (*Instances, error) {
 	return NewInstances(), nil
 }
-func (store mockInstanceStore) StoreInstance(instance Instance) error {
+func (store *mockInstanceStore) StoreInstance(instance Instance) error {
 	return nil
 }
-func (store mockInstanceStore) StoreInstances(*Instances) error {
+func (store *mockInstanceStore) StoreInstances(*Instances) error {
 	return nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -188,7 +188,7 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	jsonBytes, err := json.Marshal(ec.AdminAPIToken)
 	if err != nil {
-		p.client.Log.Warn("Error marshaling the admin API token", "error", err)
+		p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
 		return err
 	}
 
@@ -200,7 +200,7 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(encryptionKey))
 	if err != nil {
-		p.client.Log.Warn("Error encrypting the admin API token", "error", err)
+		p.client.Log.Warn("Error encrypting the admin API token", "error", err.Error())
 		return err
 	}
 	ec.AdminAPIToken = string(encryptedAdminAPIToken)
@@ -378,11 +378,11 @@ func (p *Plugin) SetupAutolink(instances *Instances) {
 		switch instance := instance.(type) {
 		case *cloudInstance:
 			if err = p.AddAutolinksForCloudInstance(instance); err != nil {
-				p.client.Log.Info("could not install autolinks for cloud instance", "instance", instance.BaseURL, "error", err)
+				p.client.Log.Info("could not install autolinks for cloud instance", "instance", instance.BaseURL, "error", err.Error())
 			}
 		case *cloudOAuthInstance:
 			if err = p.AddAutolinksForCloudOAuthInstance(instance); err != nil {
-				p.client.Log.Info("could not install autolinks for cloud-oauth instance", "instance", instance.JiraBaseURL, "error", err)
+				p.client.Log.Info("could not install autolinks for cloud-oauth instance", "instance", instance.JiraBaseURL, "error", err.Error())
 			}
 		}
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -379,10 +379,14 @@ func (p *Plugin) SetupAutolink(instances *Instances) {
 		case *cloudInstance:
 			if err = p.AddAutolinksForCloudInstance(instance); err != nil {
 				p.client.Log.Info("could not install autolinks for cloud instance", "instance", instance.BaseURL, "error", err.Error())
+			} else {
+				p.client.Log.Info("successfully installed autolinks for cloud instance", "instance", instance.BaseURL)
 			}
 		case *cloudOAuthInstance:
 			if err = p.AddAutolinksForCloudOAuthInstance(instance); err != nil {
 				p.client.Log.Info("could not install autolinks for cloud-oauth instance", "instance", instance.JiraBaseURL, "error", err.Error())
+			} else {
+				p.client.Log.Info("successfully installed autolinks for cloud-oauth instance", "instance", instance.JiraBaseURL)
 			}
 		}
 	}
@@ -441,7 +445,10 @@ func (p *Plugin) AddAutolinks(key, baseURL string) error {
 
 	client := autolinkclient.NewClientPlugin(p.API)
 	if err := client.Add(installList...); err != nil {
-		return fmt.Errorf("unable to add autolinks: %w", err)
+		// Do not return an error if the status code is 304 (indicating that the autolink for this project is already installed).
+		if !strings.Contains(err.Error(), `Error: 304, {"status": "OK"}`) {
+			return fmt.Errorf("unable to add autolinks: %w", err)
+		}
 	}
 
 	return nil

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -192,7 +192,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		return err
 	}
 
-	encryptionKey := p.getConfig().EncryptionKey
+	encryptionKey := ec.EncryptionKey
 	if encryptionKey == "" {
 		p.client.Log.Warn("Encryption key required to encrypt admin API token")
 		return errors.New("failed to encrypt admin token. Encryption key not generated")
@@ -537,6 +537,15 @@ func (c *externalConfig) setDefaults() (bool, error) {
 			return false, err
 		}
 		c.Secret = secret
+		changed = true
+	}
+
+	if c.EncryptionKey == "" {
+		encryptionKey, err := generateSecret()
+		if err != nil {
+			return false, err
+		}
+		c.EncryptionKey = encryptionKey
 		changed = true
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -46,8 +46,6 @@ const (
 	WebhookMaxProcsPerServer = 20
 	WebhookBufferSize        = 10000
 	PluginRepo               = "https://github.com/mattermost/mattermost-plugin-jira"
-
-	apiTokenEncryptionKey = "token_encryption_key"
 )
 
 type externalConfig struct {
@@ -354,7 +352,7 @@ func (p *Plugin) SetupAutolink(instances *Instances) {
 		coi, coiOk := instance.(*cloudOAuthInstance)
 
 		if !ciOk && !coiOk {
-			p.client.Log.Info("only cloud and cloud-oauth instances supported for autolink", "err", err)
+			p.client.Log.Info("only cloud and cloud-oauth instances supported for autolink")
 			continue
 		}
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -177,7 +177,6 @@ func TestSetupAutolink(t *testing.T) {
 		{
 			name: "Unsupported instance type",
 			setup: func(p *Plugin, mockAPI *plugintest.API, dummyInstanceStore *mockInstanceStore) {
-				mockAPI.On("GetPluginStatus", "mattermost-autolink").Return(&model.PluginStatus{State: model.PluginStateRunning}, nil).Times(1)
 				mockAPI.On("LogInfo", "only cloud and cloud-oauth instances supported for autolink").Return(nil).Times(1)
 				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(&serverInstance{}, nil).Times(1)
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	MockInstanceID      = "mockInstanceID"
+	MockAPIToken        = "mockAPIToken"
+	MockAdminEmail      = "mockadmin@email.com"
+	MockBaseURL         = "mockBaseURL"
+	MockASCKey          = "mockAtlassianSecurityContextKey"
+	MockASCClientKey    = "mockAtlassianSecurityContextClientKey"
+	MockASCSharedSecret = "mockAtlassianSecurityContextSharedSecret" // #nosec G101: Potential hardcoded credentials - This is a mock for testing purposes
+)
+
 func validRequestBody() io.ReadCloser {
 	if f, err := os.Open("testdata/webhook-issue-created.json"); err != nil {
 		panic(err)
@@ -143,4 +153,130 @@ func TestPlugin(t *testing.T) {
 			assert.Equal(t, tc.ExpectedStatusCode, w.Result().StatusCode)
 		})
 	}
+}
+
+func TestSetupAutolink(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	dummyInstanceStore := new(mockInstanceStore)
+	mockPluginClient := pluginapi.NewClient(mockAPI, nil)
+	p := &Plugin{
+		client:        mockPluginClient,
+		instanceStore: dummyInstanceStore,
+	}
+
+	tests := []struct {
+		name         string
+		setup        func()
+		InstanceType InstanceType
+	}{
+		{
+			name: "Missing API token or Admin email",
+			setup: func() {
+				mockAPI.On("LogInfo", "unable to setup autolink due to missing API Token or Admin Email").Return(nil).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(&serverInstance{}, nil).Times(1)
+
+				p.updateConfig(func(c *config) {
+					c.AdminAPIToken = ""
+					c.AdminEmail = ""
+				})
+			},
+			InstanceType: ServerInstanceType,
+		},
+		{
+			name: "Unsupported instance type",
+			setup: func() {
+				mockAPI.On("LogInfo", "only cloud and cloud-oauth instances supported for autolink").Return(nil).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(&serverInstance{}, nil).Times(1)
+
+				p.updateConfig(GetConfigSetterFunction())
+			},
+			InstanceType: ServerInstanceType,
+		},
+		{
+			name: "Autolink plugin unavailable API returned error",
+			setup: func() {
+				mockAPI.On("LogWarn", "OnActivate: Autolink plugin unavailable. API returned error", "error", mock.Anything).Return(nil).Times(1)
+				mockAPI.On("GetPluginStatus", autolinkPluginID).Return(nil, &model.AppError{Message: "error getting plugin status"}).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(&cloudInstance{}, nil).Times(1)
+
+				p.updateConfig(GetConfigSetterFunction())
+			},
+			InstanceType: CloudInstanceType,
+		},
+		{
+			name: "Autolink plugin not running",
+			setup: func() {
+				mockAPI.On("LogWarn", "OnActivate: Autolink plugin unavailable. Plugin is not running", "status", &model.PluginStatus{State: model.PluginStateNotRunning}).Return(nil).Times(1)
+				mockAPI.On("GetPluginStatus", autolinkPluginID).Return(&model.PluginStatus{State: model.PluginStateNotRunning}, nil).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(&cloudInstance{}, nil).Times(1)
+
+				p.updateConfig(GetConfigSetterFunction())
+			},
+			InstanceType: CloudInstanceType,
+		},
+		{
+			name: "Error installing autolinks for cloud instance",
+			setup: func() {
+				mockAPI.On("LogInfo", "could not install autolinks for cloud instance", "instance", "mockBaseURL", "err", mock.Anything).Return(nil).Times(1)
+				mockAPI.On("GetPluginStatus", autolinkPluginID).Return(&model.PluginStatus{State: model.PluginStateRunning}, nil).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(
+					&cloudInstance{
+						InstanceCommon: &InstanceCommon{
+							Plugin: p,
+						},
+						AtlassianSecurityContext: &AtlassianSecurityContext{
+							BaseURL:      MockBaseURL,
+							Key:          MockASCKey,
+							ClientKey:    MockASCClientKey,
+							SharedSecret: MockASCSharedSecret,
+						},
+					}, nil).Times(1)
+
+				p.updateConfig(GetConfigSetterFunction())
+			},
+			InstanceType: CloudInstanceType,
+		},
+		{
+			name: "Error installing autolinks for cloud-oauth instance",
+			setup: func() {
+				mockAPI.On("LogInfo", "could not install autolinks for cloud-oauth instance", "instance", "mockBaseURL", "err", mock.Anything).Return(nil).Times(1)
+				mockAPI.On("GetPluginStatus", autolinkPluginID).Return(&model.PluginStatus{State: model.PluginStateRunning}, nil).Times(1)
+				dummyInstanceStore.On("LoadInstance", mock.Anything).Return(
+					&cloudOAuthInstance{
+						InstanceCommon: &InstanceCommon{
+							Plugin: p,
+						},
+						JiraBaseURL: MockBaseURL,
+					}, nil).Times(1)
+
+				p.updateConfig(GetConfigSetterFunction())
+			},
+			InstanceType: CloudOAuthInstanceType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			instances := GetInstancesWithType(tt.InstanceType)
+
+			p.SetupAutolink(instances)
+
+			mockAPI.AssertExpectations(t)
+			dummyInstanceStore.AssertExpectations(t)
+		})
+	}
+}
+
+func GetConfigSetterFunction() func(*config) {
+	return func(c *config) {
+		c.AdminAPIToken = MockAPIToken
+		c.AdminEmail = MockAdminEmail
+	}
+}
+
+func GetInstancesWithType(instanceType InstanceType) *Instances {
+	return NewInstances(&InstanceCommon{
+		InstanceID: MockInstanceID,
+		Type:       instanceType,
+	})
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -7,7 +7,9 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -181,4 +183,25 @@ func getS256PKCEParams() (*PKCEParams, error) {
 		CodeChallenge: challenge,
 		CodeVerifier:  verifier,
 	}, nil
+}
+
+func (p *Plugin) SetAdminAPITokenRequestHeader(req *http.Request) error {
+	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
+	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	if err != nil {
+		p.client.Log.Warn("Error decrypting admin API token", "error", err)
+		return err
+	}
+	var adminAPIToken string
+	err = json.Unmarshal(jsonBytes, &adminAPIToken)
+	if err != nil {
+		p.client.Log.Warn("Error unmarshalling admin API token", "error", err)
+		return err
+	}
+
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
+	req.Header.Set("Authorization", "Basic "+encodedAuth)
+	req.Header.Set("Accept", "application/json")
+
+	return nil
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -189,13 +189,13 @@ func (p *Plugin) SetAdminAPITokenRequestHeader(req *http.Request) error {
 	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
 	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
 	if err != nil {
-		p.client.Log.Warn("Error decrypting admin API token", "error", err)
+		p.client.Log.Warn("Error decrypting admin API token", "error", err.Error())
 		return err
 	}
 	var adminAPIToken string
 	err = json.Unmarshal(jsonBytes, &adminAPIToken)
 	if err != nil {
-		p.client.Log.Warn("Error unmarshalling admin API token", "error", err)
+		p.client.Log.Warn("Error unmarshalling admin API token", "error", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
#### Summary
- Added support for CloudOAuth for Autolink
- Updated the API call to get Issues with AdminAPIToken
- Added test cases for the SetupAutoLink function

#### Ticket Link
 Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/1137

#### What to test
- Autolink for Jira tickets
- Issue comment notification after the admin has disconnected his Jira account
- Keep an eye on the server logs

#### Testing step
- Install autolink plugin for you MM
- Install Jira plugin
- Add the admin API token and admin email in the Jira plugin configuration before enabling it
- enable the plugin
- Paste a link to a jira ticket on your MM chat
