### PR TITLE
MM-67485 Fixing issues with processing of issue_assigned events

### DIFF
--- a/server/testdata/webhook-issue-assigned-empty-changelog.json
+++ b/server/testdata/webhook-issue-assigned-empty-changelog.json
@@ -1,0 +1,88 @@
+{
+  "timestamp": 1724179662935,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_assigned",
+  "user": {
+    "self": "https://test-instance.atlassian.net/rest/api/2/user?accountId=123456",
+    "accountId": "123456",
+    "emailAddress": "admin@example.com",
+    "avatarUrls": {
+      "48x48": "https://avatar-management.services.atlassian.com/initials/AA-1.png",
+      "24x24": "https://avatar-management.services.atlassian.com/initials/AA-1.png",
+      "16x16": "https://avatar-management.services.atlassian.com/initials/AA-1.png",
+      "32x32": "https://avatar-management.services.atlassian.com/initials/AA-1.png"
+    },
+    "displayName": "Admin User",
+    "active": true,
+    "timeZone": "America/New_York",
+    "accountType": "atlassian"
+  },
+  "issue": {
+    "id": "10001",
+    "self": "https://test-instance.atlassian.net/rest/api/2/issue/10001",
+    "key": "TEST-123",
+    "fields": {
+      "summary": "Test issue for empty changelog assignment",
+      "status": {
+        "self": "https://test-instance.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://test-instance.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://test-instance.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      "priority": {
+        "self": "https://test-instance.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://test-instance.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "assignee": {
+        "self": "https://test-instance.atlassian.net/rest/api/2/user?accountId=789012",
+        "accountId": "789012",
+        "emailAddress": "assignee@example.com",
+        "avatarUrls": {
+          "48x48": "https://avatar-management.services.atlassian.com/initials/JD-2.png",
+          "24x24": "https://avatar-management.services.atlassian.com/initials/JD-2.png",
+          "16x16": "https://avatar-management.services.atlassian.com/initials/JD-2.png",
+          "32x32": "https://avatar-management.services.atlassian.com/initials/JD-2.png"
+        },
+        "displayName": "John Doe",
+        "active": true,
+        "timeZone": "America/Los_Angeles",
+        "accountType": "atlassian"
+      },
+      "issuetype": {
+        "self": "https://test-instance.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "A task that needs to be done.",
+        "iconUrl": "https://test-instance.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10318&avatarType=issuetype",
+        "name": "Task",
+        "subtask": false
+      },
+      "project": {
+        "self": "https://test-instance.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "TEST",
+        "name": "Test Project",
+        "avatarUrls": {
+          "48x48": "https://test-instance.atlassian.net/secure/projectavatar?pid=10000&avatarId=10324",
+          "24x24": "https://test-instance.atlassian.net/secure/projectavatar?size=small&pid=10000&avatarId=10324",
+          "16x16": "https://test-instance.atlassian.net/secure/projectavatar?size=xsmall&pid=10000&avatarId=10324",
+          "32x32": "https://test-instance.atlassian.net/secure/projectavatar?size=medium&pid=10000&avatarId=10324"
+        }
+      },
+      "description": "This webhook simulates an assignment event with empty changelog items, which can occur with API assignments, automation rules, or bulk operations."
+    }
+  },
+  "changelog": {
+    "id": "10500",
+    "items": []
+  }
+}

--- a/server/webhook_http_test.go
+++ b/server/webhook_http_test.go
@@ -149,6 +149,12 @@ func TestWebhookHTTP(t *testing.T) {
 			ExpectedHeadline: "Test User **assigned** Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",
 			CurrentInstance:  true,
 		},
+		"issue assigned with empty changelog": {
+			Request:         testWebhookRequest("webhook-issue-assigned-empty-changelog.json"),
+			ExpectedIgnored: true,
+			ExpectedStatus:  http.StatusBadRequest,
+			CurrentInstance: true,
+		},
 		"SERVER (old version) issue assigned (no issue_event_type_name)": {
 			Request:          testWebhookRequest("webhook-server-old-issue-updated-no-event-type-assigned.json"),
 			ExpectedHeadline: "Test User **assigned** Test User to story [TES-41: Unit test summary 1](https://some-instance-test.atlassian.net/browse/TES-41)",

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -61,9 +61,7 @@ func ParseWebhook(bb []byte) (wh Webhook, err error) {
 		wh = parseWebhookDeleted(jwh)
 	case "jira:issue_updated":
 		switch jwh.IssueEventTypeName {
-		case "issue_assigned":
-			wh = parseWebhookAssigned(jwh, jwh.ChangeLog.Items[0].FromString, jwh.ChangeLog.Items[0].ToString)
-		case "issue_updated", "issue_generic", "issue_resolved", "issue_closed", "issue_work_started", "issue_reopened":
+		case "issue_assigned", "issue_updated", "issue_generic", "issue_resolved", "issue_closed", "issue_work_started", "issue_reopened":
 			wh = parseWebhookChangeLog(jwh)
 		case "issue_commented":
 			wh, err = parseWebhookCommentCreated(jwh)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR removes an unsafe mapping of values when processing webhook payloads that in certain scenarios could cause the plugin to panic and adds a test case to validate the fix and prevent regressions

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-67485


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for issue assignment webhook events with empty changelog data

* **Refactor**
  * Improved webhook event processing to use consistent handling for issue assignment events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->