### PR TITLE
docs: tighten readme wording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Restart the server if prompted.
 - `host.docker.internal` works on macOS with Docker Desktop. On Linux, specify the gateway explicitly when starting Jira (`docker run --add-host=host.docker.internal:host-gateway ...`) or use your workstation’s LAN IP in both `SiteURL` and the commands above.
 - Whichever hostname you choose, open Mattermost in your browser using that same URL as mismatches can trigger WebSocket CORS blocks and slash-command errors.
 - If Jira runs on another machine or you need external access, expose Mattermost via a tunnel or a real domain with valid HTTPS, and update the config values accordingly.
-- When you create the Application Link in Jira, supply that same externally reachable Mattermost URL. Jira reuses it to call the plugin’s endpoints.
+- When you create the Application Link in Jira, supply that same externally reachable Mattermost URL. Jira reuses it to call the plugin endpoints.
 - You can sanity-check connectivity from the Jira container with `docker exec jira curl -I <your-site-url>`.
 
 ### 2. Build and install the Jira plugin


### PR DESCRIPTION
Minimal harmless documentation-only PR for CI behavior verification. This changes a single wording in the README and does not touch code, build scripts, workflows, or release files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a documentation-only change affecting the README with no code modifications, shared dependencies, or critical paths involved. The update provides clarification on externally reachable Mattermost URLs in the Jira Application Link configuration, introducing zero regression risk.

**Regression Risk:** No code is modified, no dependencies are affected, and no functional behavior changes. Regression risk is negligible.

**QA Recommendation:** Manual QA is not required for this change. Documentation updates carry no execution risk and do not require testing beyond standard review for clarity and accuracy.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-jira/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->