### PR TITLE
Preserve consecutive spaces in subscription names on list page

### DIFF
--- a/webapp/src/components/modals/channel_subscriptions/channel_subscriptions_modal.scss
+++ b/webapp/src/components/modals/channel_subscriptions/channel_subscriptions_modal.scss
@@ -46,6 +46,7 @@
 
         td {
             word-break: break-word;
+            white-space: pre-wrap;
         }
     }
     &__learnMore {


### PR DESCRIPTION

#### Summary
Add `white-space: pre-wrap` to subscription list table cells so that consecutive spaces in subscription names are preserved.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67235

