### PR TITLE
[MM-62634] Change the fix for LinkTooltip to be backward compatible for jira plugin

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
     "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
     "icon_path": "assets/icon.svg",
-    "min_server_version": "10.5.0",
+    "min_server_version": "7.8.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/src/components/jira_ticket_tooltip/jira_ticket_tooltip.tsx
+++ b/webapp/src/components/jira_ticket_tooltip/jira_ticket_tooltip.tsx
@@ -81,21 +81,25 @@ export default class TicketPopover extends React.PureComponent<Props, State> {
         return null;
     };
 
-    componentDidMount() {
+    fetchIssue = (show: boolean, connected: boolean, ticketId?: string, ticketDetails?: TicketDetails | null): void => {
         const issueKey = this.getIssueKey();
         if (!issueKey) {
             return;
         }
 
-        const {instanceID} = issueKey;
-        if (this.props.show && this.state.ticketId && !this.state.ticketDetails) {
-            this.props.fetchIssueByKey(this.state.ticketId, instanceID).then((res: {data?: TicketData, error?: any}) => {
+        if (!show) {
+            return;
+        }
+
+        if (ticketId && !ticketDetails) {
+            this.props.fetchIssueByKey(ticketId, issueKey.instanceID).then((res: {data?: TicketData, error?: any}) => {
                 if (res.error) {
                     this.setState({error: 'There was a problem loading the details for this Jira link'});
                     return;
                 }
+
                 const updatedTicketDetails = getJiraTicketDetails(res.data);
-                if (this.props.connected && updatedTicketDetails && updatedTicketDetails.ticketId === this.state.ticketId) {
+                if (connected && updatedTicketDetails && updatedTicketDetails.ticketId === ticketId) {
                     this.setState({
                         ticketDetails: updatedTicketDetails,
                         error: null,
@@ -103,9 +107,17 @@ export default class TicketPopover extends React.PureComponent<Props, State> {
                 }
             });
         }
+    };
+
+    componentDidMount(): void {
+        this.fetchIssue(this.props.show, this.props.connected, this.state.ticketId, this.state.ticketDetails);
     }
 
-    fixVersionLabel(fixVersion: string) {
+    componentDidUpdate(): void {
+        this.fetchIssue(this.props.show, this.props.connected, this.state.ticketId, this.state.ticketDetails);
+    }
+
+    fixVersionLabel(fixVersion: string): ReactNode {
         if (fixVersion) {
             const fixVersionString = 'Fix Version :';
             return (
@@ -121,7 +133,7 @@ export default class TicketPopover extends React.PureComponent<Props, State> {
         return null;
     }
 
-    tagTicketStatus(ticketStatus: string) {
+    tagTicketStatus(ticketStatus: string): ReactNode {
         let ticketStatusClass = 'default-style ticket-status--default';
 
         const myStatusClass = myStatusClasses[ticketStatus && ticketStatus.toLowerCase()];


### PR DESCRIPTION
#### Summary
This fix backports the fix for improved link tooltip to work with version prior to MM v10.5 as well. The minimum MM version for plugin is also reverted back to v7.8. Changes adds more lifecycle hooks one for 10.5 and other for less than that.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-62634

#### Screenshots
With v10.5
![CleanShot 2025-01-20 at 21 28 59](https://github.com/user-attachments/assets/2fa2885b-1b0f-4a0b-81b2-5e5c55c24fc8)

With less than v10.5
![CleanShot 2025-01-20 at 21 44 31](https://github.com/user-attachments/assets/392008b6-9907-4274-9ddc-901d0ce4391c)



