### PR TITLE
MM-69458 Improving notification deduplication logic

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -221,6 +221,10 @@ func (p *Plugin) OnConfigurationChange() error {
 	case ec.AdminAPIToken == "":
 	case ec.AdminAPIToken == prevExternal.AdminAPIToken:
 	default:
+		if ec.EncryptionKey == "" {
+			p.client.Log.Warn("Encryption key required to encrypt admin API token")
+			return errors.New("failed to encrypt admin token. Encryption key not generated")
+		}
 		if _, decErr := decrypt([]byte(ec.AdminAPIToken), []byte(ec.EncryptionKey)); decErr == nil {
 			break
 		}
@@ -228,10 +232,6 @@ func (p *Plugin) OnConfigurationChange() error {
 		if err != nil {
 			p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())
 			return err
-		}
-		if ec.EncryptionKey == "" {
-			p.client.Log.Warn("Encryption key required to encrypt admin API token")
-			return errors.New("failed to encrypt admin token. Encryption key not generated")
 		}
 		encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(ec.EncryptionKey))
 		if err != nil {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -220,22 +220,30 @@ func (wh *webhook) PostNotifications(p *Plugin, instanceID types.ID) ([]*model.P
 
 		notification.message = p.replaceJiraAccountIds(instance.GetID(), notification.message, client)
 
-		dedupKey := notificationDedupKey(wh, mattermostUserID, notification.message)
-		var alreadySent bool
-		if kvErr := p.client.KV.Get(dedupKey, &alreadySent); kvErr != nil {
-			p.client.Log.Warn("PostNotifications: failed to read dedup key, sending notification anyway", "key", dedupKey, "error", kvErr.Error())
-		}
-		if alreadySent {
+		// Atomically claim the dedup key before posting so concurrent webhook
+		// deliveries can't both pass the check and send duplicates. SetAtomic(nil)
+		// only writes when the key does not already exist.
+		dedupKey := notificationDedupKey(instance.GetID(), wh, mattermostUserID, notification.message)
+		claimed, kvErr := p.client.KV.Set(dedupKey, true, pluginapi.SetExpiry(notificationDedupTTL), pluginapi.SetAtomic(nil))
+		switch {
+		case kvErr != nil:
+			// Fail open: send the notification rather than dropping it.
+			p.client.Log.Warn("PostNotifications: failed to claim dedup key, sending notification anyway", "key", dedupKey, "error", kvErr.Error())
+		case !claimed:
+			// Another delivery already claimed this notification.
 			continue
 		}
 
 		post, err := p.CreateBotDMPost(instance.GetID(), mattermostUserID, notification.message, notification.postType)
 		if err != nil {
 			p.errorf("PostNotifications: failed to create notification post, err: %v", err)
+			// Release the claim so the notification can be retried.
+			if claimed {
+				if delErr := p.client.KV.Delete(dedupKey); delErr != nil {
+					p.client.Log.Warn("PostNotifications: failed to release dedup key after post failure", "key", dedupKey, "error", delErr.Error())
+				}
+			}
 			continue
-		}
-		if _, kvErr := p.client.KV.Set(dedupKey, true, pluginapi.SetExpiry(notificationDedupTTL)); kvErr != nil {
-			p.client.Log.Warn("PostNotifications: failed to write dedup key, duplicate may be sent", "key", dedupKey, "error", kvErr.Error())
 		}
 		posts = append(posts, post)
 	}
@@ -250,8 +258,9 @@ func newWebhook(jwh *JiraWebhook, eventType string, format string, args ...inter
 	}
 }
 
-func notificationDedupKey(wh *webhook, recipientID types.ID, message string) string {
-	raw := fmt.Sprintf("%s_%s_%s",
+func notificationDedupKey(instanceID types.ID, wh *webhook, recipientID types.ID, message string) string {
+	raw := fmt.Sprintf("%s_%s_%s_%s",
+		string(instanceID),
 		wh.Issue.Key,
 		string(recipientID),
 		message,

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	notificationDedupTTL    = 3 * time.Second
+	notificationDedupTTL    = 30 * time.Second
 	notificationDedupKeyFmt = "notif_dedup_%s"
 )
 
@@ -237,12 +237,9 @@ func (wh *webhook) PostNotifications(p *Plugin, instanceID types.ID) ([]*model.P
 		post, err := p.CreateBotDMPost(instance.GetID(), mattermostUserID, notification.message, notification.postType)
 		if err != nil {
 			p.errorf("PostNotifications: failed to create notification post, err: %v", err)
-			// Release the claim so the notification can be retried.
-			if claimed {
-				if delErr := p.client.KV.Delete(dedupKey); delErr != nil {
-					p.client.Log.Warn("PostNotifications: failed to release dedup key after post failure", "key", dedupKey, "error", delErr.Error())
-				}
-			}
+			// Keep the claim: CreateBotDMPost may have persisted the post despite
+			// returning an error, so releasing it would let a retry post a
+			// duplicate. Let the claim TTL expire on its own.
 			continue
 		}
 		posts = append(posts, post)

--- a/server/webhook_parser_misc_test.go
+++ b/server/webhook_parser_misc_test.go
@@ -13,6 +13,8 @@ import (
 	jira "github.com/andygrunwald/go-jira"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
 func TestMarkdown(t *testing.T) {
@@ -279,12 +281,14 @@ func TestNotificationDedupKey(t *testing.T) {
 		}
 	}
 
-	t.Run("same issue, recipient and message produce the same key", func(t *testing.T) {
+	const instanceID = types.ID("https://jira.example.com")
+
+	t.Run("same instance, issue, recipient and message produce the same key", func(t *testing.T) {
 		wh1 := makeWebhook("PROJ-1")
 		wh2 := makeWebhook("PROJ-1")
 		assert.Equal(t,
-			notificationDedupKey(wh1, "user-abc", "Actor **assigned** you to PROJ-1"),
-			notificationDedupKey(wh2, "user-abc", "Actor **assigned** you to PROJ-1"))
+			notificationDedupKey(instanceID, wh1, "user-abc", "Actor **assigned** you to PROJ-1"),
+			notificationDedupKey(instanceID, wh2, "user-abc", "Actor **assigned** you to PROJ-1"))
 	})
 
 	t.Run("different events producing identical notifications still dedup", func(t *testing.T) {
@@ -299,29 +303,37 @@ func TestNotificationDedupKey(t *testing.T) {
 		}}
 		msg := "Actor **assigned** you to PROJ-1"
 		assert.Equal(t,
-			notificationDedupKey(whCreated, "user-abc", msg),
-			notificationDedupKey(whAssigned, "user-abc", msg))
+			notificationDedupKey(instanceID, whCreated, "user-abc", msg),
+			notificationDedupKey(instanceID, whAssigned, "user-abc", msg))
+	})
+
+	t.Run("different instances produce different keys", func(t *testing.T) {
+		wh := makeWebhook("PROJ-1")
+		msg := "Actor **assigned** you to PROJ-1"
+		assert.NotEqual(t,
+			notificationDedupKey(types.ID("https://jira-a.example.com"), wh, "user-abc", msg),
+			notificationDedupKey(types.ID("https://jira-b.example.com"), wh, "user-abc", msg))
 	})
 
 	t.Run("different recipients produce different keys", func(t *testing.T) {
 		wh := makeWebhook("PROJ-1")
 		msg := "Actor **assigned** you to PROJ-1"
 		assert.NotEqual(t,
-			notificationDedupKey(wh, "user-abc", msg),
-			notificationDedupKey(wh, "user-xyz", msg))
+			notificationDedupKey(instanceID, wh, "user-abc", msg),
+			notificationDedupKey(instanceID, wh, "user-xyz", msg))
 	})
 
 	t.Run("different issues produce different keys", func(t *testing.T) {
 		msg := "Actor **assigned** you to %s"
 		assert.NotEqual(t,
-			notificationDedupKey(makeWebhook("PROJ-1"), "user-abc", fmt.Sprintf(msg, "PROJ-1")),
-			notificationDedupKey(makeWebhook("PROJ-2"), "user-abc", fmt.Sprintf(msg, "PROJ-2")))
+			notificationDedupKey(instanceID, makeWebhook("PROJ-1"), "user-abc", fmt.Sprintf(msg, "PROJ-1")),
+			notificationDedupKey(instanceID, makeWebhook("PROJ-2"), "user-abc", fmt.Sprintf(msg, "PROJ-2")))
 	})
 
 	t.Run("different messages produce different keys", func(t *testing.T) {
 		wh := makeWebhook("PROJ-1")
 		assert.NotEqual(t,
-			notificationDedupKey(wh, "user-abc", "Actor **assigned** you to PROJ-1"),
-			notificationDedupKey(wh, "user-abc", "Actor **commented** on PROJ-1"))
+			notificationDedupKey(instanceID, wh, "user-abc", "Actor **assigned** you to PROJ-1"),
+			notificationDedupKey(instanceID, wh, "user-abc", "Actor **commented** on PROJ-1"))
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR is meant to pay some technical debt that was identified during a review in a backport PR. This is aimed to make 3 general improvements:
1. Moving encryption guard up to prevent mistakenly treating the raw admin API token as an encrypted value
2. Adding the instance ID to the dedup notification logic so we also take instance installations into consideration when evaluating duplicates
3. Ensuring parallel operations can't bypass the dedup flow

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-69458


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Reasoning:** The PR hardens admin API token handling (encryption guard ordering) and materially changes webhook notification de-duplication semantics under concurrency (atomic claim, instance-scoped keys, longer TTL), both of which affect correctness of sensitive flows but remain contained to server-side plugin/webhook logic.  
**Regression Risk:** Moderate. Token decryption/config-path behavior and user-facing DM notification delivery/dedup behavior are both impacted; however, the change is localized, has accompanying test updates for the dedup key, and rollback should be straightforward (revert server/plugin/webhook logic).  
**QA Recommendation:** Run targeted manual QA focused on (1) admin API token configuration cases (with/without encryption key) and failure logging/error behavior, and (2) webhook notification delivery under concurrent deliveries to confirm duplicates are suppressed only within the intended instance scope. Skipping manual QA is not recommended for these user-visible correctness paths.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->