### PR TITLE
fix: Show file attachment info in Attach to Jira Issue modal

### DIFF
--- a/webapp/src/components/modals/attach_comment_modal/attach_comment_form.tsx
+++ b/webapp/src/components/modals/attach_comment_modal/attach_comment_form.tsx
@@ -24,7 +24,7 @@ function getPostDisplayMessage(post: Post): string {
         return post.message;
     }
 
-    // If no message check for file attachments
+    // If no message, check for file attachments
     const files = post.metadata?.files;
     if (files && files.length > 0) {
         const fileNames = files.map((file) => file.name);
@@ -32,6 +32,15 @@ function getPostDisplayMessage(post: Post): string {
             return `Attached file: ${fileNames[0]}`;
         }
         return `Attached files: ${fileNames.join(', ')}`;
+    }
+
+    // Fallback: check file_ids if metadata.files is not populated
+    const fileIds = post.file_ids;
+    if (fileIds && fileIds.length > 0) {
+        if (fileIds.length === 1) {
+            return 'Attached file';
+        }
+        return `Attached ${fileIds.length} files`;
     }
 
     return '';


### PR DESCRIPTION

#### Summary
Fixes the "Attach to Jira Issue" modal showing a blank message when the user is attaching a file only post by adding getPostDisplayMessage() that returns the post message or falls back to displaying file attachment names. 

Single file: "Attached file: document.pdf"
Multiple files: "Attached files: image.png, doc.pdf"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66431

