### PR TITLE
MM-70686 Fixing issues with incorrect resource matching

### DIFF
--- a/server/instance_cloud_oauth.go
+++ b/server/instance_cloud_oauth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -43,7 +44,8 @@ type CloudOAuthConfigure struct {
 }
 
 type JiraAccessibleResources []struct {
-	ID string
+	ID  string `json:"id"`
+	URL string `json:"url"`
 }
 
 type PKCEParams struct {
@@ -169,15 +171,23 @@ func (ci *cloudOAuthInstance) getClientForConnection(connection *Connection) (*j
 		}
 	}
 
-	// TODO: Get resource ID if not in the KV Store?
-	jiraID, err := ci.getJiraCloudResourceID(*client)
-	ci.JiraResourceID = jiraID
+	resourceID, err := ci.resolveJiraCloudResourceID(*client)
 	if err != nil {
 		if errors.Is(err, errTokenExpired) {
 			ci.Plugin.disconnectUserDueToExpiredToken(connection.MattermostUserID, ci.GetID())
 			return nil, nil, errors.New("your Jira token has expired, please use `/jira connect` to reconnect your account")
 		}
 		return nil, nil, err
+	}
+
+	if ci.JiraResourceID != resourceID {
+		ci.JiraResourceID = resourceID
+		// Cached so the lookup above stops running on every Jira request. A
+		// failure only costs the next request another lookup.
+		if err := ci.Plugin.instanceStore.StoreInstance(ci); err != nil {
+			ci.Plugin.client.Log.Warn("Failed to cache the resolved Jira resource ID",
+				"instance_id", string(ci.InstanceID), "error", err.Error())
+		}
 	}
 
 	jiraClient, err := jira.NewClient(client, ci.GetURL())
@@ -243,7 +253,11 @@ func (ci *cloudOAuthInstance) GetMattermostKey() string {
 
 var errTokenExpired = errors.New("token expired or revoked")
 
-func (ci *cloudOAuthInstance) getJiraCloudResourceID(client http.Client) (string, error) {
+func (ci *cloudOAuthInstance) resolveJiraCloudResourceID(client http.Client) (string, error) {
+	if ci.JiraResourceID != "" {
+		return ci.JiraResourceID, nil
+	}
+
 	request, err := http.NewRequest(
 		http.MethodGet,
 		jiraOAuthAccessibleResourcesURL,
@@ -275,10 +289,43 @@ func (ci *cloudOAuthInstance) getJiraCloudResourceID(client http.Client) (string
 		return "", errors.Wrap(err, "failed to unmarshal JiraAccessibleResources")
 	}
 
-	// We return the first resource ID only
+	return ci.selectResourceID(resources)
+}
+
+// selectResourceID picks the resource for this instance's own site. A token can
+// grant access to several Jira sites in an unspecified order, and each site has
+// its own project key sequences, so taking the wrong one sends reads and writes
+// to one site while every link we render points at another. No match has to be
+// an error rather than a guess.
+func (ci *cloudOAuthInstance) selectResourceID(resources JiraAccessibleResources) (string, error) {
 	if len(resources) < 1 {
 		return "", errors.New("No resources are available for this Jira Cloud Account.")
 	}
 
-	return resources[0].ID, nil
+	wantHost := jiraURLHost(ci.JiraBaseURL)
+	if wantHost == "" {
+		return "", errors.Errorf("instance has an unusable Jira base URL %q", ci.JiraBaseURL)
+	}
+
+	available := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		if jiraURLHost(resource.URL) == wantHost {
+			return resource.ID, nil
+		}
+		available = append(available, resource.URL)
+	}
+
+	return "", errors.Errorf(
+		"your Jira account does not have access to %s, only to: %s. Please use `/jira disconnect` and `/jira connect`, and authorize %s",
+		ci.JiraBaseURL, strings.Join(available, ", "), ci.JiraBaseURL)
+}
+
+// jiraURLHost reduces a Jira site URL to the only part that identifies the
+// site, so scheme, case, port and trailing path cannot cause a false mismatch.
+func jiraURLHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
 }

--- a/server/instance_cloud_oauth_migration_test.go
+++ b/server/instance_cloud_oauth_migration_test.go
@@ -233,7 +233,8 @@ func TestCloudOAuthMigration(t *testing.T) {
 			runAssertions: func(p *Plugin, api *plugintest.API, instanceID string) {
 				fakeJiraResourcesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					accessibleResources := JiraAccessibleResources{{
-						ID: "someid",
+						ID:  "someid",
+						URL: jiraCloudURL,
 					}}
 					_ = json.NewEncoder(w).Encode(accessibleResources)
 				}))
@@ -286,7 +287,8 @@ func TestCloudOAuthMigration(t *testing.T) {
 			runAssertions: func(p *Plugin, api *plugintest.API, instanceID string) {
 				fakeJiraResourcesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					accessibleResources := JiraAccessibleResources{{
-						ID: "someid",
+						ID:  "someid",
+						URL: jiraCloudURL,
 					}}
 					_ = json.NewEncoder(w).Encode(accessibleResources)
 				}))
@@ -360,7 +362,8 @@ func TestCloudOAuthMigration(t *testing.T) {
 			runAssertions: func(p *Plugin, api *plugintest.API, instanceID string) {
 				fakeJiraResourcesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					accessibleResources := JiraAccessibleResources{{
-						ID: "someid",
+						ID:  "someid",
+						URL: jiraCloudURL,
 					}}
 					_ = json.NewEncoder(w).Encode(accessibleResources)
 				}))
@@ -415,7 +418,8 @@ func TestCloudOAuthMigration(t *testing.T) {
 			runAssertions: func(p *Plugin, api *plugintest.API, instanceID string) {
 				fakeJiraResourcesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					accessibleResources := JiraAccessibleResources{{
-						ID: "someid",
+						ID:  "someid",
+						URL: jiraCloudURL,
 					}}
 					_ = json.NewEncoder(w).Encode(accessibleResources)
 				}))

--- a/server/instance_cloud_oauth_test.go
+++ b/server/instance_cloud_oauth_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-jira/server/utils/types"
+)
+
+// TestSelectResourceID covers routing Jira API calls to the site the instance
+// was installed for. A token can grant access to several sites, whose project
+// key sequences are independent, so taking the wrong one creates issues in one
+// site while every link the plugin renders points at another.
+func TestSelectResourceID(t *testing.T) {
+	const productionURL = "https://production.example.com"
+	const sandboxURL = "https://sandbox.example.com"
+
+	instanceFor := func(baseURL string) *cloudOAuthInstance {
+		return &cloudOAuthInstance{
+			InstanceCommon: &InstanceCommon{
+				InstanceID: types.ID(baseURL),
+				Type:       CloudOAuthInstanceType,
+			},
+			JiraBaseURL: baseURL,
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		baseURL    string
+		resources  JiraAccessibleResources
+		expectedID string
+		expectErr  string
+	}{
+		"the installed site is picked when the sandbox is listed first": {
+			baseURL: productionURL,
+			resources: JiraAccessibleResources{
+				{ID: "sandbox-resource", URL: sandboxURL},
+				{ID: "production-resource", URL: productionURL},
+			},
+			expectedID: "production-resource",
+		},
+		"the installed site is picked when it is listed first": {
+			baseURL: productionURL,
+			resources: JiraAccessibleResources{
+				{ID: "production-resource", URL: productionURL},
+				{ID: "sandbox-resource", URL: sandboxURL},
+			},
+			expectedID: "production-resource",
+		},
+		"a sandbox instance resolves to the sandbox": {
+			baseURL: sandboxURL,
+			resources: JiraAccessibleResources{
+				{ID: "production-resource", URL: productionURL},
+				{ID: "sandbox-resource", URL: sandboxURL},
+			},
+			expectedID: "sandbox-resource",
+		},
+		"a single granted site still has to match": {
+			baseURL:   productionURL,
+			resources: JiraAccessibleResources{{ID: "sandbox-resource", URL: sandboxURL}},
+			expectErr: "does not have access to",
+		},
+		"scheme, case and trailing slash do not cause a false mismatch": {
+			baseURL:    productionURL,
+			resources:  JiraAccessibleResources{{ID: "production-resource", URL: "http://PRODUCTION.example.com/"}},
+			expectedID: "production-resource",
+		},
+		"no granted sites": {
+			baseURL:   productionURL,
+			resources: JiraAccessibleResources{},
+			expectErr: "No resources are available",
+		},
+		"a resource with no URL never matches": {
+			baseURL:   productionURL,
+			resources: JiraAccessibleResources{{ID: "someid"}},
+			expectErr: "does not have access to",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resourceID, err := instanceFor(tc.baseURL).selectResourceID(tc.resources)
+
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErr)
+				assert.Empty(t, resourceID, "a resource ID must not be returned alongside an error, GetURL would use it")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedID, resourceID)
+		})
+	}
+}
+
+// TestResolveJiraCloudResourceIDUsesCache pins that a resolved ID is reused
+// rather than re-derived on every Jira request. The zero-value http.Client
+// would fail the lookup, so reaching it at all fails the test.
+func TestResolveJiraCloudResourceIDUsesCache(t *testing.T) {
+	ci := &cloudOAuthInstance{
+		InstanceCommon: &InstanceCommon{InstanceID: "https://jira.example.com", Type: CloudOAuthInstanceType},
+		JiraBaseURL:    "https://jira.example.com",
+		JiraResourceID: "already-resolved",
+	}
+
+	resourceID, err := ci.resolveJiraCloudResourceID(http.Client{})
+	require.NoError(t, err)
+	assert.Equal(t, "already-resolved", resourceID)
+}
+
+func TestCloudOAuthInstanceGetURL(t *testing.T) {
+	ci := &cloudOAuthInstance{
+		InstanceCommon: &InstanceCommon{InstanceID: "https://jira.example.com", Type: CloudOAuthInstanceType},
+		JiraBaseURL:    "https://jira.example.com",
+		JiraResourceID: "resource-id",
+	}
+
+	assert.Equal(t, "https://api.atlassian.com/ex/jira/resource-id", ci.GetURL())
+	assert.Equal(t, "https://jira.example.com", ci.GetJiraBaseURL())
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR corrects a behavior that would take the first resource returned by Jira and treat it as the target instance, and applies a matching based on the configured base URL for the instance

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-70686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Reasoning:** The change updates Jira Cloud OAuth resource matching in a user-facing authentication flow. The affected logic is isolated and has focused test coverage.

**Regression Risk:** Incorrect URL matching or cache handling could prevent access to a Jira instance. Tests cover the main matching and URL scenarios.

**QA Recommendation:** Perform targeted manual QA for Jira Cloud OAuth with production and sandbox URLs, cached resource IDs, inaccessible sites, and multiple resources. Skipping manual QA carries moderate risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->