### PR TITLE
feat: Secure Jira post actions against forged requests

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -95,6 +95,11 @@ func (p *Plugin) httpShareIssuePublicly(w http.ResponseWriter, r *http.Request) 
 			"user not authorized"), w, http.StatusUnauthorized)
 	}
 
+	if originalPost.ChannelId != channelID {
+		return p.respondErrWithFeedback(authenticatedUserID, makePost(jiraBotID, channelID,
+			"channel mismatch"), w, http.StatusBadRequest)
+	}
+
 	if requestData.UserId != "" && requestData.UserId != authenticatedUserID {
 		p.client.Log.Warn("share issue payload user mismatch",
 			"header_user_id", authenticatedUserID,
@@ -183,6 +188,11 @@ func (p *Plugin) httpTransitionIssuePostAction(w http.ResponseWriter, r *http.Re
 	if originalPost.UserId != jiraBotID {
 		return p.respondErrWithFeedback(authenticatedUserID, makePost(jiraBotID, channelID,
 			"user not authorized"), w, http.StatusUnauthorized)
+	}
+
+	if originalPost.ChannelId != channelID {
+		return p.respondErrWithFeedback(authenticatedUserID, makePost(jiraBotID, channelID,
+			"channel mismatch"), w, http.StatusBadRequest)
 	}
 
 	if requestData.UserId != "" && requestData.UserId != authenticatedUserID {


### PR DESCRIPTION
#### Summary
- harden httpShareIssuePublicly and httpTransitionIssuePostAction to trust the Mattermost-User-ID header, validate the originating Jira bot post, and reject malformed issue keys
- add targeted unit coverage so missing headers, wrong post authors, bad issue keys, and payload/header mismatches fail fast

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66565
https://mattermost.atlassian.net/browse/MM-66701