### PR TITLE
MM-67959: Add fallback for missing user in webhook notifications

### DIFF
--- a/server/webhook_jira.go
+++ b/server/webhook_jira.go
@@ -207,20 +207,20 @@ func mdUser(user *jira.User) string {
 	if user == nil {
 		return ""
 	}
-	if user.DisplayName != "" {
-		return user.DisplayName
+	if v := strings.TrimSpace(user.DisplayName); v != "" {
+		return v
 	}
-	if user.Name != "" {
-		return user.Name
+	if v := strings.TrimSpace(user.Name); v != "" {
+		return v
 	}
-	if user.EmailAddress != "" {
-		return user.EmailAddress
+	if v := strings.TrimSpace(user.AccountID); v != "" {
+		return v
 	}
-	if user.AccountID != "" {
-		return user.AccountID
+	if v := strings.TrimSpace(user.Key); v != "" {
+		return v
 	}
-	if user.Key != "" {
-		return user.Key
+	if v := strings.TrimSpace(user.EmailAddress); v != "" {
+		return v
 	}
 	return "Someone"
 }

--- a/server/webhook_jira.go
+++ b/server/webhook_jira.go
@@ -207,7 +207,22 @@ func mdUser(user *jira.User) string {
 	if user == nil {
 		return ""
 	}
-	return user.DisplayName
+	if user.DisplayName != "" {
+		return user.DisplayName
+	}
+	if user.Name != "" {
+		return user.Name
+	}
+	if user.EmailAddress != "" {
+		return user.EmailAddress
+	}
+	if user.AccountID != "" {
+		return user.AccountID
+	}
+	if user.Key != "" {
+		return user.Key
+	}
+	return "Someone"
 }
 
 func truncate(s string, maxLen int) string {

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -105,11 +105,15 @@ func TestMdUserFallback(t *testing.T) {
 	assert.Equal(t, "Someone", mdUser(&jira.User{}))
 	assert.Equal(t, "John Doe", mdUser(&jira.User{DisplayName: "John Doe"}))
 	assert.Equal(t, "jdoe", mdUser(&jira.User{Name: "jdoe"}))
-	assert.Equal(t, "jdoe@example.com", mdUser(&jira.User{EmailAddress: "jdoe@example.com"}))
 	assert.Equal(t, "abc123", mdUser(&jira.User{AccountID: "abc123"}))
 	assert.Equal(t, "JIRAUSER123", mdUser(&jira.User{Key: "JIRAUSER123"}))
+	assert.Equal(t, "jdoe@example.com", mdUser(&jira.User{EmailAddress: "jdoe@example.com"}))
 	assert.Equal(t, "John Doe", mdUser(&jira.User{DisplayName: "John Doe", Name: "jdoe", EmailAddress: "jdoe@example.com"}))
 	assert.Equal(t, "jdoe", mdUser(&jira.User{Name: "jdoe", AccountID: "abc123"}))
+
+	// Whitespace-only values should be skipped
+	assert.Equal(t, "Someone", mdUser(&jira.User{DisplayName: "   ", Name: "  "}))
+	assert.Equal(t, "jdoe", mdUser(&jira.User{DisplayName: "  ", Name: "jdoe"}))
 }
 
 func TestTruncate(t *testing.T) {

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -97,7 +97,19 @@ func TestWebhookVariousErrors(t *testing.T) {
 	assert.Equal(t, "", wh.mdIssueType())
 	assert.Equal(t, " ", wh.mdSummaryLink())
 	assert.Equal(t, " ", wh.mdKeyLink())
-	assert.Equal(t, "", wh.mdUser())
+	assert.Equal(t, "Someone", wh.mdUser())
+}
+
+func TestMdUserFallback(t *testing.T) {
+	assert.Equal(t, "", mdUser(nil))
+	assert.Equal(t, "Someone", mdUser(&jira.User{}))
+	assert.Equal(t, "John Doe", mdUser(&jira.User{DisplayName: "John Doe"}))
+	assert.Equal(t, "jdoe", mdUser(&jira.User{Name: "jdoe"}))
+	assert.Equal(t, "jdoe@example.com", mdUser(&jira.User{EmailAddress: "jdoe@example.com"}))
+	assert.Equal(t, "abc123", mdUser(&jira.User{AccountID: "abc123"}))
+	assert.Equal(t, "JIRAUSER123", mdUser(&jira.User{Key: "JIRAUSER123"}))
+	assert.Equal(t, "John Doe", mdUser(&jira.User{DisplayName: "John Doe", Name: "jdoe", EmailAddress: "jdoe@example.com"}))
+	assert.Equal(t, "jdoe", mdUser(&jira.User{Name: "jdoe", AccountID: "abc123"}))
 }
 
 func TestTruncate(t *testing.T) {


### PR DESCRIPTION
#### Summary
- Fix issue where webhook notification headlines show a missing/empty user when the Jira webhook payload has no `DisplayName` for the event initiator
- Add a fallback chain in `mdUser()`: `DisplayName` → `Name` → `EmailAddress` → `AccountID` → `Key` → `"Someone"`

#### Ticket
[MM-67959](https://mattermost.atlassian.net/browse/MM-67959)

#### Note for QA: 
Test 1: Verify normal notifications still work
1. Go to Jira and update any issue 
2. Check the subscribed Mattermost channel
3. **Expected:** The notification shows the user's name before the action

Test 2: Reproduce the original bug scenario
1. In Jira, set up an automation rule that updates an issue. Automation rules often trigger webhooks without a full user profile.
2. Let the automation trigger an issue update
3. Check the subscribed Mattermost channel
5. **Expected:** The notification shows some identifier for the user (username, email, or "Someone") instead of a blank space


[MM-67959]: https://mattermost.atlassian.net/browse/MM-67959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The changes are isolated to a single internal function (`mdUser()`) used only for formatting user identifiers in webhook notification headlines. The modifications enhance resilience by implementing a fallback chain to handle missing user profile data, with no breaking changes to the function signature or contract. Comprehensive test coverage validates all fallback paths.

**Regression Risk:** Minimal. The function is private (non-exported) with limited scope to the webhook module. The change is additive—expanding from relying solely on `DisplayName` to a prioritized fallback chain (`DisplayName` → `Name` → `AccountID` → `Key` → `EmailAddress` → `"Someone"`). The behavioral shift (returning `"Someone"` instead of blank when all fields are empty) is a safe improvement. All call sites in the webhook parsing and issue handling code will benefit from the fallback logic without requiring modifications.

**QA Recommendation:** Minimal manual QA required. The `TestMdUserFallback` test covers all fallback scenarios comprehensively (individual fields, field combinations, whitespace handling, nil pointer). The PR's suggested manual tests (verifying normal notifications display user names and automation-triggered webhooks show identifiers instead of blanks) are low-effort validation checks. Risk of skipping manual QA is low given the isolated scope and robust automated test coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->