### PR TITLE
[GH-768] Fix redirect connect doesn't open mattermost's subpath url

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -448,8 +448,9 @@ export function handleConnectFlow(instanceID?: string) {
 
 export function redirectConnect(instanceID: string) {
     return async (dispatch: Dispatch, getState: GlobalState) => {
+        const baseUrl = getPluginServerRoute(getState());
         const instancePrefix = '/instance/' + btoa(instanceID);
-        const target = '/plugins/' + manifest.id + instancePrefix + '/user/connect';
+        const target = baseUrl + instancePrefix + '/user/connect';
         window.open(target, '_blank');
     };
 }

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -6,8 +6,6 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/common';
 
 import {Action, Dispatch, Store} from 'redux';
 
-import manifest from '../manifest';
-
 import ActionTypes from 'action_types';
 import {buildQueryString, doFetch, doFetchWithResponse} from 'client';
 import {getInstalledInstances, getPluginServerRoute, getUserConnectedInstances} from 'selectors';


### PR DESCRIPTION
#### Summary

Issue #768 remains relevant. The previous PR #870 introduced a new `baseUrl` variable intended to resolve a bug where the `/jira connect` command did not include the subpath in the URL when Mattermost was running on a subpath. However, this variable was never utilized, and as a result, the issue persisted. Furthermore, the `baseUrl` variable was removed in a later commit while addressing linting errors [a206519](https://github.com/mattermost/mattermost-plugin-jira/commit/a206519f9ad88e55a5ad7a1aabc8d29d0b68dc23#diff-3890cc5337cb185259d5838427a78eb3a949f1efbacdcdacea1479d719e101c9L436).

This PR reintroduces the `baseUrl` variable and ensures it is properly utilized, effectively resolving the bug.

#### Ticket Link
Fixes PR #870
Fixes issue #768
