### PR TITLE
Add install token verification to cloud instance lifecycle callback

### DIFF
--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"crypto/hmac"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -16,10 +17,21 @@ import (
 const userRedirectPageKey = "user-redirect"
 
 func (p *Plugin) httpACJSON(w http.ResponseWriter, r *http.Request, instanceID types.ID) (int, error) {
+	instance, err := p.instanceStore.LoadInstance(instanceID)
+	if err != nil {
+		return respondErr(w, http.StatusInternalServerError,
+			errors.WithMessage(err, "failed to load instance"))
+	}
+
+	installRoute := routeACInstalled
+	if ci, ok := instance.(*cloudInstance); ok && ci.InstallToken != "" {
+		installRoute = routeACInstalled + "?token=" + ci.InstallToken
+	}
+
 	return p.respondTemplate(w, r, "application/json", map[string]string{
 		"BaseURL":                      p.GetPluginURL(),
 		"RouteACJSON":                  instancePath(routeACJSON, instanceID),
-		"RouteACInstalled":             routeACInstalled,
+		"RouteACInstalled":             installRoute,
 		"RouteACUninstalled":           routeACUninstalled,
 		"RouteACUserRedirectWithToken": instancePath(routeACUserRedirectWithToken, instanceID),
 		"UserRedirectPageKey":          userRedirectPageKey,
@@ -62,6 +74,14 @@ func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request) (int, e
 	if ci.Installed {
 		return respondErr(w, http.StatusForbidden,
 			errors.Errorf("Jira instance %s is already installed", asc.BaseURL))
+	}
+
+	if ci.InstallToken != "" {
+		providedToken := r.URL.Query().Get("token")
+		if !hmac.Equal([]byte(providedToken), []byte(ci.InstallToken)) {
+			return respondErr(w, http.StatusForbidden,
+				errors.New("invalid install token"))
+		}
 	}
 
 	// Create a permanent instance record, also store it as current

--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -65,7 +65,7 @@ func (p *Plugin) httpACInstalledGlobal(w http.ResponseWriter, r *http.Request) (
 	return p.processACInstalled(w, r, "", false)
 }
 
-func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request, _ types.ID) (int, error) {
+func (p *Plugin) httpACInstalledInstanceScoped(w http.ResponseWriter, r *http.Request) (int, error) {
 	rawPathID, _ := splitInstancePath(r.URL.Path)
 	return p.processACInstalled(w, r, rawPathID, true)
 }

--- a/server/atlassian_connect.go
+++ b/server/atlassian_connect.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"crypto/hmac"
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -17,30 +17,60 @@ import (
 const userRedirectPageKey = "user-redirect"
 
 func (p *Plugin) httpACJSON(w http.ResponseWriter, r *http.Request, instanceID types.ID) (int, error) {
+	rawPathID, _ := splitInstancePath(r.URL.Path)
+
 	instance, err := p.instanceStore.LoadInstance(instanceID)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError,
 			errors.WithMessage(err, "failed to load instance"))
 	}
 
+	ci, isCloud := instance.(*cloudInstance)
+	if isCloud && !ci.Installed && ci.SetupRoutingSecret != "" {
+		if !isOpaqueCloudSetupRoutingID(rawPathID) {
+			return respondErr(w, http.StatusNotFound,
+				errors.New("use the Atlassian Connect descriptor URL from your Mattermost install instructions"))
+		}
+		// Bind descriptor to this install's secret (must match path segment, not only "some" opaque id).
+		if len(rawPathID) != len(ci.SetupRoutingSecret) ||
+			subtle.ConstantTimeCompare([]byte(rawPathID), []byte(ci.SetupRoutingSecret)) != 1 {
+			return respondErr(w, http.StatusNotFound,
+				errors.New("use the Atlassian Connect descriptor URL from your Mattermost install instructions"))
+		}
+	}
+
+	routeID := instanceID
+	if isCloud && !ci.Installed && ci.SetupRoutingSecret != "" {
+		routeID = types.ID(ci.SetupRoutingSecret)
+	}
+
 	installRoute := routeACInstalled
-	if ci, ok := instance.(*cloudInstance); ok && ci.InstallToken != "" {
-		installRoute = routeACInstalled + "?token=" + ci.InstallToken
+	if isCloud && !ci.Installed && ci.SetupRoutingSecret != "" {
+		installRoute = instancePath(routeACInstalled, routeID)
 	}
 
 	return p.respondTemplate(w, r, "application/json", map[string]string{
 		"BaseURL":                      p.GetPluginURL(),
-		"RouteACJSON":                  instancePath(routeACJSON, instanceID),
+		"RouteACJSON":                  instancePath(routeACJSON, routeID),
 		"RouteACInstalled":             installRoute,
 		"RouteACUninstalled":           routeACUninstalled,
-		"RouteACUserRedirectWithToken": instancePath(routeACUserRedirectWithToken, instanceID),
+		"RouteACUserRedirectWithToken": instancePath(routeACUserRedirectWithToken, routeID),
 		"UserRedirectPageKey":          userRedirectPageKey,
 		"ExternalURL":                  p.GetSiteURL(),
 		"PluginKey":                    p.GetPluginKey(),
 	})
 }
 
-func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request) (int, error) {
+func (p *Plugin) httpACInstalledGlobal(w http.ResponseWriter, r *http.Request) (int, error) {
+	return p.processACInstalled(w, r, "", false)
+}
+
+func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request, _ types.ID) (int, error) {
+	rawPathID, _ := splitInstancePath(r.URL.Path)
+	return p.processACInstalled(w, r, rawPathID, true)
+}
+
+func (p *Plugin) processACInstalled(w http.ResponseWriter, r *http.Request, rawPathSegment string, usedInstanceScopedPath bool) (int, error) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError,
@@ -76,11 +106,20 @@ func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request) (int, e
 			errors.Errorf("Jira instance %s is already installed", asc.BaseURL))
 	}
 
-	if ci.InstallToken != "" {
-		providedToken := r.URL.Query().Get("token")
-		if !hmac.Equal([]byte(providedToken), []byte(ci.InstallToken)) {
+	if ci.SetupRoutingSecret != "" {
+		if !usedInstanceScopedPath {
 			return respondErr(w, http.StatusForbidden,
-				errors.New("invalid install token"))
+				errors.New("invalid install request"))
+		}
+		if !isOpaqueCloudSetupRoutingID(rawPathSegment) {
+			return respondErr(w, http.StatusForbidden,
+				errors.New("invalid install request"))
+		}
+		// Path must be this instance's setup URL, not only a valid-looking opaque segment.
+		if len(rawPathSegment) != len(ci.SetupRoutingSecret) ||
+			subtle.ConstantTimeCompare([]byte(rawPathSegment), []byte(ci.SetupRoutingSecret)) != 1 {
+			return respondErr(w, http.StatusForbidden,
+				errors.New("invalid install request"))
 		}
 	}
 
@@ -89,6 +128,12 @@ func (p *Plugin) httpACInstalled(w http.ResponseWriter, r *http.Request) (int, e
 	err = p.InstallInstance(newInstance)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
+	}
+
+	if ci.SetupRoutingSecret != "" {
+		if err := p.instanceStore.DeletePendingCloudSetupRoute(types.ID(ci.SetupRoutingSecret)); err != nil {
+			p.client.Log.Warn("failed to delete pending cloud setup route", "err", err.Error())
+		}
 	}
 
 	// Setup autolink

--- a/server/command.go
+++ b/server/command.go
@@ -875,7 +875,7 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 		return p.help(header)
 	}
 
-	jiraURL, err := p.installInactiveCloudInstance(args[0], header.UserId)
+	jiraURL, setupRoutingSecret, err := p.installInactiveCloudInstance(args[0], header.UserId)
 	if err != nil {
 		return p.response(header, err.Error())
 	}
@@ -883,7 +883,7 @@ func executeInstanceInstallCloud(p *Plugin, c *plugin.Context, header *model.Com
 	return p.respondCommandTemplate(header, "/command/install_cloud.md", map[string]string{
 		"JiraURL":                 jiraURL,
 		"PluginURL":               p.GetPluginURL(),
-		"AtlassianConnectJSONURL": p.GetPluginURL() + instancePath(routeACJSON, types.ID(jiraURL)),
+		"AtlassianConnectJSONURL": p.GetPluginURL() + instancePath(routeACJSON, types.ID(setupRoutingSecret)),
 	})
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -127,7 +127,8 @@ func (p *Plugin) initializeRouter() {
 
 	// Atlassian Connect application
 	instanceRouter.HandleFunc(routeACJSON, p.handleResponseWithCallbackInstance(p.httpACJSON)).Methods(http.MethodGet)
-	p.router.HandleFunc(routeACInstalled, p.handleResponse(p.httpACInstalled)).Methods(http.MethodPost)
+	instanceRouter.HandleFunc(routeACInstalled, p.handleResponseWithCallbackInstance(p.httpACInstalled)).Methods(http.MethodPost)
+	p.router.HandleFunc(routeACInstalled, p.handleResponse(p.httpACInstalledGlobal)).Methods(http.MethodPost)
 	p.router.HandleFunc(routeACUninstalled, p.handleResponse(p.httpACUninstalled)).Methods(http.MethodPost)
 
 	// Atlassian Connect user mapping
@@ -297,6 +298,23 @@ func splitInstancePath(route string) (instanceURL string, remainingPath string) 
 		return "", route
 	}
 	return string(id), leadingSlash + strings.Join(ss[2:], "/")
+}
+
+// isOpaqueCloudSetupRoutingID reports whether s is the hex encoding of 32 random
+// bytes (SetupRoutingSecret), as used in instance paths during Jira Cloud Connect setup.
+func isOpaqueCloudSetupRoutingID(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (p *Plugin) withRecovery(next http.Handler) http.Handler {

--- a/server/http.go
+++ b/server/http.go
@@ -127,7 +127,9 @@ func (p *Plugin) initializeRouter() {
 
 	// Atlassian Connect application
 	instanceRouter.HandleFunc(routeACJSON, p.handleResponseWithCallbackInstance(p.httpACJSON)).Methods(http.MethodGet)
-	instanceRouter.HandleFunc(routeACInstalled, p.handleResponseWithCallbackInstance(p.httpACInstalled)).Methods(http.MethodPost)
+	// Do not use handleResponseWithCallbackInstance: ResolveWebhookInstanceURL errors
+	// would become 500 before processACInstalled can return 403/404.
+	instanceRouter.HandleFunc(routeACInstalled, p.handleResponse(p.httpACInstalledInstanceScoped)).Methods(http.MethodPost)
 	p.router.HandleFunc(routeACInstalled, p.handleResponse(p.httpACInstalledGlobal)).Methods(http.MethodPost)
 	p.router.HandleFunc(routeACUninstalled, p.handleResponse(p.httpACUninstalled)).Methods(http.MethodPost)
 

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -34,11 +34,11 @@ type cloudInstance struct {
 	// for the instance.
 	Installed bool
 
-	// InstallToken is a cryptographic nonce generated when an inactive instance
-	// is created. It is embedded in the atlassian-connect.json installed callback
-	// URL and verified on the /ac/installed endpoint to prevent unauthenticated
-	// callers from injecting a rogue sharedSecret.
-	InstallToken string `json:"install_token,omitempty"`
+	// SetupRoutingSecret is a high-entropy value used only in instance URL paths
+	// during the Atlassian Connect install window. It must not appear in public
+	// descriptor responses reachable via the Jira-URL-derived path alone; the admin
+	// receives the full descriptor URL from Mattermost after /jira install.
+	SetupRoutingSecret string `json:"setup_routing_secret,omitempty"`
 
 	// For cloud instances (atlassian-connect.json install and user auth)
 	RawAtlassianSecurityContext string
@@ -69,30 +69,30 @@ func newCloudInstance(p *Plugin, key types.ID, installed bool, rawASC string, as
 	}
 }
 
-func (p *Plugin) installInactiveCloudInstance(rawURL string, actingUserID string) (string, error) {
-	jiraURL, err := utils.CheckJiraURL(p.GetSiteURL(), rawURL, false)
+func (p *Plugin) installInactiveCloudInstance(rawURL string, actingUserID string) (jiraURL, setupRoutingSecret string, err error) {
+	jiraURL, err = utils.CheckJiraURL(p.GetSiteURL(), rawURL, false)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !strings.HasPrefix(jiraURL, "https://") {
-		return "", errors.New("a secure HTTPS URL is required")
+		return "", "", errors.New("a secure HTTPS URL is required")
 	}
 
 	instances, _ := p.instanceStore.LoadInstances()
 	if !p.enterpriseChecker.HasEnterpriseFeatures() {
 		if instances != nil && len(instances.IDs()) > 0 {
-			return "", errors.New(licenseErrorString)
+			return "", "", errors.New(licenseErrorString)
 		}
 	}
 
 	// Create an "uninitialized" instance of Jira Cloud that will
 	// receive the /installed callback
-	err = p.instanceStore.CreateInactiveCloudInstance(types.ID(jiraURL), actingUserID)
+	setupRoutingSecret, err = p.instanceStore.CreateInactiveCloudInstance(types.ID(jiraURL), actingUserID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return jiraURL, err
+	return jiraURL, setupRoutingSecret, nil
 }
 
 func (ci *cloudInstance) GetMattermostKey() string {

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -34,6 +34,12 @@ type cloudInstance struct {
 	// for the instance.
 	Installed bool
 
+	// InstallToken is a cryptographic nonce generated when an inactive instance
+	// is created. It is embedded in the atlassian-connect.json installed callback
+	// URL and verified on the /ac/installed endpoint to prevent unauthenticated
+	// callers from injecting a rogue sharedSecret.
+	InstallToken string `json:"install_token,omitempty"`
+
 	// For cloud instances (atlassian-connect.json install and user auth)
 	RawAtlassianSecurityContext string
 	*AtlassianSecurityContext   `json:"-"`

--- a/server/instance_cloud_oauth_migration_test.go
+++ b/server/instance_cloud_oauth_migration_test.go
@@ -49,7 +49,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 			connection: nil,
 			setup: func(p *Plugin, api *plugintest.API) (instanceID string) {
 				api.On("LogDebug", "Stored: new Jira Cloud instance: https://mmtest.atlassian.net as jira_instance_b5f8e96862ed24709919a73271ae8851").Twice().Return(nil)
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				return jiraCloudURL
@@ -78,7 +78,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: new Jira Cloud instance: https://mmtest.atlassian.net as jira_instance_b5f8e96862ed24709919a73271ae8851").Return(nil)
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				return jiraCloudURL
@@ -99,7 +99,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
 
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				api.On("LogDebug", "Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.").Return(nil)
@@ -138,7 +138,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
 
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				api.On("LogDebug", "Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.").Return(nil)
@@ -175,7 +175,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
 
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				api.On("LogDebug", "Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.").Return(nil)
@@ -219,7 +219,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
 
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				api.On("LogDebug", "Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.").Return(nil)
@@ -272,7 +272,7 @@ func TestCloudOAuthMigration(t *testing.T) {
 				api.On("LogDebug", "Stored: user someuserid key:user_daa0ef689b843fada63e9f383fce33e1: connected to:[\"https://mmtest.atlassian.net\"]").Return(nil)
 				api.On("LogDebug", "Stored: connection, keys:\n\t6d03c97fdd1dee73b64caeca04e3e0d6 (someuserid): \n\t0f1a5629834c263cd6a3d59ce216c1f5 (): someuserid").Return(nil)
 
-				_, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
+				_, _, err := p.installInactiveCloudInstance(jiraCloudURL, mmUserID)
 				require.NoError(t, err)
 
 				api.On("LogDebug", "Installing cloud-oauth over existing cloud JWT instance. Carrying over existing saved JWT instance.").Return(nil)

--- a/server/instances.go
+++ b/server/instances.go
@@ -258,6 +258,13 @@ func (p *Plugin) StoreV2LegacyInstance(id types.ID) error {
 
 func (p *Plugin) ResolveWebhookInstanceURL(instanceURL string) (types.ID, error) {
 	var err error
+	if instanceURL != "" && isOpaqueCloudSetupRoutingID(instanceURL) {
+		jiraURL, err := p.instanceStore.LoadPendingCloudSetupRoute(types.ID(instanceURL))
+		if err != nil {
+			return "", err
+		}
+		return jiraURL, nil
+	}
 	if instanceURL != "" {
 		instanceURL, err = utils.NormalizeJiraURL(instanceURL)
 		if err != nil {

--- a/server/kv.go
+++ b/server/kv.go
@@ -461,11 +461,12 @@ func (store *store) CreateInactiveCloudInstance(jiraURL types.ID, actingUserID s
 		return "", err
 	}
 
+	ci.PluginVersion = manifest.Version
+
 	data, err := json.Marshal(ci)
 	if err != nil {
 		return "", errors.WithMessagef(err, "failed to store new Jira Cloud instance:%s", jiraURL)
 	}
-	ci.PluginVersion = manifest.Version
 
 	// Expire in 15 minutes
 	key := hashkey(prefixInstance, ci.GetURL())

--- a/server/kv.go
+++ b/server/kv.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5" // #nosec G501
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -445,6 +446,12 @@ func (store *store) CreateInactiveCloudInstance(jiraURL types.ID, actingUserID s
 		fmt.Sprintf(`{"BaseURL": "%s"}`, jiraURL),
 		&AtlassianSecurityContext{BaseURL: jiraURL.String()})
 	ci.SetupWizardUserID = actingUserID
+
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return errors.Wrap(err, "failed to generate install token")
+	}
+	ci.InstallToken = hex.EncodeToString(tokenBytes)
 
 	data, err := json.Marshal(ci)
 	if err != nil {

--- a/server/kv.go
+++ b/server/kv.go
@@ -28,9 +28,10 @@ const (
 	keyInstances        = "instances/v3"
 	keyRSAKey           = "rsa_key"
 	keyTokenSecret      = "token_secret"
-	prefixInstance      = "jira_instance_"
-	prefixOneTimeSecret = "ots_" // + unique key that will be deleted after the first verification
-	prefixUser          = "user_"
+	prefixInstance           = "jira_instance_"
+	prefixPendingCloudRoute  = "jira_pcsetup_" // opaque routing id to jira URL during Connect install window
+	prefixOneTimeSecret      = "ots_"          // + unique key that will be deleted after the first verification
+	prefixUser               = "user_"
 )
 
 type JiraV2Instances map[string]string
@@ -48,11 +49,14 @@ type SecretsStore interface {
 }
 
 type InstanceStore interface {
-	CreateInactiveCloudInstance(_ types.ID, actingUserID string) error
+	CreateInactiveCloudInstance(_ types.ID, actingUserID string) (setupRoutingSecret string, err error)
 	DeleteInstance(types.ID) error
 	LoadInstance(types.ID) (Instance, error)
 	LoadInstanceFullKey(string) (Instance, error)
 	LoadInstances() (*Instances, error)
+	LoadPendingCloudSetupRoute(opaque types.ID) (jiraURL types.ID, err error)
+	StorePendingCloudSetupRoute(opaque, jiraURL types.ID) error
+	DeletePendingCloudSetupRoute(opaque types.ID) error
 	StoreInstance(instance Instance) error
 	StoreInstances(*Instances) error
 }
@@ -441,21 +445,25 @@ func (store store) OneTimeLoadOauth1aTemporaryCredentials(mmUserID string) (*OAu
 	return &credentials, nil
 }
 
-func (store *store) CreateInactiveCloudInstance(jiraURL types.ID, actingUserID string) (returnErr error) {
+func (store *store) CreateInactiveCloudInstance(jiraURL types.ID, actingUserID string) (string, error) {
 	ci := newCloudInstance(store.plugin, jiraURL, false,
 		fmt.Sprintf(`{"BaseURL": "%s"}`, jiraURL),
 		&AtlassianSecurityContext{BaseURL: jiraURL.String()})
 	ci.SetupWizardUserID = actingUserID
 
-	tokenBytes := make([]byte, 32)
-	if _, err := rand.Read(tokenBytes); err != nil {
-		return errors.Wrap(err, "failed to generate install token")
+	routeSecret := make([]byte, 32)
+	if _, err := rand.Read(routeSecret); err != nil {
+		return "", errors.Wrap(err, "failed to generate setup routing secret")
 	}
-	ci.InstallToken = hex.EncodeToString(tokenBytes)
+	ci.SetupRoutingSecret = hex.EncodeToString(routeSecret)
+
+	if err := store.StorePendingCloudSetupRoute(types.ID(ci.SetupRoutingSecret), jiraURL); err != nil {
+		return "", err
+	}
 
 	data, err := json.Marshal(ci)
 	if err != nil {
-		return errors.WithMessagef(err, "failed to store new Jira Cloud instance:%s", jiraURL)
+		return "", errors.WithMessagef(err, "failed to store new Jira Cloud instance:%s", jiraURL)
 	}
 	ci.PluginVersion = manifest.Version
 
@@ -463,9 +471,54 @@ func (store *store) CreateInactiveCloudInstance(jiraURL types.ID, actingUserID s
 	key := hashkey(prefixInstance, ci.GetURL())
 	_, err = store.plugin.client.KV.Set(key, data, pluginapi.SetExpiry(15*60))
 	if err != nil {
-		return errors.WithMessagef(err, "failed to store new Jira Cloud instance:%s", jiraURL)
+		return "", errors.WithMessagef(err, "failed to store new Jira Cloud instance:%s", jiraURL)
 	}
 	store.plugin.debugf("Stored: new Jira Cloud instance: %s as %s", ci.GetURL(), key)
+	return ci.SetupRoutingSecret, nil
+}
+
+type pendingCloudSetupRoute struct {
+	JiraURL string `json:"j"`
+}
+
+func (store *store) StorePendingCloudSetupRoute(opaque, jiraURL types.ID) error {
+	payload, err := json.Marshal(pendingCloudSetupRoute{JiraURL: jiraURL.String()})
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal pending cloud setup route")
+	}
+	key := hashkey(prefixPendingCloudRoute, opaque.String())
+	_, err = store.plugin.client.KV.Set(key, payload, pluginapi.SetExpiry(15*60))
+	if err != nil {
+		return errors.WithMessage(err, "failed to store pending cloud setup route")
+	}
+	return nil
+}
+
+func (store *store) LoadPendingCloudSetupRoute(opaque types.ID) (types.ID, error) {
+	var data []byte
+	key := hashkey(prefixPendingCloudRoute, opaque.String())
+	err := store.plugin.client.KV.Get(key, &data)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load pending cloud setup route")
+	}
+	if len(data) == 0 {
+		return "", errors.Wrap(kvstore.ErrNotFound, "pending cloud setup route not found")
+	}
+	var p pendingCloudSetupRoute
+	if err := json.Unmarshal(data, &p); err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal pending cloud setup route")
+	}
+	if p.JiraURL == "" {
+		return "", errors.Wrap(kvstore.ErrNotFound, "pending cloud setup route empty")
+	}
+	return types.ID(p.JiraURL), nil
+}
+
+func (store *store) DeletePendingCloudSetupRoute(opaque types.ID) error {
+	key := hashkey(prefixPendingCloudRoute, opaque.String())
+	if err := store.plugin.client.KV.Delete(key); err != nil {
+		return errors.WithMessage(err, "failed to delete pending cloud setup route")
+	}
 	return nil
 }
 

--- a/server/kv.go
+++ b/server/kv.go
@@ -25,13 +25,13 @@ const (
 	v2keyCurrentJIRAInstance = "current_jira_instance"
 	v2keyKnownJiraInstances  = "known_jira_instances"
 
-	keyInstances        = "instances/v3"
-	keyRSAKey           = "rsa_key"
-	keyTokenSecret      = "token_secret"
-	prefixInstance           = "jira_instance_"
-	prefixPendingCloudRoute  = "jira_pcsetup_" // opaque routing id to jira URL during Connect install window
-	prefixOneTimeSecret      = "ots_"          // + unique key that will be deleted after the first verification
-	prefixUser               = "user_"
+	keyInstances            = "instances/v3"
+	keyRSAKey               = "rsa_key"
+	keyTokenSecret          = "token_secret"
+	prefixInstance          = "jira_instance_"
+	prefixPendingCloudRoute = "jira_pcsetup_" // opaque routing id to jira URL during Connect install window
+	prefixOneTimeSecret     = "ots_"          // + unique key that will be deleted after the first verification
+	prefixUser              = "user_"
 )
 
 type JiraV2Instances map[string]string

--- a/server/kv_mock_test.go
+++ b/server/kv_mock_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -107,9 +108,21 @@ type mockInstanceStore struct {
 	mock.Mock
 }
 
-func (store *mockInstanceStore) CreateInactiveCloudInstance(types.ID, string) error {
+func (store *mockInstanceStore) CreateInactiveCloudInstance(types.ID, string) (string, error) {
+	return strings.Repeat("a", 64), nil
+}
+func (store *mockInstanceStore) LoadPendingCloudSetupRoute(types.ID) (types.ID, error) {
+	return "", nil
+}
+
+func (store *mockInstanceStore) StorePendingCloudSetupRoute(types.ID, types.ID) error {
 	return nil
 }
+
+func (store *mockInstanceStore) DeletePendingCloudSetupRoute(types.ID) error {
+	return nil
+}
+
 func (store *mockInstanceStore) DeleteInstance(types.ID) error {
 	return nil
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -289,7 +289,19 @@ type mockInstanceStoreForUtils struct {
 	err      error
 }
 
-func (m mockInstanceStoreForUtils) CreateInactiveCloudInstance(types.ID, string) error {
+func (m mockInstanceStoreForUtils) CreateInactiveCloudInstance(types.ID, string) (string, error) {
+	return "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil
+}
+
+func (m mockInstanceStoreForUtils) LoadPendingCloudSetupRoute(types.ID) (types.ID, error) {
+	return "", nil
+}
+
+func (m mockInstanceStoreForUtils) StorePendingCloudSetupRoute(types.ID, types.ID) error {
+	return nil
+}
+
+func (m mockInstanceStoreForUtils) DeletePendingCloudSetupRoute(types.ID) error {
 	return nil
 }
 


### PR DESCRIPTION

#### Summary
Add a per installation cryptographic token to the Atlassian Connect  installed lifecycle callback URL. The token is generated when the cloud instance is created and verified when the callback is received.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68377

Verified as sysadmin by run /jira instance install cloud. from my machine ran: 
```
curl -X POST -H "Content-Type: application/json" \
  -d '{"key":"com.mattermost.jira","clientKey":"attacker","sharedSecret":"attacker_secret","baseUrl":"https://yourorg.atlassian.net","productType":"jira","eventType":"installed"}' \
  https://<MATTERMOST_URL>/plugins/jira/ac/installed
  ```
and got: `403 Forbidden with "invalid install token".`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Reasoning:** The PR adds security-critical install-token verification and changes the cloud installation flow, routing, and persisted state (KV-backed pending routes and altered function signatures), expanding the blast radius across instance resolution, installation handlers, and storage APIs.  
**Regression Risk:** High. The changes touch authentication/installation handlers, instance resolution, storage interfaces, and routing; they introduce new TTL-backed pending routes, path-scoped routing, and function signature changes that can produce integration regressions, race conditions, and untested edge cases.  
** QA Recommendation:** Comprehensive manual QA is strongly recommended: validate successful and failed install callbacks (valid/invalid/missing tokens), instance-scoped vs global routing behavior, pending-route TTL/expiry and concurrent install scenarios, deletion/cleanup of pending routes after install, and end-to-end integration with Atlassian Cloud. Skipping manual QA is not advised due to security and stability implications.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->