### PR TITLE
Update minimum server version

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
     "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
     "icon_path": "assets/icon.svg",
-    "min_server_version": "7.8.0",
+    "min_server_version": "10.7.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
Update the minimum Mattermost server version requirement from 7.8.0 to 10.7.0.

Mattermost server v10.7+ includes critical fixes for plugin compatibility with Go 1.23+ (see https://github.com/mattermost/mattermost/pull/30386). This change ensures that the Jira plugin will only run on server versions that include the necessary compatibility patches, preventing runtime failures related to Go 1.23's+ serialization changes.