### PR TITLE
MM-67304: Deduplicate expired-token DMs to prevent Jira bot spam

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -166,8 +166,6 @@ type Plugin struct {
 
 	teamFieldCache     map[types.ID]map[string]struct{}
 	teamFieldCacheLock sync.RWMutex
-
-	expiredTokenInFlight sync.Map
 }
 
 func (p *Plugin) getConfig() config {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -166,6 +166,8 @@ type Plugin struct {
 
 	teamFieldCache     map[types.ID]map[string]struct{}
 	teamFieldCacheLock sync.RWMutex
+
+	expiredTokenInFlight sync.Map
 }
 
 func (p *Plugin) getConfig() config {

--- a/server/utils.go
+++ b/server/utils.go
@@ -20,11 +20,12 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/kvstore"
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
 const (
-	expiredTokenNotificationCooldown = 5 * time.Minute
+	expiredTokenNotificationCooldown  = 5 * time.Minute
 	expiredTokenNotificationKeyPrefix = "expired_token_dm:"
 )
 
@@ -96,50 +97,51 @@ func (p *Plugin) CreateBotDMtoMMUserID(mattermostUserID, format string, args ...
 }
 
 func (p *Plugin) disconnectUserDueToExpiredToken(mattermostUserID types.ID, instanceID types.ID) {
-	key := expiredTokenNotificationKeyPrefix + mattermostUserID.String() + ":" + instanceID.String()
-	ok, err := p.client.KV.Set(key, []byte("1"),
+	_, disconnectErr := p.DisconnectUser(instanceID.String(), mattermostUserID)
+	if disconnectErr != nil && errors.Cause(disconnectErr) == kvstore.ErrNotFound {
+		disconnectErr = nil
+	}
+	if disconnectErr != nil {
+		p.client.Log.Warn("Failed to disconnect user after token expiry",
+			"mattermostUserID", mattermostUserID,
+			"instanceID", instanceID,
+			"error", disconnectErr.Error())
+	}
+
+	dmKey := expiredTokenNotificationKeyPrefix + mattermostUserID.String() + ":" + instanceID.String()
+	ok, kvErr := p.client.KV.Set(dmKey, []byte("1"),
 		pluginapi.SetAtomic(nil),
 		pluginapi.SetExpiry(expiredTokenNotificationCooldown),
 	)
-	if err != nil {
+	if kvErr != nil {
 		p.client.Log.Warn("Failed to set expired-token notification dedup marker; proceeding without dedup",
 			"mattermostUserID", mattermostUserID,
 			"instanceID", instanceID,
-			"error", err.Error())
+			"error", kvErr.Error())
 	} else if !ok {
 		return
 	}
 
-	// Disconnect the user first to update server and client state via websocket
-	_, err = p.DisconnectUser(instanceID.String(), mattermostUserID)
-	if err != nil {
-		p.client.Log.Warn("Failed to disconnect user after token expiry",
-			"mattermostUserID", mattermostUserID,
-			"instanceID", instanceID,
-			"error", err.Error())
-
-		// Notify user even if disconnect failed, with manual disconnect instructions
-		_, notifyErr := p.CreateBotDMtoMMUserID(mattermostUserID.String(),
+	var notifyErr error
+	if disconnectErr != nil {
+		_, notifyErr = p.CreateBotDMtoMMUserID(mattermostUserID.String(),
 			":warning: Your Jira connection has expired. Please manually disconnect and reconnect your account using:\n"+
 				"1. `/jira disconnect %s`\n"+
 				"2. `/jira connect %s`",
 			instanceID, instanceID)
-		if notifyErr != nil {
-			p.client.Log.Warn("Failed to send token expiry notification to user after disconnect failure",
-				"mattermostUserID", mattermostUserID,
-				"error", notifyErr.Error())
-		}
-		return
+	} else {
+		_, notifyErr = p.CreateBotDMtoMMUserID(mattermostUserID.String(),
+			":warning: Your Jira connection has expired. Please reconnect your account using `/jira connect %s`.",
+			instanceID)
 	}
-
-	// Send notification after successful disconnect
-	_, err = p.CreateBotDMtoMMUserID(mattermostUserID.String(),
-		":warning: Your Jira connection has expired. Please reconnect your account using `/jira connect %s`.",
-		instanceID)
-	if err != nil {
-		p.client.Log.Warn("Failed to send token expiry notification to user",
+	if notifyErr != nil {
+		label := "Failed to send token expiry notification to user"
+		if disconnectErr != nil {
+			label = "Failed to send token expiry notification to user after disconnect failure"
+		}
+		p.client.Log.Warn(label,
 			"mattermostUserID", mattermostUserID,
-			"error", err.Error())
+			"error", notifyErr.Error())
 	}
 }
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -18,11 +18,15 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
-const expiredTokenNotificationCooldown = 5 * time.Minute
+const (
+	expiredTokenNotificationCooldown = 5 * time.Minute
+	expiredTokenNotificationKeyPrefix = "expired_token_dm:"
+)
 
 func (p *Plugin) CreateBotDMPost(instanceID, mattermostUserID types.ID, message, postType string) (post *model.Post, returnErr error) {
 	defer func() {
@@ -92,16 +96,22 @@ func (p *Plugin) CreateBotDMtoMMUserID(mattermostUserID, format string, args ...
 }
 
 func (p *Plugin) disconnectUserDueToExpiredToken(mattermostUserID types.ID, instanceID types.ID) {
-	key := mattermostUserID.String() + ":" + instanceID.String()
-	if _, loaded := p.expiredTokenInFlight.LoadOrStore(key, struct{}{}); loaded {
+	key := expiredTokenNotificationKeyPrefix + mattermostUserID.String() + ":" + instanceID.String()
+	ok, err := p.client.KV.Set(key, []byte("1"),
+		pluginapi.SetAtomic(nil),
+		pluginapi.SetExpiry(expiredTokenNotificationCooldown),
+	)
+	if err != nil {
+		p.client.Log.Warn("Failed to set expired-token notification dedup marker; proceeding without dedup",
+			"mattermostUserID", mattermostUserID,
+			"instanceID", instanceID,
+			"error", err.Error())
+	} else if !ok {
 		return
 	}
-	defer time.AfterFunc(expiredTokenNotificationCooldown, func() {
-		p.expiredTokenInFlight.Delete(key)
-	})
 
 	// Disconnect the user first to update server and client state via websocket
-	_, err := p.DisconnectUser(instanceID.String(), mattermostUserID)
+	_, err = p.DisconnectUser(instanceID.String(), mattermostUserID)
 	if err != nil {
 		p.client.Log.Warn("Failed to disconnect user after token expiry",
 			"mattermostUserID", mattermostUserID,

--- a/server/utils.go
+++ b/server/utils.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -20,6 +21,8 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
+
+const expiredTokenNotificationCooldown = 5 * time.Minute
 
 func (p *Plugin) CreateBotDMPost(instanceID, mattermostUserID types.ID, message, postType string) (post *model.Post, returnErr error) {
 	defer func() {
@@ -89,6 +92,14 @@ func (p *Plugin) CreateBotDMtoMMUserID(mattermostUserID, format string, args ...
 }
 
 func (p *Plugin) disconnectUserDueToExpiredToken(mattermostUserID types.ID, instanceID types.ID) {
+	key := mattermostUserID.String() + ":" + instanceID.String()
+	if _, loaded := p.expiredTokenInFlight.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	defer time.AfterFunc(expiredTokenNotificationCooldown, func() {
+		p.expiredTokenInFlight.Delete(key)
+	})
+
 	// Disconnect the user first to update server and client state via websocket
 	_, err := p.DisconnectUser(instanceID.String(), mattermostUserID)
 	if err != nil {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/telemetry"
-	"github.com/mattermost/mattermost-plugin-jira/server/utils/kvstore"
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +155,7 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 			setupMocks: func(api *plugintest.API, userStore *mockUserStoreForTokenExpiry, instanceStore *mockInstanceStoreWithLoadInstances) {
 				api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(true, (*model.AppError)(nil)).Once()
 
-				userStore.On("LoadUser", testMattermostUserID).Return(nil, kvstore.ErrNotFound).Once()
+				userStore.On("LoadUser", testMattermostUserID).Return(nil, errors.New("transient kv failure")).Once()
 
 				api.On("GetDirectChannel", testMattermostUserID.String(), testBotUserID).Return(&model.Channel{
 					Id: testChannelID,
@@ -179,7 +178,7 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 			setupMocks: func(api *plugintest.API, userStore *mockUserStoreForTokenExpiry, instanceStore *mockInstanceStoreWithLoadInstances) {
 				api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(true, (*model.AppError)(nil)).Once()
 
-				userStore.On("LoadUser", testMattermostUserID).Return(nil, kvstore.ErrNotFound).Once()
+				userStore.On("LoadUser", testMattermostUserID).Return(nil, errors.New("transient kv failure")).Once()
 
 				api.On("GetDirectChannel", testMattermostUserID.String(), testBotUserID).Return(nil, &model.AppError{
 					Message: "channel not found",
@@ -246,13 +245,17 @@ func TestDisconnectUserDueToExpiredTokenDeduplicatesConcurrentCalls(t *testing.T
 		return false, nil
 	})
 
-	user := NewUser(testMattermostUserID)
-	user.ConnectedInstances = NewInstances()
-	user.ConnectedInstances.Set(&InstanceCommon{InstanceID: testInstanceID})
-	userStore.On("LoadUser", testMattermostUserID).Return(user, nil).Once()
+	connectedUser := NewUser(testMattermostUserID)
+	connectedUser.ConnectedInstances = NewInstances()
+	connectedUser.ConnectedInstances.Set(&InstanceCommon{InstanceID: testInstanceID})
+	disconnectedUser := NewUser(testMattermostUserID)
+	disconnectedUser.ConnectedInstances = NewInstances()
+
+	userStore.On("LoadUser", testMattermostUserID).Return(connectedUser, nil).Once()
+	userStore.On("LoadUser", testMattermostUserID).Return(disconnectedUser, nil)
 
 	mockInstance := &testInstance{InstanceCommon: InstanceCommon{InstanceID: testInstanceID}}
-	instanceStore.On("LoadInstance", testInstanceID).Return(mockInstance, nil).Once()
+	instanceStore.On("LoadInstance", testInstanceID).Return(mockInstance, nil)
 
 	connection := &Connection{MattermostUserID: testMattermostUserID}
 	userStore.On("LoadConnection", testInstanceID, testMattermostUserID).Return(connection, nil).Once()
@@ -261,7 +264,7 @@ func TestDisconnectUserDueToExpiredTokenDeduplicatesConcurrentCalls(t *testing.T
 
 	instances := NewInstances()
 	instances.Set(&InstanceCommon{InstanceID: testInstanceID})
-	instanceStore.On("LoadInstances").Return(instances, nil).Twice()
+	instanceStore.On("LoadInstances").Return(instances, nil)
 
 	api.On("PublishWebSocketEvent", "disconnect", mock.Anything, mock.MatchedBy(func(b *model.WebsocketBroadcast) bool {
 		return b.UserId == testMattermostUserID.String()

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -104,6 +105,8 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 		{
 			name: "Happy path - Disconnect succeeds and DM sent",
 			setupMocks: func(api *plugintest.API, userStore *mockUserStoreForTokenExpiry, instanceStore *mockInstanceStoreWithLoadInstances) {
+				api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(true, (*model.AppError)(nil)).Once()
+
 				user := NewUser(testMattermostUserID)
 				user.ConnectedInstances = NewInstances()
 				user.ConnectedInstances.Set(&InstanceCommon{InstanceID: testInstanceID})
@@ -151,6 +154,8 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 		{
 			name: "Disconnect fails but DM with manual instructions sent",
 			setupMocks: func(api *plugintest.API, userStore *mockUserStoreForTokenExpiry, instanceStore *mockInstanceStoreWithLoadInstances) {
+				api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(true, (*model.AppError)(nil)).Once()
+
 				userStore.On("LoadUser", testMattermostUserID).Return(nil, kvstore.ErrNotFound).Once()
 
 				api.On("GetDirectChannel", testMattermostUserID.String(), testBotUserID).Return(&model.Channel{
@@ -172,6 +177,8 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 		{
 			name: "Disconnect fails and DM also fails - only logging",
 			setupMocks: func(api *plugintest.API, userStore *mockUserStoreForTokenExpiry, instanceStore *mockInstanceStoreWithLoadInstances) {
+				api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(true, (*model.AppError)(nil)).Once()
+
 				userStore.On("LoadUser", testMattermostUserID).Return(nil, kvstore.ErrNotFound).Once()
 
 				api.On("GetDirectChannel", testMattermostUserID.String(), testBotUserID).Return(nil, &model.AppError{
@@ -230,6 +237,14 @@ func TestDisconnectUserDueToExpiredTokenDeduplicatesConcurrentCalls(t *testing.T
 	instanceStore := &mockInstanceStoreWithLoadInstances{
 		mockInstanceStore: &mockInstanceStore{},
 	}
+
+	var kvWinners atomic.Int32
+	api.On("KVSetWithOptions", mock.AnythingOfType("string"), []byte("1"), mock.Anything).Return(func(string, []byte, model.PluginKVSetOptions) (bool, *model.AppError) {
+		if kvWinners.Add(1) == 1 {
+			return true, nil
+		}
+		return false, nil
+	})
 
 	user := NewUser(testMattermostUserID)
 	user.ConnectedInstances = NewInstances()

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -216,6 +217,75 @@ func TestDisconnectUserDueToExpiredToken(t *testing.T) {
 			instanceStore.AssertExpectations(t)
 		})
 	}
+}
+
+func TestDisconnectUserDueToExpiredTokenDeduplicatesConcurrentCalls(t *testing.T) {
+	testMattermostUserID := types.ID("test-mm-user-id")
+	testInstanceID := types.ID("https://test-instance.atlassian.net")
+	testChannelID := "test-channel-id"
+	testBotUserID := "test-bot-user-id"
+
+	api := &plugintest.API{}
+	userStore := &mockUserStoreForTokenExpiry{}
+	instanceStore := &mockInstanceStoreWithLoadInstances{
+		mockInstanceStore: &mockInstanceStore{},
+	}
+
+	user := NewUser(testMattermostUserID)
+	user.ConnectedInstances = NewInstances()
+	user.ConnectedInstances.Set(&InstanceCommon{InstanceID: testInstanceID})
+	userStore.On("LoadUser", testMattermostUserID).Return(user, nil).Once()
+
+	mockInstance := &testInstance{InstanceCommon: InstanceCommon{InstanceID: testInstanceID}}
+	instanceStore.On("LoadInstance", testInstanceID).Return(mockInstance, nil).Once()
+
+	connection := &Connection{MattermostUserID: testMattermostUserID}
+	userStore.On("LoadConnection", testInstanceID, testMattermostUserID).Return(connection, nil).Once()
+	userStore.On("DeleteConnection", testInstanceID, testMattermostUserID).Return(nil).Once()
+	userStore.On("StoreUser", mock.AnythingOfType("*main.User")).Return(nil).Once()
+
+	instances := NewInstances()
+	instances.Set(&InstanceCommon{InstanceID: testInstanceID})
+	instanceStore.On("LoadInstances").Return(instances, nil).Twice()
+
+	api.On("PublishWebSocketEvent", "disconnect", mock.Anything, mock.MatchedBy(func(b *model.WebsocketBroadcast) bool {
+		return b.UserId == testMattermostUserID.String()
+	})).Return().Once()
+	api.On("GetDirectChannel", testMattermostUserID.String(), testBotUserID).Return(&model.Channel{Id: testChannelID}, nil)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+	api.On("CreatePost", mock.MatchedBy(func(post *model.Post) bool {
+		return post.UserId == testBotUserID && post.ChannelId == testChannelID
+	})).Return(&model.Post{}, nil).Once()
+
+	p := &Plugin{
+		userStore:     userStore,
+		instanceStore: instanceStore,
+		tracker:       &mockTelemetryTracker{},
+	}
+	p.SetAPI(api)
+	p.client = pluginapi.NewClient(api, p.Driver)
+	p.updateConfig(func(conf *config) {
+		conf.botUserID = testBotUserID
+	})
+
+	const callers = 25
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			p.disconnectUserDueToExpiredToken(testMattermostUserID, testInstanceID)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	api.AssertExpectations(t)
+	userStore.AssertExpectations(t)
+	instanceStore.AssertExpectations(t)
 }
 
 func TestParseJIRAUsernamesFromText(t *testing.T) {


### PR DESCRIPTION

#### Summary
Hovering Jira links with a disconnected or expired account spammed the Jira bot DM channel with the same warning message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67304

#### QA
1. As a test user, run `/jira connect` and complete OAuth.
2. Revoke the OAuth grant at https://id.atlassian.com/manage-profile/security/connected-apps → "Mattermost Jira Plugin" → Revoke access.

**Expected:** exactly **one** DM appears, regardless of how many links you hover or how fast.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change adds a KV-store-based deduplication mechanism for expired-token notifications in an authentication-adjacent flow; it’s localized to the token-expiration handler, covered by new concurrent tests, but introduces atomic KV usage and TTL reliance that present moderate operational risk.

**Regression Risk:** Moderate — the code is defensive (falls back to existing behavior if KV writes fail) and tests were updated to cover concurrent deduplication, but the deduplication depends on KV availability and correct TTL semantics which could surface edge cases in production. The change is invoked from a small number of callers, limiting blast radius.

**QA Recommendation:** Moderate manual QA recommended. Verify the reported QA steps (revoke OAuth and hover many links to confirm a single DM). Also test KV unavailability/latency, concurrent expirations, and behavior during the cooldown window to ensure no unexpected suppression or duplicate notifications.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-jira/pull/1306)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->