### PR TITLE
MM-68049: Add AdminAPIToken fallback for watcher notifications (#1303)

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
@@ -1667,6 +1668,59 @@ func (p *Plugin) GetIssueDataWithAPIToken(issueID, instanceID string) (*jira.Iss
 	return issue, nil
 }
 
+// GetWatchersWithAPIToken fetches the watcher list for an issue using the
+// admin API token configured in plugin settings. This serves as a fallback
+// when none of the issue's Creator, Assignee, or Reporter have connected
+// Jira accounts. Works with both Jira Cloud (email + API token) and
+// Server/Data Center (username + password/PAT) via HTTP Basic auth.
+func (p *Plugin) GetWatchersWithAPIToken(issueKeyOrID string, instance Instance) (*jira.Watches, error) {
+	apiVersion := "2"
+	if instance.Common().IsCloudInstance() {
+		apiVersion = "3"
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/api/%s/issue/%s/watchers", instance.GetURL(), apiVersion, issueKeyOrID), nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create HTTP request for fetching watchers. Issue: %s", issueKeyOrID)
+	}
+
+	if err = p.SetAdminAPITokenRequestHeader(req); err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch watchers. Issue: %s", issueKeyOrID)
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, errors.Errorf("missing response data for watchers. Issue: %s", issueKeyOrID)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read watchers response. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, errors.Errorf("issue does not exist or admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	case http.StatusForbidden:
+		return nil, errors.Errorf("admin does not have permission to view watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	default:
+		return nil, errors.Errorf("unexpected status code when fetching watchers. StatusCode: %d, Issue: %s", resp.StatusCode, issueKeyOrID)
+	}
+
+	var watchers jira.Watches
+	if err = json.Unmarshal(body, &watchers); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal watchers data. Issue: %s", issueKeyOrID)
+	}
+
+	return &watchers, nil
+}
+
 func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 	if !wh.eventTypes.ContainsAny(createdCommentEvent) {
 		return
@@ -1683,15 +1737,51 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 		commentMessage = fmt.Sprintf("%s **commented** on %s\n\n*You are watching this %s*",
 			commentAuthor, jwhook.mdKeySummaryLink(), jwhook.mdIssueType())
 	}
+
+	var watchers *jira.Watches
+	lookupSource := "connected_user"
 	client, connection, err := wh.fetchConnectedUser(p, instanceID)
-	if err != nil || client == nil {
-		p.errorf("error while fetching connected users for the instanceID %v , Error : %v", instanceID, err)
+	if err != nil {
+		p.errorf("error while fetching connected users for the instanceID %v, Error: %v", instanceID, err)
 		return
 	}
+	if client == nil {
+		if p.getConfig().AdminAPIToken == "" {
+			p.errorf("no connected user found and no admin API token configured for instanceID %v", instanceID)
+			return
+		}
 
-	watchers, err := client.GetWatchers(instanceID.String(), wh.Issue.ID, connection)
-	if err != nil {
-		p.errorf("error while getting watchers for the issue id %v , err : %v", wh.Issue.ID, err)
+		instance, loadErr := p.instanceStore.LoadInstance(instanceID)
+		if loadErr != nil {
+			p.errorf("error loading instance for admin-token watcher lookup, instanceID %v, err: %v", instanceID, loadErr)
+			return
+		}
+
+		issueRef := wh.Issue.ID
+		if wh.Issue.Key != "" {
+			issueRef = wh.Issue.Key
+		}
+		p.client.Log.Info("No connected users found for watcher lookup, falling back to admin API token",
+			"instanceID", instanceID.String(), "issue", issueRef)
+
+		lookupSource = "admin_api_token"
+		watchers, err = p.GetWatchersWithAPIToken(issueRef, instance)
+		if err != nil {
+			p.errorf("error while getting watchers with admin API token for issue %v, err: %v", issueRef, err)
+			return
+		}
+	} else {
+		watchers, err = client.GetWatchers(instanceID.String(), wh.Issue.ID, connection)
+		if err != nil {
+			p.errorf("error while getting watchers for the issue id %v, err: %v", wh.Issue.ID, err)
+			return
+		}
+	}
+
+	if watchers.WatchCount > 0 && len(watchers.Watchers) == 0 {
+		p.client.Log.Warn("Jira returned a non-zero watch count but an empty watcher list; "+
+			"the Jira account used for watcher lookup likely lacks the 'View voters and watchers' project permission",
+			"issue_id", wh.Issue.ID, "watch_count", watchers.WatchCount, "instance_id", instanceID.String(), "lookup_source", lookupSource)
 		return
 	}
 
@@ -1703,6 +1793,12 @@ func (p *Plugin) checkIssueWatchers(wh *webhook, instanceID types.ID) {
 	for idx, watcherUser := range watchers.Watchers {
 		if watcherUser == nil {
 			p.client.Log.Warn("nil watcherUser in watchers.Watchers", "issue_id", wh.Issue.ID, "index", idx)
+			continue
+		}
+		if watcherUser.AccountID == "" && watcherUser.Name == "" {
+			p.client.Log.Warn("Skipping watcher with empty accountId and name; cannot map to a Mattermost user",
+				"issue_id", wh.Issue.ID, "index", idx, "lookup_source", lookupSource,
+				"display_name", watcherUser.DisplayName)
 			continue
 		}
 		if !shouldNotifyWatcherUser(*watcherUser, author) {

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -1456,6 +1456,147 @@ func TestShouldNotifyWatcherUser(t *testing.T) {
 	require.True(t, shouldNotifyWatcherUser(jira.Watcher{Name: "someone"}, nil))
 }
 
+func TestGetWatchersWithAPIToken(t *testing.T) {
+	watchersPayload := jira.Watches{
+		WatchCount: 2,
+		IsWatching: false,
+		Watchers: []*jira.Watcher{
+			{AccountID: "acct-100", DisplayName: "Watcher One", Active: true},
+			{Name: "watcher-two", DisplayName: "Watcher Two", Active: true},
+		},
+	}
+
+	newCloudInst := func(baseURL string) Instance {
+		return &testInstance{InstanceCommon: InstanceCommon{
+			InstanceID: types.ID(baseURL),
+			Type:       CloudInstanceType,
+		}}
+	}
+	newServerInst := func(baseURL string) Instance {
+		return &testInstance{InstanceCommon: InstanceCommon{
+			InstanceID: types.ID(baseURL),
+			Type:       ServerInstanceType,
+		}}
+	}
+
+	t.Run("success - Cloud uses /rest/api/3 and accountId watchers", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rest/api/3/issue/PROJ-123/watchers", r.URL.Path)
+			assert.Contains(t, r.Header.Get("Authorization"), "Basic ")
+			assert.Contains(t, r.Header.Get("User-Agent"), "Mattermost-Plugin-Jira/")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(watchersPayload) //nolint:errcheck
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
+		require.NoError(t, err)
+		require.NotNil(t, watchers)
+		assert.Equal(t, 2, watchers.WatchCount)
+		require.Len(t, watchers.Watchers, 2)
+		assert.Equal(t, "acct-100", watchers.Watchers[0].AccountID)
+		assert.Equal(t, "watcher-two", watchers.Watchers[1].Name)
+	})
+
+	t.Run("success - Server/DC uses /rest/api/2 and name-based watchers", func(t *testing.T) {
+		dcPayload := jira.Watches{
+			WatchCount: 1,
+			Watchers: []*jira.Watcher{
+				{Name: "fred", DisplayName: "Fred F. User", Active: true},
+			},
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/rest/api/2/issue/ISSUE-456/watchers", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(dcPayload) //nolint:errcheck
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("admin-password")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("ISSUE-456", newServerInst(ts.URL))
+		require.NoError(t, err)
+		require.NotNil(t, watchers)
+		assert.Equal(t, 1, watchers.WatchCount)
+		assert.Equal(t, "fred", watchers.Watchers[0].Name)
+	})
+
+	t.Run("404 - issue not found", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("FAKE-999", newCloudInst(ts.URL))
+		assert.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("403 - forbidden", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = "admin@example.com"
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
+		assert.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "permission")
+	})
+
+	t.Run("missing admin email returns config error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Fatal("HTTP request should not have been made when admin email is missing")
+		}))
+		defer ts.Close()
+
+		p := setupTestPlugin(&plugintest.API{})
+		tokenJSON, _ := json.Marshal("test-api-token")
+		p.updateConfig(func(conf *config) {
+			conf.AdminAPIToken = string(tokenJSON)
+			conf.AdminEmail = ""
+			conf.EncryptionKey = ""
+		})
+
+		watchers, err := p.GetWatchersWithAPIToken("PROJ-123", newCloudInst(ts.URL))
+		require.Error(t, err)
+		assert.Nil(t, watchers)
+		assert.Contains(t, err.Error(), "admin email/username is empty in plugin config")
+	})
+}
+
 func TestInjectTeamAllowedValues(t *testing.T) {
 	t.Run("with manual team config", func(t *testing.T) {
 		metaInfo := &jira.CreateMetaInfo{

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -213,24 +213,37 @@ func (p *Plugin) OnConfigurationChange() error {
 		}
 	}
 
-	jsonBytes, err := json.Marshal(ec.AdminAPIToken)
-	if err != nil {
-		p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
-		return err
+	prevExternal := p.getConfig().externalConfig
+
+	switch {
+	case ec.AdminAPIToken == model.FakeSetting:
+		ec.AdminAPIToken = prevExternal.AdminAPIToken
+	case ec.AdminAPIToken == "":
+	case ec.AdminAPIToken == prevExternal.AdminAPIToken:
+	default:
+		if _, decErr := decrypt([]byte(ec.AdminAPIToken), []byte(ec.EncryptionKey)); decErr == nil {
+			break
+		}
+		jsonBytes, err := json.Marshal(ec.AdminAPIToken)
+		if err != nil {
+			p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
+			return err
+		}
+		if ec.EncryptionKey == "" {
+			p.client.Log.Warn("Encryption key required to encrypt admin API token")
+			return errors.New("failed to encrypt admin token. Encryption key not generated")
+		}
+		encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(ec.EncryptionKey))
+		if err != nil {
+			p.client.Log.Warn("Error encrypting the admin API token", "error", err.Error())
+			return err
+		}
+		ec.AdminAPIToken = string(encryptedAdminAPIToken)
 	}
 
-	encryptionKey := ec.EncryptionKey
-	if ec.AdminAPIToken != "" && encryptionKey == "" {
-		p.client.Log.Warn("Encryption key required to encrypt admin API token")
-		return errors.New("failed to encrypt admin token. Encryption key not generated")
+	if ec.AdminEmail == model.FakeSetting {
+		ec.AdminEmail = prevExternal.AdminEmail
 	}
-
-	encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(encryptionKey))
-	if err != nil {
-		p.client.Log.Warn("Error encrypting the admin API token", "error", err.Error())
-		return err
-	}
-	ec.AdminAPIToken = string(encryptedAdminAPIToken)
 
 	// Default to 30 days if not set
 	if ec.ThreadedJiraCommentSubscriptionDuration == "" {

--- a/server/utils.go
+++ b/server/utils.go
@@ -251,22 +251,32 @@ func getS256PKCEParams() (*PKCEParams, error) {
 }
 
 func (p *Plugin) SetAdminAPITokenRequestHeader(req *http.Request) error {
-	encryptedAdminAPIToken := p.getConfig().AdminAPIToken
-	jsonBytes, err := decrypt([]byte(encryptedAdminAPIToken), []byte(p.getConfig().EncryptionKey))
+	cfg := p.getConfig()
+	if cfg.AdminEmail == "" {
+		return errors.New("admin email/username is empty in plugin config")
+	}
+	if cfg.AdminAPIToken == "" {
+		return errors.New("admin API token is empty in plugin config")
+	}
+
+	jsonBytes, err := decrypt([]byte(cfg.AdminAPIToken), []byte(cfg.EncryptionKey))
 	if err != nil {
-		p.client.Log.Warn("Error decrypting admin API token", "error", err.Error())
+		p.client.Log.Warn("Error decrypting admin API token; re-save the Admin API Token in System Console", "error", err.Error())
 		return err
 	}
 	var adminAPIToken string
-	err = json.Unmarshal(jsonBytes, &adminAPIToken)
-	if err != nil {
+	if err = json.Unmarshal(jsonBytes, &adminAPIToken); err != nil {
 		p.client.Log.Warn("Error unmarshalling admin API token", "error", err.Error())
 		return err
 	}
+	if adminAPIToken == "" {
+		return errors.New("decrypted admin API token is empty; re-save the Admin API Token in System Console")
+	}
 
-	encodedAuth := base64.StdEncoding.EncodeToString([]byte(p.getConfig().AdminEmail + ":" + adminAPIToken))
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(cfg.AdminEmail + ":" + adminAPIToken))
 	req.Header.Set("Authorization", "Basic "+encodedAuth)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Mattermost-Plugin-Jira/"+manifest.Version)
 
 	return nil
 }


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR is a manual cherry-pick of #1303 on release-4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🔴 High

**Reasoning:** These changes modify critical authentication/authorization handling for Admin API tokens and introduce new fallback logic in the core watcher notification pipeline. The PR touches encryption/decryption handling in configuration management, creates a new public API method, and modifies how admin credentials are validated across multiple modules, creating significant regression risk for existing configurations and notification flows.

**Regression Risk:** Changes to token encryption/decryption in `OnConfigurationChange` could break existing configuration migrations if tokens are already encrypted. The fallback watcher lookup introduces complex conditional logic with multiple code paths. The modification to `SetAdminAPITokenRequestHeader` adds validation that could fail silently or unexpectedly on previously working configurations. Configuration preservation logic for `AdminAPIToken` and `AdminEmail` adds complexity to an already sensitive code path.

**QA Recommendation:** Full manual QA is strongly recommended across the following scenarios: (1) Configuration updates with pre-existing encrypted Admin API tokens, (2) Watcher notification delivery with connected user client present vs. absent, (3) Watcher notification with admin token fallback when connected user lacks permissions, (4) Admin token decryption failures and error handling, (5) Issue notification flows with both Cloud and Server/Data Center Jira instances. Automated test coverage exists for the new `GetWatchersWithAPIToken` method, but integration testing of the fallback flow and configuration migration paths is essential before production release to a release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->