### PR TITLE
Fix missing slash in release notes URL generation

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -137,7 +138,10 @@ func findManifest() (*model.Manifest, error) {
 
 	// If no release notes specified, generate one from the latest tag, if present.
 	if manifest.ReleaseNotesURL == "" && BuildTagLatest != "" {
-		manifest.ReleaseNotesURL = manifest.HomepageURL + "releases/tag/" + BuildTagLatest
+		manifest.ReleaseNotesURL, err = url.JoinPath(manifest.HomepageURL, "releases", "tag", BuildTagLatest)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate release notes URL")
+		}
 	}
 
 	return &manifest, nil


### PR DESCRIPTION
## Summary
- Fix bug where release notes URL was missing a leading slash
- Replace string concatenation with `url.JoinPath()` for proper URL construction
- Handles URLs with or without trailing slashes correctly

## Test plan
- Build the plugin with a release tag and verify the release notes URL is properly formatted
- Verify the generated URL matches the expected format: `https://github.com/mattermost/mattermost-plugin-jira/releases/tag/vX.Y.Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)