### PR TITLE
MM-68049: Add AdminAPIToken fallback for watcher notifications

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -1693,11 +1693,13 @@ func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID, instanceID string) (*jira
 		return nil, errors.Wrapf(err, "failed to read watchers response. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
 		return nil, errors.Errorf("issue does not exist or admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
-	} else if resp.StatusCode == http.StatusForbidden {
+	case http.StatusForbidden:
 		return nil, errors.Errorf("admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
-	} else if resp.StatusCode != http.StatusOK {
+	default:
 		return nil, errors.Errorf("unexpected status code when fetching watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
 	}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -1662,6 +1662,53 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 	return issue, nil
 }
 
+// GetWatchersWithAPIToken fetches the watcher list for an issue using the
+// admin API token configured in plugin settings. This serves as a fallback
+// when none of the issue's Creator, Assignee, or Reporter have connected
+// Jira accounts.  Works with both Jira Cloud (email + API token) and
+// Server/Data Center (username + password/PAT) via HTTP Basic auth.
+// Endpoint: GET /rest/api/2/issue/{issueIdOrKey}/watchers
+func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID, instanceID string) (*jira.Watches, error) {
+	httpClient := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/api/2/issue/%s/watchers", instanceID, issueKeyOrID), nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching watchers. Issue: %s", issueKeyOrID)
+	}
+
+	if err = p.SetAdminAPITokenRequestHeader(req); err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch watchers. Issue: %s", issueKeyOrID)
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, errors.Errorf("missing response data for watchers. Issue: %s", issueKeyOrID)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read watchers response. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.Errorf("issue does not exist or admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	} else if resp.StatusCode == http.StatusForbidden {
+		return nil, errors.Errorf("admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("unexpected status code when fetching watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	}
+
+	var watchers jira.Watches
+	if err = json.Unmarshal(body, &watchers); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal watchers data. Issue: %s", issueKeyOrID)
+	}
+
+	return &watchers, nil
+}
+
 func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 	if !wh.eventTypes.ContainsAny(createdCommentEvent) {
 		return
@@ -1678,15 +1725,39 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 		commentMessage = fmt.Sprintf("%s **commented** on %s\n\n*You are watching this %s*",
 			commentAuthor, jwhook.mdKeySummaryLink(), jwhook.mdIssueType())
 	}
+
+	var watchers *jira.Watches
 	client, connection, err := wh.fetchConnectedUser(p, instanceID)
 	if err != nil || client == nil {
-		p.errorf("error while fetching connected users for the instanceID %v , Error : %v", instanceID, err)
-		return
+		if p.getConfig().AdminAPIToken == "" {
+			p.errorf("error while fetching connected users for the instanceID %v, Error: %v", instanceID, err)
+			return
+		}
+
+		issueRef := wh.Issue.ID
+		if wh.Issue.Key != "" {
+			issueRef = wh.Issue.Key
+		}
+		p.client.Log.Info("No connected users found for watcher lookup, falling back to admin API token",
+			"instanceID", instanceID.String(), "issue", issueRef)
+
+		watchers, err = p.GetWatchersWithAPIToken(issueRef, instanceID.String())
+		if err != nil {
+			p.errorf("error while getting watchers with admin API token for issue %v, err: %v", issueRef, err)
+			return
+		}
+	} else {
+		watchers, err = client.GetWatchers(instanceID.String(), wh.Issue.ID, connection)
+		if err != nil {
+			p.errorf("error while getting watchers for the issue id %v, err: %v", wh.Issue.ID, err)
+			return
+		}
 	}
 
-	watchers, err := client.GetWatchers(instanceID.String(), wh.Issue.ID, connection)
-	if err != nil {
-		p.errorf("error while getting watchers for the issue id %v , err : %v", wh.Issue.ID, err)
+	if watchers.WatchCount > 0 && len(watchers.Watchers) == 0 {
+		p.client.Log.Warn("Jira returned a non-zero watch count but an empty watcher list; "+
+			"the admin account likely lacks the 'View voters and watchers' project permission",
+			"issue_id", wh.Issue.ID, "watch_count", watchers.WatchCount, "instance_id", instanceID.String())
 		return
 	}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -1731,9 +1731,13 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 
 	var watchers *jira.Watches
 	client, connection, err := wh.fetchConnectedUser(p, instanceID)
-	if err != nil || client == nil {
+	if err != nil {
+		p.errorf("error while fetching connected users for the instanceID %v, Error: %v", instanceID, err)
+		return
+	}
+	if client == nil {
 		if p.getConfig().AdminAPIToken == "" {
-			p.errorf("error while fetching connected users for the instanceID %v, Error: %v", instanceID, err)
+			p.errorf("no connected user found and no admin API token configured for instanceID %v", instanceID)
 			return
 		}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -1669,7 +1670,7 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 // Server/Data Center (username + password/PAT) via HTTP Basic auth.
 // Endpoint: GET /rest/api/2/issue/{issueIdOrKey}/watchers
 func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID, instanceID string) (*jira.Watches, error) {
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Timeout: 30 * time.Second}
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/api/2/issue/%s/watchers", instanceID, issueKeyOrID), nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching watchers. Issue: %s", issueKeyOrID)

--- a/server/issue.go
+++ b/server/issue.go
@@ -1730,6 +1730,7 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 	}
 
 	var watchers *jira.Watches
+	lookupSource := "connected_user"
 	client, connection, err := wh.fetchConnectedUser(p, instanceID)
 	if err != nil {
 		p.errorf("error while fetching connected users for the instanceID %v, Error: %v", instanceID, err)
@@ -1748,6 +1749,7 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 		p.client.Log.Info("No connected users found for watcher lookup, falling back to admin API token",
 			"instanceID", instanceID.String(), "issue", issueRef)
 
+		lookupSource = "admin_api_token"
 		watchers, err = p.GetWatchersWithAPIToken(issueRef, instanceID.String())
 		if err != nil {
 			p.errorf("error while getting watchers with admin API token for issue %v, err: %v", issueRef, err)
@@ -1763,8 +1765,8 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 
 	if watchers.WatchCount > 0 && len(watchers.Watchers) == 0 {
 		p.client.Log.Warn("Jira returned a non-zero watch count but an empty watcher list; "+
-			"the admin account likely lacks the 'View voters and watchers' project permission",
-			"issue_id", wh.Issue.ID, "watch_count", watchers.WatchCount, "instance_id", instanceID.String())
+			"the Jira account used for watcher lookup likely lacks the 'View voters and watchers' project permission",
+			"issue_id", wh.Issue.ID, "watch_count", watchers.WatchCount, "instance_id", instanceID.String(), "lookup_source", lookupSource)
 		return
 	}
 

--- a/server/issue.go
+++ b/server/issue.go
@@ -1671,12 +1671,16 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 // GetWatchersWithAPIToken fetches the watcher list for an issue using the
 // admin API token configured in plugin settings. This serves as a fallback
 // when none of the issue's Creator, Assignee, or Reporter have connected
-// Jira accounts.  Works with both Jira Cloud (email + API token) and
+// Jira accounts. Works with both Jira Cloud (email + API token) and
 // Server/Data Center (username + password/PAT) via HTTP Basic auth.
-// Endpoint: GET /rest/api/2/issue/{issueIdOrKey}/watchers
-func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID, instanceID string) (*jira.Watches, error) {
+func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID string, instance Instance) (*jira.Watches, error) {
+	apiVersion := "2"
+	if instance.Common().IsCloudInstance() {
+		apiVersion = "3"
+	}
+
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/api/2/issue/%s/watchers", instanceID, issueKeyOrID), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/api/%s/issue/%s/watchers", instance.GetURL(), apiVersion, issueKeyOrID), nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching watchers. Issue: %s", issueKeyOrID)
 	}
@@ -1747,6 +1751,12 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 			return
 		}
 
+		instance, loadErr := p.instanceStore.LoadInstance(instanceID)
+		if loadErr != nil {
+			p.errorf("error loading instance for admin-token watcher lookup, instanceID %v, err: %v", instanceID, loadErr)
+			return
+		}
+
 		issueRef := wh.Issue.ID
 		if wh.Issue.Key != "" {
 			issueRef = wh.Issue.Key
@@ -1755,7 +1765,7 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 			"instanceID", instanceID.String(), "issue", issueRef)
 
 		lookupSource = "admin_api_token"
-		watchers, err = p.GetWatchersWithAPIToken(issueRef, instanceID.String())
+		watchers, err = p.GetWatchersWithAPIToken(issueRef, instance)
 		if err != nil {
 			p.errorf("error while getting watchers with admin API token for issue %v, err: %v", issueRef, err)
 			return
@@ -1783,6 +1793,12 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 	for idx, watcherUser := range watchers.Watchers {
 		if watcherUser == nil {
 			p.client.Log.Warn("nil watcherUser in watchers.Watchers", "issue_id", wh.Issue.ID, "index", idx)
+			continue
+		}
+		if watcherUser.AccountID == "" && watcherUser.Name == "" {
+			p.client.Log.Warn("Skipping watcher with empty accountId and name; cannot map to a Mattermost user",
+				"issue_id", wh.Issue.ID, "index", idx, "lookup_source", lookupSource,
+				"display_name", watcherUser.DisplayName)
 			continue
 		}
 		if !shouldNotifyWatcherUser(*watcherUser, author) {

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -1456,6 +1456,113 @@ func TestShouldNotifyWatcherUser(t *testing.T) {
 	require.True(t, shouldNotifyWatcherUser(jira.Watcher{Name: "someone"}, nil))
 }
 
+func TestGetWatchersWithAPIToken(t *testing.T) {
+	watchersPayload := jira.Watches{
+		WatchCount: 2,
+		IsWatching: false,
+		Watchers: []*jira.Watcher{
+			{AccountID: "acct-100", DisplayName: "Watcher One", Active: true},
+			{Name: "watcher-two", DisplayName: "Watcher Two", Active: true},
+		},
+	}
+
+	t.Run("success - Cloud (accountId watchers)", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rest/api/2/issue/PROJ-123/watchers", r.URL.Path)
+			assert.Contains(t, r.Header.Get("Authorization"), "Basic ")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(watchersPayload) //nolint:errcheck
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", ts.URL)
+		require.NoError(t, err)
+		require.NotNil(t, watchers)
+		assert.Equal(t, 2, watchers.WatchCount)
+		require.Len(t, watchers.Watchers, 2)
+		assert.Equal(t, "acct-100", watchers.Watchers[0].AccountID)
+		assert.Equal(t, "watcher-two", watchers.Watchers[1].Name)
+	})
+
+	t.Run("success - Server/DC (name-based watchers)", func(t *testing.T) {
+		dcPayload := jira.Watches{
+			WatchCount: 1,
+			Watchers: []*jira.Watcher{
+				{Name: "fred", DisplayName: "Fred F. User", Active: true},
+			},
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rest/api/2/issue/ISSUE-456/watchers", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(dcPayload) //nolint:errcheck
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("admin-password")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("ISSUE-456", ts.URL)
+		require.NoError(t, err)
+		require.NotNil(t, watchers)
+		assert.Equal(t, 1, watchers.WatchCount)
+		assert.Equal(t, "fred", watchers.Watchers[0].Name)
+	})
+
+	t.Run("404 - issue not found", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("FAKE-999", ts.URL)
+		assert.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("403 - forbidden", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", ts.URL)
+		assert.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "permission")
+	})
+}
+
 func TestInjectTeamAllowedValues(t *testing.T) {
 	t.Run("with manual team config", func(t *testing.T) {
 		metaInfo := &jira.CreateMetaInfo{

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -1466,10 +1466,24 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 		},
 	}
 
-	t.Run("success - Cloud (accountId watchers)", func(t *testing.T) {
+	newCloudInst := func(baseURL string) Instance {
+		return &testInstance{InstanceCommon: InstanceCommon{
+			InstanceID: types.ID(baseURL),
+			Type:       CloudInstanceType,
+		}}
+	}
+	newServerInst := func(baseURL string) Instance {
+		return &testInstance{InstanceCommon: InstanceCommon{
+			InstanceID: types.ID(baseURL),
+			Type:       ServerInstanceType,
+		}}
+	}
+
+	t.Run("success - Cloud uses /rest/api/3 and accountId watchers", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/rest/api/2/issue/PROJ-123/watchers", r.URL.Path)
+			assert.Equal(t, "/rest/api/3/issue/PROJ-123/watchers", r.URL.Path)
 			assert.Contains(t, r.Header.Get("Authorization"), "Basic ")
+			assert.Contains(t, r.Header.Get("User-Agent"), "Mattermost-Plugin-Jira/")
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(watchersPayload) //nolint:errcheck
 		}))
@@ -1483,7 +1497,7 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 			conf.EncryptionKey = ""
 		})
 
-		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", ts.URL)
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
 		require.NoError(t, err)
 		require.NotNil(t, watchers)
 		assert.Equal(t, 2, watchers.WatchCount)
@@ -1492,7 +1506,7 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 		assert.Equal(t, "watcher-two", watchers.Watchers[1].Name)
 	})
 
-	t.Run("success - Server/DC (name-based watchers)", func(t *testing.T) {
+	t.Run("success - Server/DC uses /rest/api/2 and name-based watchers", func(t *testing.T) {
 		dcPayload := jira.Watches{
 			WatchCount: 1,
 			Watchers: []*jira.Watcher{
@@ -1515,7 +1529,7 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 			conf.EncryptionKey = ""
 		})
 
-		watchers, err := p.GetWatchersWithAPIToken("ISSUE-456", ts.URL)
+		watchers, err := p.GetWatchersWithAPIToken("ISSUE-456", newServerInst(ts.URL))
 		require.NoError(t, err)
 		require.NotNil(t, watchers)
 		assert.Equal(t, 1, watchers.WatchCount)
@@ -1536,7 +1550,7 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 			conf.EncryptionKey = ""
 		})
 
-		watchers, err := p.GetWatchersWithAPIToken("FAKE-999", ts.URL)
+		watchers, err := p.GetWatchersWithAPIToken("FAKE-999", newCloudInst(ts.URL))
 		assert.Error(t, err)
 		assert.Nil(t, watchers)
 		assert.Contains(t, err.Error(), "does not exist")
@@ -1556,10 +1570,30 @@ func TestGetWatchersWithAPIToken(t *testing.T) {
 			conf.EncryptionKey = ""
 		})
 
-		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", ts.URL)
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
 		assert.Error(t, err)
 		assert.Nil(t, watchers)
 		assert.Contains(t, err.Error(), "permission")
+	})
+
+	t.Run("missing admin email returns config error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Fatal("HTTP request should not have been made when admin email is missing")
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = ""
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
+		require.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "admin email/username is empty in plugin config")
 	})
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -213,24 +213,36 @@ func (p *Plugin) OnConfigurationChange() error {
 		}
 	}
 
-	jsonBytes, err := json.Marshal(ec.AdminAPIToken)
-	if err != nil {
-		p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
-		return err
+	prevExternal := p.getConfig().externalConfig
+
+	switch {
+	case ec.AdminAPIToken == "" || ec.AdminAPIToken == model.FakeSetting:
+		ec.AdminAPIToken = prevExternal.AdminAPIToken
+	case ec.AdminAPIToken == prevExternal.AdminAPIToken:
+	default:
+		if _, decErr := decrypt([]byte(ec.AdminAPIToken), []byte(ec.EncryptionKey)); decErr == nil {
+			break
+		}
+		jsonBytes, err := json.Marshal(ec.AdminAPIToken)
+		if err != nil {
+			p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
+			return err
+		}
+		if ec.EncryptionKey == "" {
+			p.client.Log.Warn("Encryption key required to encrypt admin API token")
+			return errors.New("failed to encrypt admin token. Encryption key not generated")
+		}
+		encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(ec.EncryptionKey))
+		if err != nil {
+			p.client.Log.Warn("Error encrypting the admin API token", "error", err.Error())
+			return err
+		}
+		ec.AdminAPIToken = string(encryptedAdminAPIToken)
 	}
 
-	encryptionKey := ec.EncryptionKey
-	if ec.AdminAPIToken != "" && encryptionKey == "" {
-		p.client.Log.Warn("Encryption key required to encrypt admin API token")
-		return errors.New("failed to encrypt admin token. Encryption key not generated")
+	if ec.AdminEmail == "" {
+		ec.AdminEmail = prevExternal.AdminEmail
 	}
-
-	encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(encryptionKey))
-	if err != nil {
-		p.client.Log.Warn("Error encrypting the admin API token", "error", err.Error())
-		return err
-	}
-	ec.AdminAPIToken = string(encryptedAdminAPIToken)
 
 	// Default to 30 days if not set
 	if ec.ThreadedJiraCommentSubscriptionDuration == "" {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -216,8 +216,9 @@ func (p *Plugin) OnConfigurationChange() error {
 	prevExternal := p.getConfig().externalConfig
 
 	switch {
-	case ec.AdminAPIToken == "" || ec.AdminAPIToken == model.FakeSetting:
+	case ec.AdminAPIToken == model.FakeSetting:
 		ec.AdminAPIToken = prevExternal.AdminAPIToken
+	case ec.AdminAPIToken == "":
 	case ec.AdminAPIToken == prevExternal.AdminAPIToken:
 	default:
 		if _, decErr := decrypt([]byte(ec.AdminAPIToken), []byte(ec.EncryptionKey)); decErr == nil {
@@ -240,7 +241,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		ec.AdminAPIToken = string(encryptedAdminAPIToken)
 	}
 
-	if ec.AdminEmail == "" {
+	if ec.AdminEmail == model.FakeSetting {
 		ec.AdminEmail = prevExternal.AdminEmail
 	}
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -251,22 +251,32 @@ func getS256PKCEParams() (*PKCEParams, error) {
 }
 
 func (p *Plugin) SetAdminAPITokenRequestHeader(req *http.Request) error {
-	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
-	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	cfg := p.getConfig()
+	if cfg.AdminEmail == "" {
+		return errors.New("admin email/username is empty in plugin config")
+	}
+	if cfg.AdminAPIToken == "" {
+		return errors.New("admin API token is empty in plugin config")
+	}
+
+	jsonBytes, err := decrypt([]byte(cfg.AdminAPIToken), []byte(cfg.EncryptionKey))
 	if err != nil {
-		p.client.Log.Warn("Error decrypting admin API token", "error", err.Error())
+		p.client.Log.Warn("Error decrypting admin API token; re-save the Admin API Token in System Console", "error", err.Error())
 		return err
 	}
 	var adminAPIToken string
-	err = json.Unmarshal(jsonBytes, &adminAPIToken)
-	if err != nil {
+	if err = json.Unmarshal(jsonBytes, &adminAPIToken); err != nil {
 		p.client.Log.Warn("Error unmarshalling admin API token", "error", err.Error())
 		return err
 	}
+	if adminAPIToken == "" {
+		return errors.New("decrypted admin API token is empty; re-save the Admin API Token in System Console")
+	}
 
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(cfg.AdminEmail + ":" + adminAPIToken))
 	req.Header.Set("Authorization", "Basic "+encodedAuth)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Mattermost-Plugin-Jira/"+manifest.Version)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary

When a comment is added to a Jira issue, the plugin attempts to notify all watchers. To fetch the watcher list it needs a valid Jira API client, which it obtains from the first connected Mattermost user among the issue's Creator, Assignee, or Reporter. If none of these three users have connected accounts, the watcher list cannot be retrieved and notifications silently fail.

This PR adds a fallback: when no connected user is available, the plugin uses the **AdminAPIToken** (configured in plugin settings) to call `GET /rest/api/2/issue/{key}/watchers` directly via HTTP Basic auth. This is consistent with how the admin token is already used elsewhere in the plugin (e.g. `GetIssueDataWithAPIToken` for expanding issue data in Cloud OAuth webhooks).

**Changes:**
- **`GetWatchersWithAPIToken`** — New function that fetches the watcher list using the admin API token with Basic auth. Follows the same pattern as `GetIssueDataWithAPIToken`. Works with both Jira Cloud (`email:api-token`) and Server/Data Center (`username:password` or `username:PAT`).
- **`checkIssueWatchers`** — Modified to fall back to `GetWatchersWithAPIToken` when `fetchConnectedUser` returns no client and `AdminAPIToken` is configured. Also adds a safety check: if Jira returns a non-zero `watchCount` but an empty `watchers` array, the admin account likely lacks the "View voters and watchers" project permission, and a warning is logged.
- **Tests** — Added `TestGetWatchersWithAPIToken` covering Cloud (accountId-based), Server/DC (name-based), 404, and 403 scenarios using `httptest.NewServer`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-68049

#### Manual QA Steps

1. **Setup:** Configure `AdminAPIToken` and `AdminEmail` in **System Console > Plugins > Jira > Admin API Token / Admin Email**. The Jira admin account must have "Browse projects" and "View voters and watchers" permissions.
2. **Create a Jira issue** where the Creator, Assignee, and Reporter are all users who have **not** connected their Jira accounts to Mattermost.
3. **Have at least one connected Mattermost user watch the issue** in Jira (and ensure their watching notification setting is enabled in `/jira settings`).
4. **Add a comment** on the issue from any Jira user.
5. **Verify** the watching Mattermost user receives a DM notification with the comment content and "You are watching this issue" message.
6. **Check server logs** for the info message: `No connected users found for watcher lookup, falling back to admin API token`.
7. **Negative test:** Remove the `AdminAPIToken` from plugin settings and repeat steps 2-4. Verify no watcher notification is sent and an error is logged: `error while fetching connected users for the instanceID`.
8. **Permission test:** Configure an admin token for a Jira account that lacks "View voters and watchers" permission. Repeat steps 2-4. Verify a warning is logged about non-zero watch count with empty watcher list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** Adds an admin-API-token fallback for fetching Jira issue watchers when no connected Mattermost user provides a Jira client. The change is localized to watcher notification logic but introduces an alternate authentication flow and additional REST calls that affect a user-facing notification feature.

**Regression Risk:** Low–Medium. The primary connected-user behavior remains unchanged and the fallback is conditional, but the new admin-token path and added HTTP requests can surface permission-related failures or unexpected Jira responses (e.g., watchCount vs watchers list) that may impact notification delivery.

** QA Recommendation:** Moderate manual QA recommended. Validate: (1) connected users present (no regression), (2) no connected users + AdminAPIToken configured (fallback triggers and returns watchers), (3) no AdminAPIToken configured (graceful behavior), and (4) admin account lacking "View voters and watchers" permission (confirm warning logs and behavior). Unit tests cover Cloud/Server-DC success and 404/403 cases; run integration/end-to-end tests for notification flows.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->