### PR TITLE
fix: Attachment filenames showing as ~~~~ in subscription notifications

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -575,7 +575,7 @@ func parseWebhookUpdatedDescription(jwh *JiraWebhook, from, to string) *webhook 
 
 func parseWebhookUpdatedAttachments(jwh *JiraWebhook, from, to, fromWithDefault, toWithDefault string) *webhook {
 	wh := newWebhook(jwh, eventUpdatedAttachment, "%s", mdAddRemove(from, to, "**attached**", "**removed** attachments"))
-	wh.fieldInfo = webhookField{"attachments", "attachment", fromWithDefault, toWithDefault}
+	wh.fieldInfo = webhookField{"attachments", "attachment", from, to}
 	return wh
 }
 


### PR DESCRIPTION

#### Summary
Subscription notifications show ~~~~ instead of attachment filenames. I fixed parseWebhookUpdatedAttachments to populate fieldInfo.from and fieldInfo.to values. When multiple field updates are merged attachment names now display correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66432
