### PR TITLE
fixed issue of plugin config not prefilling from previous build

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -193,7 +193,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	encryptionKey := ec.EncryptionKey
-	if encryptionKey == "" {
+	if encryptionKey == "" && ec.AdminAPIToken != "" {
 		p.client.Log.Warn("Encryption key required to encrypt admin API token")
 		return errors.New("failed to encrypt admin token. Encryption key not generated")
 	}
@@ -560,7 +560,12 @@ func (c *externalConfig) setDefaults() (bool, error) {
 }
 
 func (p *Plugin) setDefaultConfiguration() error {
-	ec := p.getConfig().externalConfig
+	ec := externalConfig{}
+	err := p.client.Configuration.LoadPluginConfiguration(&ec)
+	if err != nil {
+		return errors.WithMessage(err, "failed to load plugin configuration")
+	}
+
 	changed, err := ec.setDefaults()
 	if err != nil {
 		return err

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -193,7 +193,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	encryptionKey := ec.EncryptionKey
-	if encryptionKey == "" && ec.AdminAPIToken != "" {
+	if ec.AdminAPIToken != "" && encryptionKey == "" {
 		p.client.Log.Warn("Encryption key required to encrypt admin API token")
 		return errors.New("failed to encrypt admin token. Encryption key not generated")
 	}


### PR DESCRIPTION
#### Summary
Fixed the issue of config not prefilling when uploading a new build of release 4.2.0

#### Testing step
- Upload release 4.1.1 build
- Generate and set all plugin config
- Create & test webhook
- Upload new build
- Bool and string configs should be prefilled to the previous configs and webhooks should remain working