### PR TITLE
MM-68851 Preventing duplicate notifications from being sent (#1313)

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +18,11 @@ import (
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
+)
+
+const (
+	notificationDedupTTL    = 3 * time.Second
+	notificationDedupKeyFmt = "notif_dedup_%s"
 )
 
 const (
@@ -213,10 +220,22 @@ func (wh *webhook) PostNotifications(p *Plugin, instanceID types.ID) ([]*model.P
 
 		notification.message = p.replaceJiraAccountIds(instance.GetID(), notification.message, client)
 
+		dedupKey := notificationDedupKey(wh, mattermostUserID, notification.message)
+		var alreadySent bool
+		if kvErr := p.client.KV.Get(dedupKey, &alreadySent); kvErr != nil {
+			p.client.Log.Warn("PostNotifications: failed to read dedup key, sending notification anyway", "key", dedupKey, "error", kvErr.Error())
+		}
+		if alreadySent {
+			continue
+		}
+
 		post, err := p.CreateBotDMPost(instance.GetID(), mattermostUserID, notification.message, notification.postType)
 		if err != nil {
 			p.errorf("PostNotifications: failed to create notification post, err: %v", err)
 			continue
+		}
+		if _, kvErr := p.client.KV.Set(dedupKey, true, pluginapi.SetExpiry(notificationDedupTTL)); kvErr != nil {
+			p.client.Log.Warn("PostNotifications: failed to write dedup key, duplicate may be sent", "key", dedupKey, "error", kvErr.Error())
 		}
 		posts = append(posts, post)
 	}
@@ -229,6 +248,16 @@ func newWebhook(jwh *JiraWebhook, eventType string, format string, args ...inter
 		eventTypes:  NewStringSet(eventType),
 		headline:    jwh.mdUser() + " " + fmt.Sprintf(format, args...) + " " + jwh.mdKeySummaryLink(),
 	}
+}
+
+func notificationDedupKey(wh *webhook, recipientID types.ID, message string) string {
+	raw := fmt.Sprintf("%s_%s_%s",
+		wh.Issue.Key,
+		string(recipientID),
+		message,
+	)
+	hash := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf(notificationDedupKeyFmt, hex.EncodeToString(hash[:]))
 }
 
 func (p *Plugin) GetWebhookURL(jiraURL string, teamID, channelID string) (subURL, legacyURL string, err error) {

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -267,4 +268,60 @@ more text data in code block.{noformat}`,
 			assert.Equal(t, tc.expectedOutput, actualOutput)
 		})
 	}
+}
+
+func TestNotificationDedupKey(t *testing.T) {
+	makeWebhook := func(issueKey string) *webhook {
+		return &webhook{
+			JiraWebhook: &JiraWebhook{
+				Issue: jira.Issue{Key: issueKey},
+			},
+		}
+	}
+
+	t.Run("same issue, recipient and message produce the same key", func(t *testing.T) {
+		wh1 := makeWebhook("PROJ-1")
+		wh2 := makeWebhook("PROJ-1")
+		assert.Equal(t,
+			notificationDedupKey(wh1, "user-abc", "Actor **assigned** you to PROJ-1"),
+			notificationDedupKey(wh2, "user-abc", "Actor **assigned** you to PROJ-1"))
+	})
+
+	t.Run("different events producing identical notifications still dedup", func(t *testing.T) {
+		whCreated := &webhook{JiraWebhook: &JiraWebhook{
+			WebhookEvent: "jira:issue_created",
+			Issue:        jira.Issue{Key: "PROJ-1"},
+		}}
+		whAssigned := &webhook{JiraWebhook: &JiraWebhook{
+			WebhookEvent:       "jira:issue_updated",
+			IssueEventTypeName: "issue_assigned",
+			Issue:              jira.Issue{Key: "PROJ-1"},
+		}}
+		msg := "Actor **assigned** you to PROJ-1"
+		assert.Equal(t,
+			notificationDedupKey(whCreated, "user-abc", msg),
+			notificationDedupKey(whAssigned, "user-abc", msg))
+	})
+
+	t.Run("different recipients produce different keys", func(t *testing.T) {
+		wh := makeWebhook("PROJ-1")
+		msg := "Actor **assigned** you to PROJ-1"
+		assert.NotEqual(t,
+			notificationDedupKey(wh, "user-abc", msg),
+			notificationDedupKey(wh, "user-xyz", msg))
+	})
+
+	t.Run("different issues produce different keys", func(t *testing.T) {
+		msg := "Actor **assigned** you to %s"
+		assert.NotEqual(t,
+			notificationDedupKey(makeWebhook("PROJ-1"), "user-abc", fmt.Sprintf(msg, "PROJ-1")),
+			notificationDedupKey(makeWebhook("PROJ-2"), "user-abc", fmt.Sprintf(msg, "PROJ-2")))
+	})
+
+	t.Run("different messages produce different keys", func(t *testing.T) {
+		wh := makeWebhook("PROJ-1")
+		assert.NotEqual(t,
+			notificationDedupKey(wh, "user-abc", "Actor **assigned** you to PROJ-1"),
+			notificationDedupKey(wh, "user-abc", "Actor **commented** on PROJ-1"))
+	})
 }


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR is a manual cherry-pick of #1313 on release-4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This PR implements an isolated, additive notification deduplication feature using a 3-second TTL mechanism confined to webhook direct message notifications. The implementation includes comprehensive test coverage and fail-open error handling. No critical paths, public APIs, data integrity mechanisms, or widely-used modules are affected.

**Regression Risk:** The change introduces minimal regression risk. The deduplication logic is purely additive and uses a fail-open design: on any KV store read failure, notifications are sent anyway (with a logged warning); on write failure, the notification still succeeds. The core notification flow remains unchanged. The tight 3-second TTL window prevents duplicate issues while avoiding extended delays for legitimate notifications. The implementation is completely isolated to the `PostNotifications` method and does not touch shared utilities, base classes, or other modules. Existing notification functionality is preserved as-is when deduplication is unavailable.

**QA Recommendation:** Minimal manual QA is required. Testing should focus on: (1) verifying duplicate notifications within the 3-second window are correctly suppressed, (2) confirming legitimate notifications are delivered after TTL expiration, and (3) validating graceful degradation when KV store is unavailable. The comprehensive unit test suite (`TestNotificationDedupKey`) covering various dedup scenarios (identical notifications, different event types, different recipients/issues/messages) provides strong confidence. This change is safe to deploy without extensive manual testing; rollback is straightforward given the feature's isolation and additive nature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->