### PR TITLE
Fix plugin config loading failure on upgrade to 4.4.0

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -232,6 +232,10 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 	ec.AdminAPIToken = string(encryptedAdminAPIToken)
 
+	// Default to 30 days if not set
+	if ec.ThreadedJiraCommentSubscriptionDuration == "" {
+		ec.ThreadedJiraCommentSubscriptionDuration = "30"
+	}
 	duration, err := strconv.Atoi(ec.ThreadedJiraCommentSubscriptionDuration)
 	if err != nil {
 		return errors.New("error converting comment post reply duration to integer")


### PR DESCRIPTION

#### Summary
When upgrading from 4.3.0 to 4.4.0 the plugin failed loading its configuration resulting in missing webhook secret. The new ThreadedJiraCommentSubscriptionDuration config field added in 4.4.0 isn't set when upgrading from older versions. 
Default it to "30" if not set ensuring backwards compatibility on upgrade. 

#### QA Testing
1. Install 4.3.0 and check /jira subscribe in a channel with subscriptions doesn't work and displays
*Failed to fetch project metadata for any projects.*

2. Upgrade to this build
3. Verify /jira webhook shows URL with secret
4. Verify /jira subscribe opens modal successfully

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66639
