### PR TITLE
MM-69474: normalize Jira base URL to prevent duplicate slash in posted links

### DIFF
--- a/server/instance.go
+++ b/server/instance.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
@@ -71,4 +72,8 @@ func (ic *InstanceCommon) Common() *InstanceCommon {
 
 func (ic InstanceCommon) IsCloudInstance() bool {
 	return ic.Type == CloudInstanceType || ic.Type == CloudOAuthInstanceType
+}
+
+func normalizeJiraBaseURL(baseURL string) string {
+	return strings.TrimSuffix(baseURL, "/")
 }

--- a/server/instance.go
+++ b/server/instance.go
@@ -75,5 +75,5 @@ func (ic InstanceCommon) IsCloudInstance() bool {
 }
 
 func normalizeJiraBaseURL(baseURL string) string {
-	return strings.TrimSuffix(baseURL, "/")
+	return strings.TrimRight(baseURL, "/")
 }

--- a/server/instance_cloud.go
+++ b/server/instance_cloud.go
@@ -192,15 +192,15 @@ func (ci *cloudInstance) GetURL() string {
 }
 
 func (ci *cloudInstance) GetJiraBaseURL() string {
-	return ci.GetURL()
+	return normalizeJiraBaseURL(ci.GetURL())
 }
 
 func (ci *cloudInstance) GetManageAppsURL() string {
-	return fmt.Sprintf("%s/plugins/servlet/upm", ci.GetURL())
+	return fmt.Sprintf("%s/plugins/servlet/upm", ci.GetJiraBaseURL())
 }
 
 func (ci *cloudInstance) GetManageWebhooksURL() string {
-	return cloudManageWebhooksURL(ci.GetURL())
+	return cloudManageWebhooksURL(ci.GetJiraBaseURL())
 }
 
 func cloudManageWebhooksURL(jiraURL string) string {

--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -79,7 +79,7 @@ func (p *Plugin) installCloudOAuthInstance(rawURL string) (string, *cloudOAuthIn
 	newInstance := &cloudOAuthInstance{
 		InstanceCommon: newInstanceCommon(p, CloudOAuthInstanceType, types.ID(jiraURL)),
 		MattermostKey:  p.GetPluginKey(),
-		JiraBaseURL:    rawURL,
+		JiraBaseURL:    jiraURL,
 		CodeVerifier:   params.CodeVerifier,
 		CodeChallenge:  params.CodeChallenge,
 	}
@@ -226,7 +226,7 @@ func (ci *cloudOAuthInstance) GetURL() string {
 }
 
 func (ci *cloudOAuthInstance) GetJiraBaseURL() string {
-	return ci.JiraBaseURL
+	return normalizeJiraBaseURL(ci.JiraBaseURL)
 }
 
 func (ci *cloudOAuthInstance) GetManageAppsURL() string {

--- a/server/instance_server.go
+++ b/server/instance_server.go
@@ -53,15 +53,15 @@ func (si *serverInstance) GetURL() string {
 }
 
 func (si *serverInstance) GetJiraBaseURL() string {
-	return si.GetURL()
+	return normalizeJiraBaseURL(si.GetURL())
 }
 
 func (si *serverInstance) GetManageAppsURL() string {
-	return fmt.Sprintf("%s/plugins/servlet/applinks/listApplicationLinks", si.GetURL())
+	return fmt.Sprintf("%s/plugins/servlet/applinks/listApplicationLinks", si.GetJiraBaseURL())
 }
 
 func (si *serverInstance) GetManageWebhooksURL() string {
-	return fmt.Sprintf("%s/plugins/servlet/webhooks", si.GetURL())
+	return fmt.Sprintf("%s/plugins/servlet/webhooks", si.GetJiraBaseURL())
 }
 
 func (si *serverInstance) GetMattermostKey() string {

--- a/server/instance_test.go
+++ b/server/instance_test.go
@@ -24,6 +24,10 @@ func TestGetJiraBaseURLTrimsTrailingSlash(t *testing.T) {
 			instance: &cloudOAuthInstance{JiraBaseURL: "https://mmtest.atlassian.net/"},
 			expected: "https://mmtest.atlassian.net",
 		},
+		"cloud-oauth, repeated trailing slashes": {
+			instance: &cloudOAuthInstance{JiraBaseURL: "https://mmtest.atlassian.net///"},
+			expected: "https://mmtest.atlassian.net",
+		},
 		"cloud, trailing slash": {
 			instance: &cloudInstance{
 				AtlassianSecurityContext: &AtlassianSecurityContext{BaseURL: "https://mmtest.atlassian.net/"},

--- a/server/instance_test.go
+++ b/server/instance_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
+)
+
+func TestGetJiraBaseURLTrimsTrailingSlash(t *testing.T) {
+	for name, tc := range map[string]struct {
+		instance Instance
+		expected string
+	}{
+		"cloud-oauth, no trailing slash": {
+			instance: &cloudOAuthInstance{JiraBaseURL: "https://mmtest.atlassian.net"},
+			expected: "https://mmtest.atlassian.net",
+		},
+		"cloud-oauth, trailing slash": {
+			instance: &cloudOAuthInstance{JiraBaseURL: "https://mmtest.atlassian.net/"},
+			expected: "https://mmtest.atlassian.net",
+		},
+		"cloud, trailing slash": {
+			instance: &cloudInstance{
+				AtlassianSecurityContext: &AtlassianSecurityContext{BaseURL: "https://mmtest.atlassian.net/"},
+			},
+			expected: "https://mmtest.atlassian.net",
+		},
+		"server, trailing slash": {
+			instance: &serverInstance{
+				InstanceCommon: &InstanceCommon{InstanceID: types.ID("https://jira.example.com/")},
+			},
+			expected: "https://jira.example.com",
+		},
+		"server, no trailing slash": {
+			instance: &serverInstance{
+				InstanceCommon: &InstanceCommon{InstanceID: types.ID("https://jira.example.com")},
+			},
+			expected: "https://jira.example.com",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.instance.GetJiraBaseURL())
+		})
+	}
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -518,7 +518,7 @@ func (p *Plugin) AddAutolinksForCloudOAuthInstance(coi *cloudOAuthInstance) erro
 		return fmt.Errorf("error getting project list: %w", err)
 	}
 
-	return p.AddAutoLinkForProjects(*plist, coi.JiraBaseURL)
+	return p.AddAutoLinkForProjects(*plist, coi.GetJiraBaseURL())
 }
 
 func (p *Plugin) AddAutoLinkForProjects(plist jira.ProjectList, baseURL string) error {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -509,7 +509,7 @@ func (p *Plugin) AddAutolinksForCloudInstance(ci *cloudInstance) error {
 		return fmt.Errorf("unable to get project keys: %w", err)
 	}
 
-	return p.AddAutoLinkForProjects(plist, ci.BaseURL)
+	return p.AddAutoLinkForProjects(plist, ci.GetJiraBaseURL())
 }
 
 func (p *Plugin) AddAutolinksForCloudOAuthInstance(coi *cloudOAuthInstance) error {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -5,18 +5,22 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/mattermost-community/mattermost-plugin-autolink/server/autolink"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -265,6 +269,48 @@ func TestSetupAutolink(t *testing.T) {
 
 			mockAPI.AssertExpectations(t)
 			dummyInstanceStore.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAddAutoLinkForProjectsNormalizesBaseURL(t *testing.T) {
+	rawURL := "https://mmtest.atlassian.net///"
+	accessorURL := (&cloudInstance{
+		AtlassianSecurityContext: &AtlassianSecurityContext{BaseURL: rawURL},
+	}).GetJiraBaseURL()
+
+	for name, baseURL := range map[string]string{
+		"no trailing slash":         "https://mmtest.atlassian.net",
+		"trailing slash":            "https://mmtest.atlassian.net/",
+		"repeated trailing slashes": rawURL,
+		"normalized by accessor":    accessorURL,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockAPI := &plugintest.API{}
+			var installed []autolink.Autolink
+			mockAPI.On("PluginHTTP", mock.AnythingOfType("*http.Request")).Return(
+				&http.Response{StatusCode: http.StatusOK, Body: http.NoBody},
+			).Run(func(args mock.Arguments) {
+				req := args.Get(0).(*http.Request)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+
+				var link autolink.Autolink
+				require.NoError(t, json.Unmarshal(body, &link))
+				installed = append(installed, link)
+			})
+
+			p := &Plugin{}
+			p.SetAPI(mockAPI)
+
+			require.NoError(t, p.AddAutoLinkForProjects(jira.ProjectList{{Key: "TES"}}, baseURL))
+
+			require.Len(t, installed, 2)
+			for _, link := range installed {
+				assert.NotContains(t, link.Template, "net//browse/")
+				assert.Contains(t, link.Template, "https://mmtest.atlassian.net/browse/TES-${jira_id}")
+			}
+			assert.Contains(t, installed[1].Pattern, `https://mmtest\.atlassian\.net/browse/`)
 		})
 	}
 }


### PR DESCRIPTION


#### Summary
Every posted Jira link is built as `GetJiraBaseURL() + "/browse/" + key  so the base URL must not carry a trailing slash. 
The same gap existed beyond Cloud OAuth. `GetJiraBaseURL()` has three implementations and none of them normalized. 

- **Cloud OAuth**: the reported bug
- **Server/DC**: safe on a fresh install but v2-migrated instances bypass that
- **Cloud JWT**: base URL comes from Atlassian's connect payload which in practice has no trailing slash, but nothing in our code guarantees it.

Fixes:
- `installCloudOAuthInstance` now stores the normalized `jiraURL` instead of `rawURL`.
- Added `normalizeJiraBaseURL` and routed all three `GetJiraBaseURL()` implementations through it, so instances already persisted with a bad URL are corrected without requiring a reinstall and every consumer is covered.
- Pointed the Server/DC and Cloud JWT manage-apps/manage-webhooks URLs at `GetJiraBaseURL()` instead of `GetURL()`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69474

#### Test Steps
1. Install a Jira Cloud instance via the setup wizard, entering the URL with a trailing slash (`https://your-instance.atlassian.net/`).
2. Run `/jira create` and create an issue, or attach a comment to an existing one.
3. Confirm the posted link is `https://your-instance.atlassian.net/browse/KEY-1` with a single slash and opens without a redirect.
4. Repeat for a Jira Server/DC instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The changes affect shared Jira URL handling across Cloud OAuth, Cloud JWT, and Server/DC integrations. Tests cover normalization and autolink paths, but management and webhook URLs also change.

**Regression Risk:** Medium. Existing instances and multiple integration paths are affected. The behavior change is limited to trailing-slash normalization.

**QA Recommendation:** Perform targeted manual QA for management links, webhooks, and autolinks across all supported integrations. Skipping manual QA has moderate risk.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->