### PR TITLE
persist Jira team field discovery so team subscription filters match reliably

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -27,6 +27,7 @@ import (
 
 const autocompleteSearchRoute = "2/jql/autocompletedata/suggestions"
 const commentVisibilityRoute = "2/user"
+const fieldRoute = "2/field"
 const userSearchRoute = "2/user/assignable/search"
 const unrecognizedEndpoint = "_unrecognized"
 const visibleToAllUsers = "visible-to-all-users"
@@ -84,6 +85,7 @@ type IssueService interface {
 	DoTransition(issueKey, transitionID string) error
 	GetCreateMetaInfo(api plugin.API, options *jira.GetQueryOptions) (*jira.CreateMetaInfo, error)
 	GetTransitions(issueKey string) ([]jira.Transition, error)
+	ListFields() ([]JiraField, error)
 	UpdateAssignee(issueKey string, user *jira.User) error
 	UpdateComment(issueKey string, comment *jira.Comment) (*jira.Comment, error)
 }
@@ -355,6 +357,25 @@ func (client JiraClient) GetUserVisibilityGroups(params map[string]string) (*Com
 	}
 	result.Groups.JiraUserGroups = append(result.Groups.JiraUserGroups, &JiraUserGroup{visibleToAllUsers})
 	return result, nil
+}
+
+type JiraField struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Schema struct {
+		Custom string `json:"custom"`
+	} `json:"schema"`
+}
+
+// ListFields returns the field metadata for the instance, including custom fields
+// that are not present on any project's create screen.
+func (client JiraClient) ListFields() ([]JiraField, error) {
+	fields := []JiraField{}
+	if err := client.RESTGet(fieldRoute, nil, &fields); err != nil {
+		return nil, err
+	}
+
+	return fields, nil
 }
 
 // DoTransition executes a transition on an issue.

--- a/server/issue.go
+++ b/server/issue.go
@@ -98,7 +98,6 @@ const (
 	teamFieldSchema            = "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team"
 	teamAdvancedRoadmapsSchema = "com.atlassian.teams:rm-team-custom-field-team"
 	teamAdvancedRoadmapsDC     = "com.atlassian.teams:rm-teams-custom-field-team"
-	defaultTeamFieldKey        = "customfield_10001"
 )
 
 type CreateMetaInfo struct {
@@ -639,19 +638,18 @@ func (p *Plugin) httpGetTeamFields(w http.ResponseWriter, r *http.Request) (int,
 	instanceID := r.FormValue(instanceIDQueryParam)
 	fieldValue := r.FormValue(fieldValueQueryParam)
 
-	// getTeamFieldKeys returns defaultTeamFieldKey when the cache is empty (cold start).
-	// The cache is populated with the real keys when GetCreateIssueMetadataForProjects
-	// inspects the create-meta schema via injectTeamAllowedValues → cacheTeamFieldKeys.
-	teamFieldKeys := p.getTeamFieldKeys(types.ID(instanceID))
-	sortedKeys := make([]string, 0, len(teamFieldKeys))
-	for key := range teamFieldKeys {
-		sortedKeys = append(sortedKeys, key)
-	}
-	sort.Strings(sortedKeys)
-
 	if instanceID != "" {
 		client, _, _, err := p.getClient(types.ID(instanceID), types.ID(mattermostUserID))
 		if err == nil {
+			p.discoverTeamFieldKeys(types.ID(instanceID), client)
+
+			teamFieldKeys := p.getTeamFieldKeys(types.ID(instanceID))
+			sortedKeys := make([]string, 0, len(teamFieldKeys))
+			for key := range teamFieldKeys {
+				sortedKeys = append(sortedKeys, key)
+			}
+			sort.Strings(sortedKeys)
+
 			for _, fieldName := range sortedKeys {
 				suggestions, apiErr := client.SearchAutoCompleteFields(map[string]string{
 					"fieldName":  fmt.Sprintf("cf[%s]", strings.TrimPrefix(fieldName, "customfield_")),

--- a/server/issue_test.go
+++ b/server/issue_test.go
@@ -1155,6 +1155,7 @@ func setupCreateIssueAPIMock() *plugintest.API {
 	api.On("SendEphemeralPost", mock.AnythingOfType("string"), mock.AnythingOfType("*model.Post")).Return(&model.Post{})
 	api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, (*model.AppError)(nil))
 	api.On("PublishWebSocketEvent", "update_defaults", mock.AnythingOfType("map[string]interface {}"), mock.AnythingOfType("*model.WebsocketBroadcast"))
+	api.On("KVGet", mock.AnythingOfType("string")).Return(nil, (*model.AppError)(nil))
 
 	return api
 }

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -232,6 +232,10 @@ func (p *Plugin) matchesSubscriptionFilters(wh *webhook, instanceID types.ID, fi
 		}
 
 		if field.Key == TeamFilter {
+			if len(teamFieldKeys) == 0 {
+				p.client.Log.Warn("Jira team field is unresolved for this instance, team subscription filters cannot match",
+					"instance_id", string(instanceID))
+			}
 			value = updateTeamValue(value, issue, teamFieldKeys)
 		}
 
@@ -265,6 +269,16 @@ func updateCommentVisibilityValue(value StringSet, wh *webhook) StringSet {
 type JiraTeamData struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+func hasTeamFilter(filters SubscriptionFilters) bool {
+	for _, field := range filters.Fields {
+		if field.Key == TeamFilter {
+			return true
+		}
+	}
+
+	return false
 }
 
 func updateTeamValue(value StringSet, issue *jira.Issue, teamFieldKeys map[string]struct{}) StringSet {
@@ -1187,6 +1201,10 @@ func (p *Plugin) httpChannelCreateSubscription(w http.ResponseWriter, r *http.Re
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
 
+	if hasTeamFilter(subscription.Filters) {
+		p.discoverTeamFieldKeys(subscription.InstanceID, client)
+	}
+
 	err = p.addChannelSubscription(subscription.InstanceID, &subscription, client)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
@@ -1279,6 +1297,11 @@ func (p *Plugin) httpChannelEditSubscription(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)
 	}
+
+	if hasTeamFilter(subscription.Filters) {
+		p.discoverTeamFieldKeys(subscription.InstanceID, client)
+	}
+
 	err = p.editChannelSubscription(subscription.InstanceID, &subscription, client)
 	if err != nil {
 		return respondErr(w, http.StatusInternalServerError, err)

--- a/server/subscribe.go
+++ b/server/subscribe.go
@@ -233,8 +233,9 @@ func (p *Plugin) matchesSubscriptionFilters(wh *webhook, instanceID types.ID, fi
 
 		if field.Key == TeamFilter {
 			if len(teamFieldKeys) == 0 {
-				p.client.Log.Warn("Jira team field is unresolved for this instance, team subscription filters cannot match",
+				p.client.Log.Warn("Jira team field is unresolved for this instance, skipping team subscription filter",
 					"instance_id", string(instanceID))
+				return false
 			}
 			value = updateTeamValue(value, issue, teamFieldKeys)
 		}

--- a/server/subscribe_test.go
+++ b/server/subscribe_test.go
@@ -1645,6 +1645,7 @@ func TestGetChannelsSubscribed(t *testing.T) {
 			assert.Nil(t, err)
 
 			api.On("KVGet", testSubKey).Return(subscriptionBytes, nil)
+			api.On("KVGet", mock.AnythingOfType("string")).Return(nil, (*model.AppError)(nil))
 
 			api.On("KVCompareAndSet", testSubKey, subscriptionBytes, mock.MatchedBy(func(data []byte) bool {
 				return true

--- a/server/team_fields.go
+++ b/server/team_fields.go
@@ -86,7 +86,11 @@ func (p *Plugin) getTeamFieldKeys(instanceID types.ID) map[string]struct{} {
 	if p.teamFieldCache == nil {
 		p.teamFieldCache = make(map[types.ID]map[string]struct{})
 	}
-	p.teamFieldCache[instanceID] = stored
+	if current, ok := p.teamFieldCache[instanceID]; ok {
+		stored = current
+	} else {
+		p.teamFieldCache[instanceID] = stored
+	}
 	p.teamFieldCacheLock.Unlock()
 
 	return copyTeamFieldKeys(stored)

--- a/server/team_fields.go
+++ b/server/team_fields.go
@@ -4,16 +4,15 @@
 package main
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
 )
 
-func (p *Plugin) cacheTeamFieldKeys(instanceID types.ID, keys []string) {
-	if len(keys) == 0 {
-		return
-	}
+const teamFieldKeysKey = "team_field_keys"
 
+func normalizeTeamFieldKeys(keys []string) map[string]struct{} {
 	normalized := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
 		key = strings.TrimSpace(strings.ToLower(key))
@@ -23,44 +22,112 @@ func (p *Plugin) cacheTeamFieldKeys(instanceID types.ID, keys []string) {
 		normalized[key] = struct{}{}
 	}
 
+	return normalized
+}
+
+func copyTeamFieldKeys(keys map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{}, len(keys))
+	for key := range keys {
+		result[key] = struct{}{}
+	}
+
+	return result
+}
+
+func (p *Plugin) cacheTeamFieldKeys(instanceID types.ID, keys []string) {
+	normalized := normalizeTeamFieldKeys(keys)
 	if len(normalized) == 0 {
 		return
 	}
 
 	p.teamFieldCacheLock.Lock()
-	defer p.teamFieldCacheLock.Unlock()
-
 	if p.teamFieldCache == nil {
 		p.teamFieldCache = make(map[types.ID]map[string]struct{})
 	}
 
-	current := p.teamFieldCache[instanceID]
-	if current == nil {
-		current = make(map[string]struct{}, len(normalized))
-	}
+	merged := copyTeamFieldKeys(p.teamFieldCache[instanceID])
+	added := false
 	for key := range normalized {
-		current[key] = struct{}{}
+		if _, ok := merged[key]; !ok {
+			merged[key] = struct{}{}
+			added = true
+		}
+	}
+	p.teamFieldCache[instanceID] = merged
+	p.teamFieldCacheLock.Unlock()
+
+	if !added {
+		return
 	}
 
-	p.teamFieldCache[instanceID] = current
+	if err := p.storeTeamFieldKeys(instanceID, merged); err != nil {
+		p.client.Log.Warn("Failed to persist Jira team field keys",
+			"instance_id", string(instanceID), "error", err.Error())
+	}
 }
 
 func (p *Plugin) getTeamFieldKeys(instanceID types.ID) map[string]struct{} {
 	p.teamFieldCacheLock.RLock()
-	defer p.teamFieldCacheLock.RUnlock()
+	cached, loaded := p.teamFieldCache[instanceID]
+	p.teamFieldCacheLock.RUnlock()
 
-	cached := p.teamFieldCache[instanceID]
-	if len(cached) == 0 {
-		return map[string]struct{}{
-			defaultTeamFieldKey: {},
+	if loaded {
+		return copyTeamFieldKeys(cached)
+	}
+
+	stored, err := p.loadTeamFieldKeys(instanceID)
+	if err != nil {
+		p.client.Log.Warn("Failed to load Jira team field keys",
+			"instance_id", string(instanceID), "error", err.Error())
+		return map[string]struct{}{}
+	}
+
+	p.teamFieldCacheLock.Lock()
+	if p.teamFieldCache == nil {
+		p.teamFieldCache = make(map[types.ID]map[string]struct{})
+	}
+	p.teamFieldCache[instanceID] = stored
+	p.teamFieldCacheLock.Unlock()
+
+	return copyTeamFieldKeys(stored)
+}
+
+func (p *Plugin) storeTeamFieldKeys(instanceID types.ID, keys map[string]struct{}) error {
+	sorted := make([]string, 0, len(keys))
+	for key := range keys {
+		sorted = append(sorted, key)
+	}
+	sort.Strings(sorted)
+
+	_, err := p.client.KV.Set(keyWithInstanceID(instanceID, teamFieldKeysKey), sorted)
+	return err
+}
+
+func (p *Plugin) loadTeamFieldKeys(instanceID types.ID) (map[string]struct{}, error) {
+	var keys []string
+	if err := p.client.KV.Get(keyWithInstanceID(instanceID, teamFieldKeysKey), &keys); err != nil {
+		return nil, err
+	}
+
+	return normalizeTeamFieldKeys(keys), nil
+}
+
+// discoverTeamFieldKeys resolves the instance's team field keys from Jira's field
+// metadata, which covers fields that never appear on a project's create screen.
+func (p *Plugin) discoverTeamFieldKeys(instanceID types.ID, client Client) {
+	fields, err := client.ListFields()
+	if err != nil {
+		p.client.Log.Debug("Failed to list Jira fields for team field discovery",
+			"instance_id", string(instanceID), "error", err.Error())
+		return
+	}
+
+	keys := make([]string, 0, 1)
+	for _, field := range fields {
+		if isTeamFieldSchema(field.Schema.Custom) {
+			keys = append(keys, field.ID)
 		}
 	}
 
-	// Copy under the read lock to avoid races if the map is updated concurrently.
-	result := make(map[string]struct{}, len(cached))
-	for key := range cached {
-		result[key] = struct{}{}
-	}
-
-	return result
+	p.cacheTeamFieldKeys(instanceID, keys)
 }

--- a/server/team_fields_test.go
+++ b/server/team_fields_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
+)
+
+type teamFieldTestClient struct {
+	Client
+	fields []JiraField
+	err    error
+}
+
+func (c teamFieldTestClient) ListFields() ([]JiraField, error) {
+	return c.fields, c.err
+}
+
+func setupTeamFieldPlugin(t *testing.T) (*Plugin, *plugintest.API) {
+	t.Helper()
+
+	api := &plugintest.API{}
+	api.On("LogWarn", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	p := &Plugin{}
+	p.SetAPI(api)
+	p.client = pluginapi.NewClient(api, p.Driver)
+	p.teamFieldCache = make(map[types.ID]map[string]struct{})
+
+	return p, api
+}
+
+func TestGetTeamFieldKeysNoHardcodedFallback(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(nil, (*model.AppError)(nil))
+
+	keys := p.getTeamFieldKeys(testInstance1.InstanceID)
+
+	assert.Empty(t, keys, "an instance with no discovered team field must not fall back to a hardcoded key")
+}
+
+func TestGetTeamFieldKeysFromKV(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+
+	stored, err := json.Marshal([]string{"customfield_10800"})
+	require.NoError(t, err)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(stored, (*model.AppError)(nil))
+
+	keys := p.getTeamFieldKeys(testInstance1.InstanceID)
+	assert.Equal(t, map[string]struct{}{"customfield_10800": {}}, keys)
+
+	// A second read is served from memory, so the KV round trip happens once per process.
+	keys = p.getTeamFieldKeys(testInstance1.InstanceID)
+	assert.Equal(t, map[string]struct{}{"customfield_10800": {}}, keys)
+	api.AssertNumberOfCalls(t, "KVGet", 1)
+}
+
+func TestGetTeamFieldKeysKVError(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(nil, &model.AppError{Message: "kv unavailable"})
+
+	assert.Empty(t, p.getTeamFieldKeys(testInstance1.InstanceID))
+
+	// A failed load must not be cached, otherwise a transient KV error would
+	// disable team filters until the next restart.
+	assert.Empty(t, p.getTeamFieldKeys(testInstance1.InstanceID))
+	api.AssertNumberOfCalls(t, "KVGet", 2)
+}
+
+func TestCacheTeamFieldKeysPersists(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+
+	var persisted []byte
+	api.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			persisted, _ = args.Get(1).([]byte)
+		}).Return(true, (*model.AppError)(nil))
+
+	p.cacheTeamFieldKeys(testInstance1.InstanceID, []string{"CustomField_10800", " ", ""})
+
+	assert.Equal(t, map[string]struct{}{"customfield_10800": {}}, p.getTeamFieldKeys(testInstance1.InstanceID))
+
+	var stored []string
+	require.NoError(t, json.Unmarshal(persisted, &stored))
+	assert.Equal(t, []string{"customfield_10800"}, stored)
+
+	// Re-caching a known key must not write to KV again.
+	p.cacheTeamFieldKeys(testInstance1.InstanceID, []string{"customfield_10800"})
+	api.AssertNumberOfCalls(t, "KVSetWithOptions", 1)
+}
+
+func TestDiscoverTeamFieldKeys(t *testing.T) {
+	for name, tc := range map[string]struct {
+		client   teamFieldTestClient
+		expected map[string]struct{}
+	}{
+		"atlassian team field": {
+			client: teamFieldTestClient{fields: []JiraField{
+				{ID: "customfield_10800", Name: "Team", Schema: schemaWithCustom(teamFieldSchema)},
+				{ID: "customfield_10001", Name: "Sprint", Schema: schemaWithCustom("com.pyxis.greenhopper.jira:gh-sprint")},
+			}},
+			expected: map[string]struct{}{"customfield_10800": {}},
+		},
+		"advanced roadmaps cloud and dc": {
+			client: teamFieldTestClient{fields: []JiraField{
+				{ID: "customfield_10500", Schema: schemaWithCustom(teamAdvancedRoadmapsSchema)},
+				{ID: "customfield_10600", Schema: schemaWithCustom(teamAdvancedRoadmapsDC)},
+			}},
+			expected: map[string]struct{}{"customfield_10500": {}, "customfield_10600": {}},
+		},
+		"no team field": {
+			client: teamFieldTestClient{fields: []JiraField{
+				{ID: "customfield_10001", Schema: schemaWithCustom("com.pyxis.greenhopper.jira:gh-sprint")},
+			}},
+			expected: map[string]struct{}{},
+		},
+		"jira error": {
+			client:   teamFieldTestClient{err: errors.New("jira unavailable")},
+			expected: map[string]struct{}{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p, api := setupTeamFieldPlugin(t)
+			api.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.Anything, mock.Anything).
+				Return(true, (*model.AppError)(nil)).Maybe()
+			api.On("KVGet", mock.AnythingOfType("string")).Return(nil, (*model.AppError)(nil)).Maybe()
+
+			p.discoverTeamFieldKeys(testInstance1.InstanceID, tc.client)
+
+			assert.Equal(t, tc.expected, p.getTeamFieldKeys(testInstance1.InstanceID))
+		})
+	}
+}
+
+func TestHasTeamFilter(t *testing.T) {
+	assert.True(t, hasTeamFilter(SubscriptionFilters{Fields: []FieldFilter{
+		{Key: securityLevelField},
+		{Key: TeamFilter},
+	}}))
+	assert.False(t, hasTeamFilter(SubscriptionFilters{Fields: []FieldFilter{
+		{Key: securityLevelField},
+	}}))
+}
+
+func schemaWithCustom(custom string) struct {
+	Custom string `json:"custom"`
+} {
+	return struct {
+		Custom string `json:"custom"`
+	}{Custom: custom}
+}

--- a/server/team_fields_test.go
+++ b/server/team_fields_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	jira "github.com/andygrunwald/go-jira"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -142,6 +143,80 @@ func TestDiscoverTeamFieldKeys(t *testing.T) {
 			p.discoverTeamFieldKeys(testInstance1.InstanceID, tc.client)
 
 			assert.Equal(t, tc.expected, p.getTeamFieldKeys(testInstance1.InstanceID))
+		})
+	}
+}
+
+func TestGetTeamFieldKeysKeepsConcurrentDiscovery(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+	api.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.Anything, mock.Anything).
+		Return(true, (*model.AppError)(nil))
+
+	// Simulate a discovery landing while this instance's KV read is in flight.
+	api.On("KVGet", mock.AnythingOfType("string")).
+		Run(func(_ mock.Arguments) {
+			p.cacheTeamFieldKeys(testInstance1.InstanceID, []string{"customfield_10800"})
+		}).Return(nil, (*model.AppError)(nil))
+
+	assert.Equal(t, map[string]struct{}{"customfield_10800": {}}, p.getTeamFieldKeys(testInstance1.InstanceID))
+	assert.Equal(t, map[string]struct{}{"customfield_10800": {}}, p.getTeamFieldKeys(testInstance1.InstanceID))
+}
+
+const testTeamID = "d885d551-c24d-45d5-a8a3-5be1808be30f"
+
+func teamFilterWebhook(teamFieldKey string) *webhook {
+	fields := &jira.IssueFields{
+		Type:     jira.IssueType{ID: "10001"},
+		Project:  jira.Project{Key: mockProjectKey},
+		Unknowns: map[string]interface{}{},
+	}
+	if teamFieldKey != "" {
+		fields.Unknowns[teamFieldKey] = map[string]interface{}{"id": testTeamID}
+	}
+
+	return &webhook{
+		JiraWebhook: &JiraWebhook{Issue: jira.Issue{Fields: fields}},
+		eventTypes:  NewStringSet(eventCreated),
+	}
+}
+
+func teamFilters(inclusion string) SubscriptionFilters {
+	return SubscriptionFilters{
+		Events:     NewStringSet(eventCreated),
+		IssueTypes: NewStringSet("10001"),
+		Projects:   NewStringSet(mockProjectKey),
+		Fields: []FieldFilter{{
+			Key:       TeamFilter,
+			Inclusion: inclusion,
+			Values:    NewStringSet(testTeamID),
+		}},
+	}
+}
+
+func TestMatchesSubscriptionFiltersResolvedTeamField(t *testing.T) {
+	p, api := setupTeamFieldPlugin(t)
+
+	stored, err := json.Marshal([]string{"customfield_10800"})
+	require.NoError(t, err)
+	api.On("KVGet", mock.AnythingOfType("string")).Return(stored, (*model.AppError)(nil))
+
+	assert.True(t, p.matchesSubscriptionFilters(
+		teamFilterWebhook("customfield_10800"), testInstance1.InstanceID, teamFilters(FilterIncludeAny)))
+
+	assert.False(t, p.matchesSubscriptionFilters(
+		teamFilterWebhook("customfield_10800"), testInstance1.InstanceID, teamFilters(FilterExcludeAny)))
+}
+
+func TestMatchesSubscriptionFiltersUnresolvedTeamFieldFailsClosed(t *testing.T) {
+	for _, inclusion := range []string{FilterIncludeAny, FilterIncludeAll, FilterExcludeAny, FilterEmpty, FilterIncludeOrEmpty} {
+		t.Run(inclusion, func(t *testing.T) {
+			p, api := setupTeamFieldPlugin(t)
+			api.On("KVGet", mock.AnythingOfType("string")).Return(nil, (*model.AppError)(nil))
+
+			matched := p.matchesSubscriptionFilters(
+				teamFilterWebhook("customfield_10800"), testInstance1.InstanceID, teamFilters(inclusion))
+
+			assert.False(t, matched, "an unresolved team field must not select the channel")
 		})
 	}
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -463,6 +463,7 @@ func (m *mockJiraClient) GetCreateMetaInfo(_ plugin.API, _ *jira.GetQueryOptions
 	return nil, nil
 }
 func (m *mockJiraClient) GetTransitions(_ string) ([]jira.Transition, error) { return nil, nil }
+func (m *mockJiraClient) ListFields() ([]JiraField, error)                   { return nil, nil }
 func (m *mockJiraClient) UpdateAssignee(_ string, _ *jira.User) error        { return nil }
 func (m *mockJiraClient) UpdateComment(_ string, _ *jira.Comment) (*jira.Comment, error) {
 	return nil, nil


### PR DESCRIPTION

#### Summary
Team subscription filters silently never matched on most instances. On any instance whose team field is not `customfield_10001` the webhook lookup read the wrong key and the filter rejected every issue.

Because the cache was per process this worked only on nodes where someone had opened the create-issue modal only until the next restart.

- Persist discovered keys in KV per instance under `team_field_keys`.
- Remove the `defaultTeamFieldKey` fallback. Guessing `customfield_10001` risked matching an unrelated field rather than just failing.
- Log a warning when a team filter is evaluated with no resolved keys.

#### Ticket Link
https://hub.mattermost.com/pde/pl/bc87psyf7jgdidfybqynpfgd3a

#### Test
`server/team_fields_test.go` covers the removed fallback the KV round trip and its memoization.

Manual on an instance whose team field is not customfield_10001
1. Disable and re enable the plugin then create a team filtered subscription without opening the create issue modal.
2. Create a matching issue in Jira and confirm the notification posts.
3. Disable and re enable the plugin again and create another matching issue and confirm it still posts.
4. Confirm a subscription filtered on a different team does not post.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Reasoning:** The changes span Jira client, subscription, issue, and KV persistence layers. Tests cover key discovery and persistence, but team filtering remains a user-facing path.

**Regression Risk:** Medium. The removed fallback can affect cold-start behavior, and KV or Jira field discovery failures can affect team filters.

**QA Recommendation:** Perform manual QA for team-filter creation, editing, and evaluation across plugin restarts and multiple Jira instances. Skipping manual QA carries moderate risk.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->