### PR TITLE
Fix empty issue dropdown in Attach to Jira Issue modal (MM-67234)

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -305,7 +305,7 @@ func (client JiraClient) UpdateComment(issueKey string, comment *jira.Comment) (
 func (client JiraClient) SearchIssues(jql string, options *jira.SearchOptions) ([]jira.Issue, error) {
 	found, resp, err := client.Jira.Issue.Search(jql, options)
 	if err != nil {
-		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized) {
 			return nil, errors.New("not authorized to search issues")
 		}
 		return nil, userFriendlyJiraError(resp, err)

--- a/server/client_cloud.go
+++ b/server/client_cloud.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/mattermost/mattermost/server/public/plugin"
@@ -147,4 +148,32 @@ func (client jiraCloudClient) ListProjectStatuses(projectID string) ([]*IssueTyp
 	}
 
 	return result, nil
+}
+
+// SearchIssues overrides the base JiraClient implementation to use the new
+// /rest/api/2/search/jql endpoint, since /rest/api/2/search is being removed
+// from Jira Cloud.
+func (client jiraCloudClient) SearchIssues(jql string, options *jira.SearchOptions) ([]jira.Issue, error) {
+	type searchResult struct {
+		Issues []jira.Issue `json:"issues"`
+	}
+
+	params := map[string]string{
+		"jql": jql,
+	}
+	if options != nil {
+		if options.MaxResults > 0 {
+			params["maxResults"] = strconv.Itoa(options.MaxResults)
+		}
+		if len(options.Fields) > 0 {
+			params["fields"] = strings.Join(options.Fields, ",")
+		}
+	}
+
+	var result searchResult
+	err := client.RESTGet("2/search/jql", params, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Issues, nil
 }

--- a/server/issue.go
+++ b/server/issue.go
@@ -927,9 +927,10 @@ func (p *Plugin) GetSearchIssues(instanceID, mattermostUserID types.ID, q, jqlSt
 	if len(jqlString) == 0 {
 		q = strings.TrimSpace(q)
 		if len(q) == 0 {
-			jqlString = "ORDER BY updated DESC"
+			jqlString = "updated >= -4w ORDER BY updated DESC"
 		} else {
-			escaped := strings.ReplaceAll(q, `"`, `\"`)
+			escaped := strings.ReplaceAll(q, `\`, `\\`)
+			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 			jqlString = fmt.Sprintf(`text ~ "%s" OR text ~ "%s*"`, escaped, escaped)
 		}
 	}
@@ -957,12 +958,11 @@ func (p *Plugin) GetSearchIssues(instanceID, mattermostUserID types.ID, q, jqlSt
 	var found []jira.Issue
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		found, _ = client.SearchIssues(jqlString, &jira.SearchOptions{
 			MaxResults: limit,
 			Fields:     fields,
 		})
-
-		wg.Done()
 	}()
 
 	wg.Wait()

--- a/server/issue.go
+++ b/server/issue.go
@@ -925,8 +925,13 @@ func (p *Plugin) GetSearchIssues(instanceID, mattermostUserID types.ID, q, jqlSt
 		fieldsStr = "key,summary"
 	}
 	if len(jqlString) == 0 {
-		escaped := strings.ReplaceAll(q, `"`, `\"`)
-		jqlString = fmt.Sprintf(`text ~ "%s" OR text ~ "%s*"`, escaped, escaped)
+		q = strings.TrimSpace(q)
+		if len(q) == 0 {
+			jqlString = "ORDER BY updated DESC"
+		} else {
+			escaped := strings.ReplaceAll(q, `"`, `\"`)
+			jqlString = fmt.Sprintf(`text ~ "%s" OR text ~ "%s*"`, escaped, escaped)
+		}
 	}
 
 	limit := 50

--- a/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
+++ b/webapp/src/components/jira_issue_selector/jira_issue_selector.jsx
@@ -60,12 +60,16 @@ export default class JiraIssueSelector extends Component {
         };
 
         return this.props.searchIssues(params).then(({data}) => {
+            if (!data) {
+                return [];
+            }
             return data.map((issue) => ({
                 value: issue.key,
                 label: `${issue.key}: ${issue.fields.summary}`,
             }));
         }).catch((e) => {
             this.setState({error: e});
+            return [];
         });
     };
 


### PR DESCRIPTION
### Summary
- Fix the "Attach to Jira Issue" modal dropdown not showing any issues when first opened
- When the query string is empty use `ORDER BY updated DESC` to return recently updated issues instead of constructing invalid JQL
- Add null guard for the search results data on the frontend to prevent crashes when the API returns no data

### Ticket
[MM-67234](https://mattermost.atlassian.net/browse/MM-67234)

### QA Steps
1. Connect a Mattermost account to a Jira instance
2. Post a message in any channel
3. Click the post menu then "Attach to Jira Issue"
4. Select your Jira instance
5. **Before fix**: The issue dropdown shows "No options" when first opened
6. **After fix**: The issue dropdown shows recently updated issues immediately when opened



[MM-67234]: https://mattermost.atlassian.net/browse/MM-67234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The changes touch both backend and frontend layers (JQL construction, Jira client error handling, and UI null-guards) and add a Jira Cloud-specific client implementation; they are focused and targeted but affect request/response flows across integration boundaries.

**Regression Risk:** Moderate. The fixes reduce errors for empty queries and prevent frontend crashes, but the new cloud-specific SearchIssues implementation and altered error-path handling broaden the surface area for integration differences and could cause divergent behavior across Jira deployments (reviewer evidence shows Cloud-specific verification still required).

**QA Recommendation:** Full QA across environments is recommended — verify behavior on both Jira Server and Jira Cloud, confirm the dropdown shows recently updated issues on open and while typing, and test error/timeout/unauthorized responses to ensure graceful UI handling. Prioritize manual verification on Cloud and add automated tests for JQL fallback, escaping, and nil-response handling; do not skip manual QA.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->