### PR TITLE
Mm 66878 fix notification formatting

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -260,8 +260,10 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	jwh := wh.JiraWebhook
 	commentAuthor := mdUser(&jwh.Comment.UpdateAuthor)
 
+	// Process Jira markup to markdown before quoting
+	processedComment := preProcessText(jwh.Comment.Body)
 	message := fmt.Sprintf("%s %s %s:\n%s",
-		commentAuthor, verb, jwh.mdKeySummaryLink(), quoteIssueComment(jwh.Comment.Body))
+		commentAuthor, verb, jwh.mdKeySummaryLink(), quoteIssueComment(processedComment))
 	assigneeMentioned := false
 
 	for _, u := range parseJIRAUsernamesFromText(wh.Comment.Body) {
@@ -309,7 +311,7 @@ func appendCommentNotifications(wh *webhook, verb string) {
 	wh.notifications = append(wh.notifications, webhookUserNotification{
 		jiraUsername:     jwh.Issue.Fields.Assignee.Name,
 		jiraAccountID:    jwh.Issue.Fields.Assignee.AccountID,
-		message:          fmt.Sprintf("%s **commented** on %s:\n>%s", commentAuthor, jwh.mdKeySummaryLink(), jwh.Comment.Body),
+		message:          fmt.Sprintf("%s **commented** on %s:\n%s", commentAuthor, jwh.mdKeySummaryLink(), quoteIssueComment(processedComment)),
 		postType:         PostTypeComment,
 		commentSelf:      jwh.Comment.Self,
 		notificationType: "assignee",


### PR DESCRIPTION

#### Summary
Fixes incorrect formatting in Jira bot comment notifications where numbered lists appeared as headings and only the first line was quoted. The appendCommentNotifications function was using the raw Jira comment body without converting Jira markup to Markdown first. This applies preProcessText() to convert Jira markup to Markdown before quoting the comment. 

#### QA Testing
1. Create a comment in Jira with a numbered list using # syntax
2. Verify the notification in Mattermost shows the list correctly as quoted numbered items not headings

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66878
