### PR TITLE
MM-70684 Update Jira plugin for React 19 in Mattermost v12

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
     "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
     "icon_path": "assets/icon.svg",
-    "min_server_version": "10.7.0",
+    "min_server_version": "12.0.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --mode=production",
     "build:watch": "webpack --mode=production --watch",
-    "debug": "webpack --mode=none",
+    "debug": "webpack --mode=development",
     "debug:watch": "webpack --mode=development --watch",
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
     "fix": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",

--- a/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
+++ b/webapp/src/components/modals/full_screen_modal/full_screen_modal.jsx
@@ -11,6 +11,8 @@ import CloseIcon from './close_icon';
 const ANIMATION_DURATION = 100;
 
 export default class FullScreenModal extends React.Component {
+    modalRef = React.createRef();
+
     static propTypes = {
         show: PropTypes.bool.isRequired,
         children: PropTypes.node.isRequired,
@@ -44,8 +46,12 @@ export default class FullScreenModal extends React.Component {
                 unmountOnExit={true}
                 timeout={ANIMATION_DURATION}
                 appear={true}
+                nodeRef={this.modalRef}
             >
-                <div className='FullScreenModal FullScreenModal--compact'>
+                <div
+                    ref={this.modalRef}
+                    className='FullScreenModal FullScreenModal--compact'
+                >
                     <CloseIcon
                         className='close-x'
                         onClick={this.close}

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -65,6 +65,9 @@ const config = {
     externals: {
         react: 'React',
         'react-dom': 'ReactDOM',
+        'react-dom/client': 'ReactDOM',
+        'react/jsx-runtime': 'ReactJSXRuntime',
+        'react/jsx-dev-runtime': 'ReactJSXDevRuntime',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
#### Summary

Fixes the Jira plugin startup crash on Mattermost v12 / React 19. Although React was already supplied by the host, the plugin bundled React 18's JSX runtime, which accesses removed React internals such as `ReactCurrentOwner`. Resolving JSX runtime imports to the host keeps React and JSX helpers aligned.

Externalizes `react-dom/client`, `react/jsx-runtime`, and `react/jsx-dev-runtime` to the host globals and requires Mattermost 12.0.0. Requires the host JSX runtime exports from https://github.com/mattermost/mattermost/pull/38489. Also changes the debug build to development mode.

Gives the full-screen modal transition an explicit DOM ref so opening and closing it no longer relies on ReactDOM's removed `findDOMNode` API.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70684

#### Release Note

```release-note
Updated the Jira plugin for React 19 in Mattermost v12 and fixed a startup crash caused by an older JSX runtime. Raised the minimum supported Mattermost version to 12.0.0. Fixed full-screen modal transitions to work without findDOMNode.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The changes affect build configuration, React runtime integration, and a user-facing modal. They do not affect authentication, data persistence, or core business logic.

**Regression Risk:** Medium. Incorrect externals or ref handling could cause startup failures or modal transition issues. The changes are isolated and rollback is straightforward.

**QA Recommendation:** Perform manual QA on plugin startup, Jira pages, and full-screen modal transitions with Mattermost v12. Skipping manual QA carries a moderate risk of runtime or UI regressions.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->